### PR TITLE
Use https as default url for git clone operation

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -35,3 +35,21 @@ func Clone(scmURL, destination string) error {
 	}
 	return nil
 }
+
+//SetConfig sets up git configuration
+func SetConfig(setting, name string) error {
+	cmd := execCommand("git", "config", setting, name)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err := cmd.Start()
+	if err != nil {
+		return fmt.Errorf("starting git config command: %v", err)
+	}
+
+	err = cmd.Wait()
+	if err != nil {
+		return fmt.Errorf("setting git config: %v", err)
+	}
+	return nil
+}

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -67,7 +67,32 @@ func TestHelperProcess(*testing.T) {
 		switch args[1] {
 		case "clone":
 			return
+		case "config":
+			return
 		}
 	}
 	os.Exit(255)
+}
+
+func TestSetConfig(t *testing.T) {
+	testUserName := "sd-buildbot"
+	testSetting := "user.name"
+	execCommand = getFakeExecCommand(func(cmd string, args ...string) {
+		want := []string{
+			"config", "user.name", testUserName,
+		}
+		if len(args) != len(want) {
+			t.Errorf("Incorrect args sent to git: %q, want %q", args, want)
+		}
+		for i, arg := range args {
+			if arg != want[i] {
+				t.Errorf("args[%d] = %q, want %q", i, arg, want[i])
+			}
+		}
+	})
+
+	err := SetConfig(testSetting, testUserName)
+	if err != nil {
+		t.Errorf("Unexpected error from git config: %v", err)
+	}
 }


### PR DESCRIPTION
- Adds a helper function that will return the url in https format.
- Adds functions to set the git user name and email
- Addresses #24 
