### PR TITLE
Change dir of each command, Merge environment variables instead of overrwite

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -58,6 +58,10 @@ func TestHelperProcess(*testing.T) {
 	os.Exit(255)
 }
 
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
+}
+
 func TestRunSingle(t *testing.T) {
 	var tests = []struct {
 		command string
@@ -104,7 +108,7 @@ func TestRunSingle(t *testing.T) {
 			Commands:    testCmds,
 			Environment: map[string]string{},
 		}
-		err := Run(nil, testJob)
+		err := Run("", nil, testJob)
 
 		if !reflect.DeepEqual(err, test.err) {
 			t.Errorf("Unexpected error from Run(%#v): %v", testCmds, err)
@@ -149,7 +153,7 @@ func TestRunMulti(t *testing.T) {
 		Commands:    testCmds,
 		Environment: testEnv,
 	}
-	err := Run(nil, testJob)
+	err := Run("", nil, testJob)
 
 	if len(called) < len(tests)-1 {
 		t.Fatalf("%d commands called, want %d", len(called), len(tests)-1)
@@ -192,7 +196,7 @@ func TestUnmocked(t *testing.T) {
 			},
 			Environment: testEnv,
 		}
-		err := Run(nil, testJob)
+		err := Run("", nil, testJob)
 
 		if !reflect.DeepEqual(err, test.err) {
 			t.Errorf("Unexpected error: %v, want %v", err, test.err)
@@ -220,7 +224,7 @@ func TestEnv(t *testing.T) {
 
 	execCommand = exec.Command
 	output := new(bytes.Buffer)
-	err := Run(output, job)
+	err := Run("", output, job)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}

--- a/launch.go
+++ b/launch.go
@@ -27,7 +27,6 @@ var mkdirAll = os.MkdirAll
 var stat = os.Stat
 var newRepo = git.New
 var open = os.Open
-var chdir = os.Chdir
 var executorRun = executor.Run
 var writeFile = ioutil.WriteFile
 
@@ -200,10 +199,6 @@ func launch(api screwdriver.API, buildID string, rootDir string) error {
 		}
 	}
 
-	if err := chdir(repo.GetPath()); err != nil {
-		return err
-	}
-
 	var yaml io.ReadCloser
 
 	yaml, err = open(path.Join(w.Src, "screwdriver.yaml"))
@@ -241,7 +236,7 @@ func launch(api screwdriver.API, buildID string, rootDir string) error {
 		return fmt.Errorf("creating environment.json artifact: %v", err)
 	}
 
-	err = executorRun(os.Stdout, currentJob)
+	err = executorRun(repo.GetPath(), os.Stdout, currentJob)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Rather than changing the directory in launch, we do so in executor.Run by passing in the path to the function.