### PR TITLE
Incorporate api /validator call

### DIFF
--- a/data/screwdriver.yaml
+++ b/data/screwdriver.yaml
@@ -1,0 +1,2 @@
+workflow:
+  - main

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1,0 +1,10 @@
+package executor
+
+import (
+	"github.com/screwdriver-cd/launcher/screwdriver"
+)
+
+// Run will be used to execute steps
+func Run(jobDef []screwdriver.JobDef) error {
+	return nil
+}

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -16,6 +16,7 @@ type API interface {
 	JobFromID(jobID string) (Job, error)
 	PipelineFromID(pipelineID string) (Pipeline, error)
 	UpdateBuildStatus(status string) error
+	PipelineDefFromYaml(yaml io.Reader) (PipelineDef, error)
 }
 
 // SDError is an error response from the Screwdriver API


### PR DESCRIPTION
This PR ties the api function `PipelineDefFromYaml` defined in #30 to the launch function

Adds an executor library that simply returns nil and should be called with the job to be executed