### PR TITLE
All code paths should now lead to marking the build success/failure

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -11,6 +11,15 @@ import (
 
 var execCommand = exec.Command
 
+// ErrStatus is an error that holds an exit status code
+type ErrStatus struct {
+	Status int
+}
+
+func (e ErrStatus) Error() string {
+	return fmt.Sprintf("exit %d", e.Status)
+}
+
 // Run executes a slice of CommandDefs
 func Run(cmds []screwdriver.CommandDef) error {
 	for _, cmd := range cmds {
@@ -27,7 +36,7 @@ func Run(cmds []screwdriver.CommandDef) error {
 		if err := c.Wait(); err != nil {
 			if exitError, ok := err.(*exec.ExitError); ok {
 				waitStatus := exitError.Sys().(syscall.WaitStatus)
-				return fmt.Errorf("exit %d", waitStatus.ExitStatus())
+				return ErrStatus{waitStatus.ExitStatus()}
 			}
 			return fmt.Errorf("running command %q: %v", cmd.Cmd, err)
 		}

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -62,7 +62,7 @@ func TestRunSingle(t *testing.T) {
 	}{
 		{"make", nil},
 		{"npm install", nil},
-		{"failer", fmt.Errorf("exit 7")},
+		{"failer", ErrStatus{7}},
 	}
 
 	for _, test := range tests {
@@ -137,7 +137,7 @@ func TestRunMulti(t *testing.T) {
 		t.Fatalf("%d commands called, want %d", len(called), len(tests)-1)
 	}
 
-	if !reflect.DeepEqual(err, fmt.Errorf("exit 7")) {
+	if !reflect.DeepEqual(err, ErrStatus{7}) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
@@ -158,9 +158,9 @@ func TestUnmocked(t *testing.T) {
 		err     error
 	}{
 		{"ls", nil},
-		{"doesntexist", fmt.Errorf("exit 127")},
+		{"doesntexist", ErrStatus{127}},
 		{"ls && ls", nil},
-		{"ls && sh -c 'exit 5' && sh -c 'exit 2'", fmt.Errorf("exit 5")},
+		{"ls && sh -c 'exit 5' && sh -c 'exit 2'", ErrStatus{5}},
 	}
 
 	for _, test := range tests {
@@ -171,7 +171,14 @@ func TestUnmocked(t *testing.T) {
 		})
 
 		if !reflect.DeepEqual(err, test.err) {
-			t.Errorf("Unexpected error: %v", err)
+			t.Errorf("Unexpected error: %v, want %v", err, test.err)
 		}
+	}
+}
+
+func TestErrStatus(t *testing.T) {
+	errText := ErrStatus{5}.Error()
+	if errText != "exit 5" {
+		t.Errorf("ErrStatus{5}.Error() == %q, want %q", errText, "exit 5")
 	}
 }

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -246,8 +247,29 @@ func TestPipelineFromYaml(t *testing.T) {
 func TestUpdateBuildStatus(t *testing.T) {
 	http := makeFakeHTTPClient(t, 200, "{}")
 	testAPI := api{"http://fakeurl", "faketoken", http}
-	err := testAPI.UpdateBuildStatus("SUCCESS")
-	if err != nil {
+	statuses := []BuildStatus{
+		Success,
+		Failure,
+		Aborted,
+		Running,
+	}
+
+	for _, status := range statuses {
+		err := testAPI.UpdateBuildStatus(status)
+		if err != nil {
+			t.Errorf("Unexpected error from UpdateBuildStatus(%s): %v", status, err)
+		}
+	}
+}
+
+func TestBadUpdateBuildStatus(t *testing.T) {
+	http := makeFakeHTTPClient(t, 200, "{}")
+	testAPI := api{"http://fakeurl", "faketoken", http}
+	err := testAPI.UpdateBuildStatus("NOTASTATUS")
+	if err == nil {
+		t.Fatalf("Expected an error from UpdateBuildStatus. Got none.")
+	}
+	if !strings.Contains(err.Error(), "invalid build status: NOTASTATUS") {
 		t.Errorf("Unexpected error from UpdateBuildStatus: %v", err)
 	}
 }


### PR DESCRIPTION
Please pay special attention when reviewing to try to catch any possible exit that would not correctly set the build status

- The command should exit 0 no matter what, to simplify job execution in
  Kubernetes
- Build failures should give good log messages and set the status to
  FAILED
- Unexpected errors that are not non-zero exit codes should result in
  making the build failed
- A panic anywhere in the codebase should attempt to mark the build
  failed, write a stack trace, and exit(0)