### PR TITLE
Fixing the tests to work with go 1.7

### DIFF
--- a/git/git_test.go
+++ b/git/git_test.go
@@ -29,6 +29,9 @@ func TestClone(t *testing.T) {
 	scmURL := "git@github.com:screwdriver-cd/launcher#master"
 	wantDest := "testdest"
 	wantBranch := "master"
+
+	oldExec := execCommand
+	defer func() { execCommand = oldExec }()
 	execCommand = getFakeExecCommand(func(cmd string, args ...string) {
 		want := []string{
 			"clone", "--quiet", "--progress", "--branch", wantBranch, wantRepo, wantDest,
@@ -97,6 +100,9 @@ func TestHelperProcess(*testing.T) {
 func TestSetConfig(t *testing.T) {
 	testUserName := "sd-buildbot"
 	testSetting := "user.name"
+
+	oldExec := execCommand
+	defer func() { execCommand = oldExec }()
 	execCommand = getFakeExecCommand(func(cmd string, args ...string) {
 		want := []string{
 			"config", "user.name", testUserName,
@@ -120,6 +126,9 @@ func TestSetConfig(t *testing.T) {
 func TestFetchPR(t *testing.T) {
 	testPrNumber := "111"
 	testBranch := "branch"
+
+	oldExec := execCommand
+	defer func() { execCommand = oldExec }()
 	execCommand = getFakeExecCommand(func(cmd string, args ...string) {
 		want := []string{
 			"fetch", "origin", "pull/" + testPrNumber + "/head:" + testBranch,
@@ -142,6 +151,9 @@ func TestFetchPR(t *testing.T) {
 
 func TestMerge(t *testing.T) {
 	testBranch := "branch"
+	oldExec := execCommand
+	defer func() { execCommand = oldExec }()
+
 	execCommand = getFakeExecCommand(func(cmd string, args ...string) {
 		want := []string{
 			"merge", "--no-edit", testBranch,
@@ -264,6 +276,7 @@ func TestSetupNonPR(t *testing.T) {
 		t.Errorf("Should not get here")
 		return nil
 	}
+	reset = func(string) error { return nil }
 	err := Setup(testScmURL, testDestination, testPrNumber, testSHA)
 
 	if err != nil {
@@ -300,6 +313,9 @@ func TestSetupPR(t *testing.T) {
 		}
 		return nil
 	}
+
+	oldMerge := mergePR
+	defer func() { mergePR = oldMerge }()
 	mergePR = func(pr, branch string) error {
 		if pr != testPrNumber {
 			t.Errorf("PR was sent with %q, want %q", pr, testPrNumber)

--- a/launch_test.go
+++ b/launch_test.go
@@ -317,6 +317,9 @@ func TestNonPR(t *testing.T) {
 		fmt.Println("yes")
 		return screwdriver.Pipeline(FakePipeline{ScmURL: testSCMURL}), nil
 	}
+
+	oldSetup := gitSetup
+	defer func() { gitSetup = oldSetup }()
 	gitSetup = func(scmUrl, destination, pr string, sha string) error {
 		if scmUrl != testHTTPS {
 			t.Errorf("Git clone was called with scmUrl %q, want %q", scmUrl, testHTTPS)
@@ -354,6 +357,9 @@ func TestPR(t *testing.T) {
 	api.pipelineFromID = func(pipelineID string) (screwdriver.Pipeline, error) {
 		return screwdriver.Pipeline(FakePipeline{ScmURL: testSCMURL}), nil
 	}
+
+	oldGitSetup := gitSetup
+	defer func() { gitSetup = oldGitSetup }()
 	gitSetup = func(scmUrl, destination, pr string, sha string) error {
 		if scmUrl != testHTTPS {
 			t.Errorf("Git clone was called with scmUrl %q, want %q", scmUrl, testHTTPS)
@@ -506,6 +512,8 @@ func TestPipelineDefFromYaml(t *testing.T) {
 		}), nil
 	}
 
+	oldRun := executorRun
+	defer func() { executorRun = oldRun }()
 	executorRun = func(out io.Writer, jobDef screwdriver.JobDef) error {
 		cmdDefs := jobDef.Commands
 		env := jobDef.Environment

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: golang:1.6
+box: golang:1.7
 
 build:
   steps:


### PR DESCRIPTION
Apparently go 1.7 gets mad if you fail a test after the test is
complete. This means that our sloppy use of global function overrides
caught up with us.