### PR TITLE
Add retry wrapper for http calls

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -11,8 +11,8 @@ import (
 var execCommand = exec.Command
 
 const (
-	SCM_URL_INDEX = 0
-	BRANCH_INDEX  = 1
+	scmUrlIndex = 0
+	branchIndex = 1
 )
 
 type repo struct {
@@ -35,9 +35,9 @@ func New(scmURL, path string) (Repo, error) {
 		return nil, fmt.Errorf("expected #branchname in SCM URL: %v", scmURL)
 	}
 	repo := repo{
-		ScmURL: parts[SCM_URL_INDEX],
+		ScmURL: parts[scmUrlIndex],
 		Path:   path,
-		Branch: parts[BRANCH_INDEX],
+		Branch: parts[branchIndex],
 	}
 	return Repo(repo), nil
 }

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -3,13 +3,15 @@ package screwdriver
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"reflect"
-	"strings"
 	"testing"
+	"time"
 )
 
 func makeFakeHTTPClient(t *testing.T, code int, body string) *http.Client {
@@ -45,232 +47,305 @@ func validateHeader(t *testing.T, key, value string) func(r *http.Request) {
 	}
 }
 
-func TestFromBuildId(t *testing.T) {
-	want := Build{
-		ID:    "testId",
-		JobID: "testJob",
-		SHA:   "testSHA",
-	}
-	json, err := json.Marshal(want)
-	if err != nil {
-		t.Fatalf("Unable to Marshal JSON for test: %v", err)
-	}
-
-	http := makeFakeHTTPClient(t, 200, string(json))
-
-	testAPI := api{"http://fakeurl", "faketoken", http}
-	build, err := testAPI.BuildFromID(want.ID)
-
-	if err != nil {
-		t.Errorf("Unexpected error from BuildFromID: %v", err)
-	}
-
-	if build != want {
-		t.Errorf("build == %#v, want %#v", build, want)
-	}
+func TestMain(m *testing.M) {
+	sleep = func(d time.Duration) {}
+	os.Exit(m.Run())
 }
 
-func TestBuild404(t *testing.T) {
-	want := SDError{
-		StatusCode: 404,
-		Reason:     "Not Found",
-		Message:    "Build does not exist",
-	}
-
-	json, err := json.Marshal(want)
-	if err != nil {
-		t.Fatalf("Unable to Marshal JSON for test: %v", err)
-	}
-
-	http := makeFakeHTTPClient(t, 404, string(json))
-	testAPI := api{"http://fakeurl", "faketoken", http}
-	_, err = testAPI.BuildFromID("doesntexist")
-
-	if err != want {
-		t.Fatalf("err = %v, want %v", err, want)
-	}
-}
-
-func TestFromJobId(t *testing.T) {
-	want := Job{
-		ID:         "testId",
-		PipelineID: "testPipeline",
-		Name:       "testName",
-	}
-	json, err := json.Marshal(want)
-	if err != nil {
-		t.Fatalf("Unable to Marshal JSON for test: %v", err)
-	}
-
-	http := makeFakeHTTPClient(t, 200, string(json))
-
-	testAPI := api{"http://fakeurl", "faketoken", http}
-	job, err := testAPI.JobFromID(want.ID)
-
-	if err != nil {
-		t.Errorf("Unexpected error from JobFromID: %v", err)
-	}
-
-	if job != want {
-		t.Errorf("job == %#v, want %#v", job, want)
-	}
-}
-
-func TestJob404(t *testing.T) {
-	want := SDError{
-		StatusCode: 404,
-		Reason:     "Not Found",
-		Message:    "Job does not exist",
-	}
-
-	json, err := json.Marshal(want)
-	if err != nil {
-		t.Fatalf("Unable to Marshal JSON for test: %v", err)
-	}
-
-	http := makeFakeHTTPClient(t, 404, string(json))
-	testAPI := api{"http://fakeurl", "faketoken", http}
-	_, err = testAPI.JobFromID("doesntexist")
-
-	if err != want {
-		t.Fatalf("err = %v, want %v", err, want)
-	}
-}
-
-func TestFromPipelineId(t *testing.T) {
-	want := Pipeline{
-		ID:     "testId",
-		ScmURL: "testScmURL",
-	}
-	json, err := json.Marshal(want)
-	if err != nil {
-		t.Fatalf("Unable to Marshal JSON for test: %v", err)
-	}
-
-	http := makeFakeHTTPClient(t, 200, string(json))
-
-	testAPI := api{"http://fakeurl", "faketoken", http}
-	pipeline, err := testAPI.PipelineFromID(want.ID)
-
-	if err != nil {
-		t.Errorf("Unexpected error from JobFromID: %v", err)
-	}
-
-	if pipeline != want {
-		t.Errorf("pipeline == %#v, want %#v", pipeline, want)
-	}
-}
-
-func TestPipeline404(t *testing.T) {
-	want := SDError{
-		StatusCode: 404,
-		Reason:     "Not Found",
-		Message:    "Pipeline does not exist",
-	}
-
-	json, err := json.Marshal(want)
-	if err != nil {
-		t.Fatalf("Unable to Marshal JSON for test: %v", err)
-	}
-
-	http := makeFakeHTTPClient(t, 404, string(json))
-	testAPI := api{"http://fakeurl", "faketoken", http}
-	_, err = testAPI.PipelineFromID("doesntexist")
-
-	if err != want {
-		t.Fatalf("err = %v, want %v", err, want)
-	}
-}
-
-func TestPipelineFromYaml(t *testing.T) {
-	json := `{
-    "jobs": {
-      "main": [
-        {
-          "image": "node:4",
-          "commands": [
-            {
-              "name": "install",
-              "command": "npm install"
-            }
-          ],
-          "environment": {
-            "ARRAY": "[\"a\",\"b\"]",
-            "BOOL": "true",
-            "OBJECT": "{\"a\":\"cat\",\"b\":\"dog\"}",
-            "NUMBER": "3",
-            "DECIMAL": "3.1415927",
-            "STRING": "test"
-          }
-        }
-      ]
-    },
-    "workflow": []
-  }`
-
-	mainJob := JobDef{
-		Image: "node:4",
-		Commands: []CommandDef{
-			{
-				Name: "install",
-				Cmd:  "npm install",
+func TestBuildFromID(t *testing.T) {
+	tests := []struct {
+		build      Build
+		statusCode int
+		err        error
+	}{
+		{
+			build: Build{
+				ID:    "testId",
+				JobID: "testJob",
+				SHA:   "testSHA",
+			},
+			statusCode: 200,
+			err:        nil,
+		},
+		{
+			build:      Build{},
+			statusCode: 500,
+			err: errors.New("timeout on request: after 5 attempts, last error: " +
+				"GET retries exhausted: 500 returned from GET http://fakeurl/v3/builds/"),
+		},
+		{
+			build:      Build{},
+			statusCode: 404,
+			err: SDError{
+				StatusCode: 404,
+				Reason:     "Not Found",
+				Message:    "Build does not exist",
 			},
 		},
-		Environment: map[string]string{
-			"ARRAY":   `["a","b"]`,
-			"BOOL":    "true",
-			"OBJECT":  `{"a":"cat","b":"dog"}`,
-			"NUMBER":  "3",
-			"DECIMAL": "3.1415927",
-			"STRING":  "test",
-		},
 	}
 
-	wantJobs := map[string][]JobDef{
-		"main": {
-			mainJob,
-		},
-	}
+	for _, test := range tests {
+		JSON := []byte{}
+		err := errors.New("")
 
-	yaml := bytes.NewBufferString("")
-	http := makeFakeHTTPClient(t, 200, json)
-	testAPI := api{"http://fakeurl", "faketoken", http}
-	p, err := testAPI.PipelineDefFromYaml(yaml)
-	if err != nil {
-		t.Errorf("Unexpected error from PipelineDefFromYaml: %v", err)
-	}
+		if reflect.TypeOf(test.err) == reflect.TypeOf(SDError{}) {
+			JSON, err = json.Marshal(test.err)
+			if err != nil {
+				t.Fatalf("Unable to Marshal JSON for SDErr: %v", err)
+			}
+		} else {
+			JSON, err = json.Marshal(test.build)
+			if err != nil {
+				t.Fatalf("Unable to Marshal JSON for SDErr: %v", err)
+			}
+		}
 
-	if !reflect.DeepEqual(p.Jobs, wantJobs) {
-		t.Errorf("PipelineDef.Jobs = %+v, \n want %+v", p.Jobs, wantJobs)
-	}
-}
+		http := makeFakeHTTPClient(t, test.statusCode, string(JSON))
+		testAPI := api{"http://fakeurl", "faketoken", http}
 
-func TestUpdateBuildStatus(t *testing.T) {
-	http := makeFakeHTTPClient(t, 200, "{}")
-	testAPI := api{"http://fakeurl", "faketoken", http}
-	statuses := []BuildStatus{
-		Success,
-		Failure,
-		Aborted,
-		Running,
-	}
+		build, err := testAPI.BuildFromID(test.build.ID)
 
-	for _, status := range statuses {
-		err := testAPI.UpdateBuildStatus(status)
-		if err != nil {
-			t.Errorf("Unexpected error from UpdateBuildStatus(%s): %v", status, err)
+		if !reflect.DeepEqual(err, test.err) {
+			t.Errorf("Unexpected error from BuildFromID: %v, want %v", err, test.err)
+		}
+
+		if !reflect.DeepEqual(build, test.build) {
+			t.Errorf("build == %#v, want %#v", build, test.build)
 		}
 	}
 }
 
-func TestBadUpdateBuildStatus(t *testing.T) {
-	http := makeFakeHTTPClient(t, 200, "{}")
-	testAPI := api{"http://fakeurl", "faketoken", http}
-	err := testAPI.UpdateBuildStatus("NOTASTATUS")
-	if err == nil {
-		t.Fatalf("Expected an error from UpdateBuildStatus. Got none.")
+func TestJobFromID(t *testing.T) {
+	tests := []struct {
+		job        Job
+		statusCode int
+		err        error
+	}{
+		{
+			job: Job{
+				ID:         "testId",
+				PipelineID: "testPipeline",
+				Name:       "testName",
+			},
+			statusCode: 200,
+			err:        nil,
+		},
+		{
+			job:        Job{},
+			statusCode: 500,
+			err: errors.New("timeout on request: after 5 attempts, last error: " +
+				"GET retries exhausted: 500 returned from GET http://fakeurl/v3/jobs/"),
+		},
+		{
+			job:        Job{},
+			statusCode: 404,
+			err: SDError{
+				StatusCode: 404,
+				Reason:     "Not Found",
+				Message:    "Job does not exist",
+			},
+		},
 	}
-	if !strings.Contains(err.Error(), "invalid build status: NOTASTATUS") {
-		t.Errorf("Unexpected error from UpdateBuildStatus: %v", err)
+
+	for _, test := range tests {
+		JSON := []byte{}
+		err := errors.New("")
+
+		if reflect.TypeOf(test.err) == reflect.TypeOf(SDError{}) {
+			JSON, err = json.Marshal(test.err)
+			if err != nil {
+				t.Fatalf("Unable to Marshal JSON for SDErr: %v", err)
+			}
+		} else {
+			JSON, err = json.Marshal(test.job)
+			if err != nil {
+				t.Fatalf("Unable to Marshal JSON for SDErr: %v", err)
+			}
+		}
+
+		http := makeFakeHTTPClient(t, test.statusCode, string(JSON))
+		testAPI := api{"http://fakeurl", "faketoken", http}
+
+		job, err := testAPI.JobFromID(test.job.ID)
+
+		if !reflect.DeepEqual(err, test.err) {
+			t.Errorf("Unexpected error from JobFromID: %v, want %v", err, test.err)
+		}
+
+		if !reflect.DeepEqual(job, test.job) {
+			t.Errorf("job == %#v, want %#v", job, test.job)
+		}
 	}
+}
+
+func TestPipelineFromID(t *testing.T) {
+	tests := []struct {
+		pipeline   Pipeline
+		statusCode int
+		err        error
+	}{
+		{
+			pipeline: Pipeline{
+				ID:     "testId",
+				ScmURL: "testScmURL",
+			},
+			statusCode: 200,
+			err:        nil,
+		},
+		{
+			pipeline:   Pipeline{},
+			statusCode: 500,
+			err: errors.New("timeout on request: after 5 attempts, last error: " +
+				"GET retries exhausted: 500 returned from GET http://fakeurl/v3/pipelines/"),
+		},
+		{
+			pipeline:   Pipeline{},
+			statusCode: 404,
+			err: SDError{
+				StatusCode: 404,
+				Reason:     "Not Found",
+				Message:    "Pipeline does not exist",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		JSON := []byte{}
+		err := errors.New("")
+
+		if reflect.TypeOf(test.err) == reflect.TypeOf(SDError{}) {
+			JSON, err = json.Marshal(test.err)
+			if err != nil {
+				t.Fatalf("Unable to Marshal JSON for SDErr: %v", err)
+			}
+		} else {
+			JSON, err = json.Marshal(test.pipeline)
+			if err != nil {
+				t.Fatalf("Unable to Marshal JSON for SDErr: %v", err)
+			}
+		}
+
+		http := makeFakeHTTPClient(t, test.statusCode, string(JSON))
+		testAPI := api{"http://fakeurl", "faketoken", http}
+
+		pipeline, err := testAPI.PipelineFromID(test.pipeline.ID)
+
+		if !reflect.DeepEqual(err, test.err) {
+			t.Errorf("Unexpected error from PipelineFromID: %v, want %v", err, test.err)
+		}
+
+		if !reflect.DeepEqual(pipeline, test.pipeline) {
+			t.Errorf("pipeline == %#v, want %#v", pipeline, test.pipeline)
+		}
+	}
+}
+
+func TestPipelineDefFromYaml(t *testing.T) {
+	tests := []struct {
+		json       string
+		jobs       map[string][]JobDef
+		statusCode int
+		err        error
+	}{
+		{
+			json: `{
+		    "jobs": {
+		      "main": [
+		        {
+		          "image": "node:4",
+		          "commands": [
+		            {
+		              "name": "install",
+		              "command": "npm install"
+		            }
+		          ],
+		          "environment": {
+		            "ARRAY": "[\"a\",\"b\"]",
+		            "BOOL": "true",
+		            "OBJECT": "{\"a\":\"cat\",\"b\":\"dog\"}",
+		            "NUMBER": "3",
+		            "DECIMAL": "3.1415927",
+		            "STRING": "test"
+		          }
+		        }
+		      ]
+		    },
+		    "workflow": []
+		  }`,
+			jobs: map[string][]JobDef{
+				"main": []JobDef{
+					{
+						Image: "node:4",
+						Commands: []CommandDef{
+							{
+								Name: "install",
+								Cmd:  "npm install",
+							},
+						},
+						Environment: map[string]string{
+							"ARRAY":   `["a","b"]`,
+							"BOOL":    "true",
+							"OBJECT":  `{"a":"cat","b":"dog"}`,
+							"NUMBER":  "3",
+							"DECIMAL": "3.1415927",
+							"STRING":  "test",
+						},
+					},
+				},
+			},
+			statusCode: 200,
+			err:        nil,
+		},
+		{
+			json:       "",
+			jobs:       map[string][]JobDef{},
+			statusCode: 500,
+			err: errors.New("posting to Validator: timeout on request after 5 attempts, " +
+				"last error: POST retries exhausted: 500 returned from POST http://fakeurl/v3/validator"),
+		},
+	}
+
+	for _, test := range tests {
+		yaml := bytes.NewBufferString("")
+		http := makeFakeHTTPClient(t, test.statusCode, test.json)
+		testAPI := api{"http://fakeurl", "faketoken", http}
+
+		p, err := testAPI.PipelineDefFromYaml(yaml)
+
+		if !reflect.DeepEqual(err, test.err) {
+			t.Errorf("Unexpected error from PipelineDefFromYaml: %v, want %v", err, test.err)
+		}
+
+		if !reflect.DeepEqual(p.Jobs, test.jobs) && len(p.Jobs) != len(test.jobs) {
+			t.Errorf("PipelineDef.Jobs = %+v, \n want %+v", p.Jobs, test.jobs)
+		}
+	}
+}
+
+func TestUpdateBuildStatus(t *testing.T) {
+	tests := []struct {
+		status     BuildStatus
+		statusCode int
+		err        error
+	}{
+		{Success, 200, nil},
+		{Failure, 200, nil},
+		{Aborted, 200, nil},
+		{Running, 200, nil},
+		{"NOTASTATUS", 200, errors.New("invalid build status: NOTASTATUS")},
+		{Success, 500, errors.New("posting to Build Status: timeout on request after 5 attempts, " +
+			"last error: POST retries exhausted: 500 returned from POST http://fakeurl/v3/webhooks/build")},
+	}
+
+	for _, test := range tests {
+		http := makeFakeHTTPClient(t, test.statusCode, "{}")
+		testAPI := api{"http://fakeurl", "faketoken", http}
+
+		err := testAPI.UpdateBuildStatus(test.status)
+
+		if !reflect.DeepEqual(err, test.err) {
+			t.Errorf("Unexpected error from UpdateBuildStatus: %v, want %v", err, test.err)
+		}
+	}
+
 }


### PR DESCRIPTION
- All HTTP calls will attempt to retry upon receiving 5XXs
- Default retry attempt is currently set to 5
- Exponential back off for up to ~1 minute (2s, 4s, 8s, 16s, 32s)

- Also refactors Screwdriver tests into tables
- Change const values into camelCase