### PR TITLE
Associating emitter data with sd-setup by default

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -149,8 +149,7 @@ func prNumber(jobName string) string {
 
 func launch(api screwdriver.API, buildID, rootDir, emitterPath string) error {
 	log.Print("Setting Build Status to RUNNING")
-	err := api.UpdateBuildStatus(screwdriver.Running, buildID)
-	if err != nil {
+	if err := api.UpdateBuildStatus(screwdriver.Running, buildID); err != nil {
 		return fmt.Errorf("updating build status to RUNNING: %v", err)
 	}
 
@@ -218,7 +217,6 @@ func launch(api screwdriver.API, buildID, rootDir, emitterPath string) error {
 	if err != nil {
 		return fmt.Errorf("opening screwdriver.yaml: %v", err)
 	}
-
 	defer yaml.Close()
 
 	pipelineDef, err := api.PipelineDefFromYaml(yaml)

--- a/screwdriver/emitter.go
+++ b/screwdriver/emitter.go
@@ -42,11 +42,6 @@ func (e *emitter) StartCmd(cmd CommandDef) {
 	e.cmd = cmd
 }
 
-// Close closes the emitter and its underlying handles
-func (e *emitter) Close() error {
-	return e.PipeWriter.Close()
-}
-
 func (e *emitter) processPipe() {
 	scanner := bufio.NewScanner(e.reader)
 	encoder := json.NewEncoder(e.file)
@@ -75,11 +70,16 @@ func NewEmitter(path string) (Emitter, error) {
 		return nil, fmt.Errorf("failed opening emitter path %q: %v", path, err)
 	}
 
+	cmd := CommandDef{
+		Name: "sd-setup",
+	}
+
 	e := &emitter{
 		file:       file,
 		buffer:     bytes.NewBuffer([]byte{}),
 		reader:     r,
 		PipeWriter: w,
+		cmd:        cmd,
 	}
 
 	go e.processPipe()

--- a/screwdriver/emitter_test.go
+++ b/screwdriver/emitter_test.go
@@ -38,31 +38,34 @@ func TestEmitter(t *testing.T) {
 	}
 	defer emitter.Close()
 
-	var tests = []struct {
+	type testlist []struct {
 		message string
 		step    string
-	}{
+	}
+	var tests = testlist{
 		{"line1", "step1"},
 		{"line2", "step1"},
 		{"line3", "step2"},
 		{"line4", "step2"},
 	}
 
+	fmt.Fprintln(emitter, "running sd-setup step")
+	time.Sleep(1 * time.Millisecond)
 	for _, test := range tests {
 		emitter.StartCmd(fakeCmd(test.step))
 		fmt.Fprintln(emitter, test.message)
 		time.Sleep(1 * time.Millisecond)
 	}
-
 	emitter.Write([]byte("This should not be processed. It has no newline."))
+
+	tests = append(testlist{{"running sd-setup step", "sd-setup"}}, tests...)
 
 	f, err := os.Open(emitterpath)
 	if err != nil {
 		t.Fatalf("Error opening file: %v", err)
 	}
 
-	data, _ := ioutil.ReadFile(emitterpath)
-	fmt.Println("DATA: ", string(data))
+	_, _ = ioutil.ReadFile(emitterpath)
 	scanner := bufio.NewScanner(f)
 	line := 0
 	var log logLine


### PR DESCRIPTION
This will allow us to emit information about the Screwdriver workspace
setup, and have it be associated with the sd-setup test