### PR TITLE
Adding an explicit content type to the github asset uploader

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -21,3 +21,4 @@ deploy:
     - github-upload-asset:
         token: $GITHUB_TOKEN
         file: launch
+        content_type: application/octet-stream


### PR DESCRIPTION
- The `file` command doesn't exist in the google/golang box, which
  causes a bug when running github-upload-asset