### PR TITLE
Update parseScmUrl() to take in scmUri and scmRepo

### DIFF
--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -96,7 +96,13 @@ type Validator struct {
 // Pipeline is a Screwdriver Pipeline definition.
 type Pipeline struct {
 	ID     string `json:"id"`
-	ScmURL string `json:"scmUrl"`
+	ScmRepo ScmRepo `json:"scmRepo"`
+	ScmUri string `json:"scmUri"`
+}
+
+// ScmRepo contains the full name of the repository for a Pipeline, e.g. "screwdriver-cd/launcher"
+type ScmRepo struct {
+	Name string `json:"name"`
 }
 
 // PipelineDef contains the step definitions and jobs for a Pipeline.

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -210,7 +210,10 @@ func TestPipelineFromID(t *testing.T) {
 		{
 			pipeline: Pipeline{
 				ID:     "testId",
-				ScmURL: "testScmURL",
+				ScmUri: "github.com:123456:master",
+				ScmRepo: ScmRepo{
+					Name: "screwdriver-cd/launcher",
+				},
 			},
 			statusCode: 200,
 			err:        nil,


### PR DESCRIPTION
- Change `parseScmUrl()` to `parseScmUri()`
- Now the method takes in `scmUri`, `scmRepo.name`  and `scmRepo.branch`

<img width="743" alt="screen shot 2016-10-19 at 8 08 20 pm" src="https://cloud.githubusercontent.com/assets/20427140/19545017/f70b7fcc-9637-11e6-939c-f91347452cab.png">


