### PR TITLE
Fixed a bug with partial line reads in the emitter

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -37,6 +37,10 @@ type MockEmitter struct {
 	found    []byte
 }
 
+func (e *MockEmitter) Error() error {
+	return nil
+}
+
 func (e *MockEmitter) StartCmd(cmd screwdriver.CommandDef) {
 	if e.startCmd != nil {
 		e.startCmd(cmd)

--- a/launch_test.go
+++ b/launch_test.go
@@ -149,6 +149,10 @@ type MockEmitter struct {
 	close    func() error
 }
 
+func (e *MockEmitter) Error() error {
+	return nil
+}
+
 func (e *MockEmitter) StartCmd(cmd screwdriver.CommandDef) {
 	if e.startCmd != nil {
 		e.startCmd(cmd)

--- a/screwdriver/emitter_test.go
+++ b/screwdriver/emitter_test.go
@@ -24,6 +24,7 @@ func TestEmitter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't create temp dir: %v", err)
 	}
+	fmt.Println("TEMPDIR:", tmp)
 	defer os.RemoveAll(tmp)
 
 	emitterpath := path.Join(tmp, "socket")
@@ -52,11 +53,16 @@ func TestEmitter(t *testing.T) {
 		fmt.Fprintln(emitter, test.message)
 		time.Sleep(1 * time.Millisecond)
 	}
+
+	emitter.Write([]byte("This should not be processed. It has no newline."))
+
 	f, err := os.Open(emitterpath)
 	if err != nil {
 		t.Fatalf("Error opening file: %v", err)
 	}
 
+	data, _ := ioutil.ReadFile(emitterpath)
+	fmt.Println("DATA: ", string(data))
 	scanner := bufio.NewScanner(f)
 	line := 0
 	var log logLine
@@ -68,6 +74,11 @@ func TestEmitter(t *testing.T) {
 		if err != nil {
 			t.Errorf("error unmarshalling %v", err)
 		}
+
+		if line >= len(tests) {
+			t.Fatalf("Too many lines received. Want %d, got %d", len(tests), line+1)
+		}
+
 		if log.Step != tests[line].step {
 			t.Errorf("step is incorrect. Wanted %v. Got %v", tests[line].step, log.Step)
 		}


### PR DESCRIPTION
- Previously reads were happening in a buffer, which could lead to
  partial lines instead of waiting for newline
- Now we are using a Pipe to allow us to pull in STDOUT/STDERR from the command subprocesses.
  This has the effect of creating a blocking pipe all the way through to the unix socket that we are 
  writing to. We may need to buffer things in the future if we start to hit delays writing to the
  logger service over the unix socket