### PR TITLE
Removing the .git portion of ScmURL

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -64,10 +64,10 @@ func (s scmPath) httpsString() string {
 
 // e.g. "git@github.com:screwdriver-cd/launch.git#master"
 func parseScmURL(url string) (scmPath, error) {
-	r := regexp.MustCompile("^git@(.*):(.*)/(.*)#(.*)$")
+	r := regexp.MustCompile("^git@(.*):(.*)/(.*?)(?:\\.git)?#(.*)$")
 	matched := r.FindStringSubmatch(url)
 	if matched == nil || len(matched) != 5 {
-		return scmPath{}, fmt.Errorf("Unable to parse SCM URL %v, match: %q", url, matched)
+		return scmPath{}, fmt.Errorf("unable to parse SCM URL %v, match: %q", url, matched)
 	}
 
 	return scmPath{
@@ -172,6 +172,10 @@ func launch(api screwdriver.API, buildID, rootDir, emitterPath string) error {
 	}
 
 	scm, err := parseScmURL(p.ScmURL)
+	if err != nil {
+		return err
+	}
+
 	log.Printf("Creating Workspace in %v", rootDir)
 	w, err := createWorkspace(rootDir, scm.Host, scm.Org, scm.Repo)
 	if err != nil {

--- a/launch_test.go
+++ b/launch_test.go
@@ -78,7 +78,7 @@ func mockAPI(t *testing.T, testBuildID, testJobID, testPipelineID string, testSt
 				// Panic to get the stacktrace
 				panic(true)
 			}
-			return screwdriver.Pipeline(FakePipeline{}), nil
+			return screwdriver.Pipeline(FakePipeline{ScmURL: "git@github.com:screwdriver-cd/launcher.git#master"}), nil
 		},
 		updateBuildStatus: func(status screwdriver.BuildStatus) error {
 			if status != testStatus {
@@ -299,10 +299,10 @@ func TestPipelineFromIdError(t *testing.T) {
 func TestParseScmURL(t *testing.T) {
 	wantHost := "github.com"
 	wantOrg := "screwdriver-cd"
-	wantRepo := "launcher.git"
+	wantRepo := "launcher"
 	wantBranch := "master"
 
-	scmURL := "git@github.com:screwdriver-cd/launcher.git#master"
+	scmURL := "git@github.com:screwdriver-cd/launcher#master"
 	parsedURL, err := parseScmURL(scmURL)
 	host, org, repo, branch := parsedURL.Host, parsedURL.Org, parsedURL.Repo, parsedURL.Branch
 	if err != nil {
@@ -465,7 +465,7 @@ func TestCreateWorkspaceError(t *testing.T) {
 
 	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter)
 
-	if err.Error() != "Cannot create workspace path \"/sd/workspace/src/github.com/screwdriver-cd/launcher.git\": Spooky error" {
+	if err.Error() != "Cannot create workspace path \"/sd/workspace/src/github.com/screwdriver-cd/launcher\": Spooky error" {
 		t.Errorf("Error is wrong, got %v", err)
 	}
 }
@@ -540,7 +540,7 @@ func TestPipelineDefFromYaml(t *testing.T) {
 	oldOpen := open
 	defer func() { open = oldOpen }()
 	open = func(f string) (*os.File, error) {
-		if f != "/sd/workspace/src/screwdriver.yaml" {
+		if f != "/sd/workspace/src/github.com/screwdriver-cd/launcher/screwdriver.yaml" {
 			t.Errorf("File name not correct: %q", f)
 		}
 


### PR DESCRIPTION
- This fixes go projects
- It's also an unnecessary bit of text in a workspace name
- New checkout: /sd/workspace/src/github.com/screwdriver-cd/launcher