### PR TITLE
Add default environment variables as argument to executor run

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -22,10 +22,13 @@ func (e ErrStatus) Error() string {
 }
 
 // Run executes a slice of CommandDefs
-func Run(path string, output io.Writer, job screwdriver.JobDef) error {
+func Run(defaultEnv map[string]string, path string, output io.Writer, job screwdriver.JobDef) error {
 	cmds := job.Commands
 	env := os.Environ()
 	for k, v := range job.Environment {
+		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	}
+	for k, v := range defaultEnv {
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}
 	for _, cmd := range cmds {

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -13,6 +13,16 @@ import (
 	"github.com/screwdriver-cd/launcher/screwdriver"
 )
 
+var defaultEnv = map[string]string{
+	"SCREWDRIVER": "true",
+	"CI":          "true",
+	"CONTINUOUS_INTEGRATION": "true",
+	"SD_JOB_NAME":            "main",
+	"SD_PULL_REQUEST":        "",
+	"SD_SOURCE_DIR":          "test/path",
+	"SD_ARTIFACTS_DIR":       "/sd/workspace/artifacts",
+}
+
 type execFunc func(command string, args ...string) *exec.Cmd
 
 func getFakeExecCommand(validator func(string, ...string)) execFunc {
@@ -108,7 +118,7 @@ func TestRunSingle(t *testing.T) {
 			Commands:    testCmds,
 			Environment: map[string]string{},
 		}
-		err := Run("", nil, testJob)
+		err := Run(defaultEnv, "", nil, testJob)
 
 		if !reflect.DeepEqual(err, test.err) {
 			t.Errorf("Unexpected error from Run(%#v): %v", testCmds, err)
@@ -153,7 +163,7 @@ func TestRunMulti(t *testing.T) {
 		Commands:    testCmds,
 		Environment: testEnv,
 	}
-	err := Run("", nil, testJob)
+	err := Run(defaultEnv, "", nil, testJob)
 
 	if len(called) < len(tests)-1 {
 		t.Fatalf("%d commands called, want %d", len(called), len(tests)-1)
@@ -196,7 +206,7 @@ func TestUnmocked(t *testing.T) {
 			},
 			Environment: testEnv,
 		}
-		err := Run("", nil, testJob)
+		err := Run(defaultEnv, "", nil, testJob)
 
 		if !reflect.DeepEqual(err, test.err) {
 			t.Errorf("Unexpected error: %v, want %v", err, test.err)
@@ -224,7 +234,7 @@ func TestEnv(t *testing.T) {
 
 	execCommand = exec.Command
 	output := new(bytes.Buffer)
-	err := Run("", output, job)
+	err := Run(defaultEnv, "", output, job)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -240,6 +250,12 @@ func TestEnv(t *testing.T) {
 	for k, v := range want {
 		if found[k] != v {
 			t.Errorf("%v=%v, want %v", k, v, want[k])
+		}
+	}
+
+	for k, v := range defaultEnv {
+		if found[k] != v {
+			t.Errorf("%v=%v, want %v", k, v, defaultEnv[k])
 		}
 	}
 }

--- a/launch.go
+++ b/launch.go
@@ -236,7 +236,18 @@ func launch(api screwdriver.API, buildID string, rootDir string) error {
 		return fmt.Errorf("creating environment.json artifact: %v", err)
 	}
 
-	err = executorRun(repo.GetPath(), os.Stdout, currentJob)
+	//Set all default environment variables
+	defaultEnv := map[string]string{
+		"SCREWDRIVER": "true",
+		"CI":          "true",
+		"CONTINUOUS_INTEGRATION": "true",
+		"SD_JOB_NAME":            j.Name,
+		"SD_PULL_REQUEST":        pr,
+		"SD_SOURCE_DIR":          repo.GetPath(),
+		"SD_ARTIFACTS_DIR":       w.Artifacts,
+	}
+
+	err = executorRun(defaultEnv, repo.GetPath(), os.Stdout, currentJob)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Alternative method to add default environment variables (#57) , please compare to PR #58 

My thoughts are that this implementation moves the responsibility of setting the default environment variables from launch to the executor.