### PR TITLE
Refactor build environment creation

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -61,10 +61,6 @@ func doRun(cmd screwdriver.CommandDef, emitter screwdriver.Emitter, env []string
 func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriver.Build, api screwdriver.API, buildID string) error {
 	cmds := build.Commands
 
-	for k, v := range build.Environment {
-		env = append(env, fmt.Sprintf("%s=%s", k, v))
-	}
-
 	for _, cmd := range cmds {
 		if err := api.UpdateStepStart(buildID, cmd.Name); err != nil {
 			return fmt.Errorf("updating step start %q: %v", cmd.Name, err)

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -177,7 +177,7 @@ func TestRunSingle(t *testing.T) {
 		})
 
 		testBuild := screwdriver.Build{
-			ID: "build",
+			ID:          "build",
 			Commands:    testCmds,
 			Environment: map[string]string{},
 		}
@@ -234,7 +234,7 @@ func TestRunMulti(t *testing.T) {
 	})
 
 	testBuild := screwdriver.Build{
-		ID: "build",
+		ID:          "build",
 		Commands:    testCmds,
 		Environment: testEnv,
 	}
@@ -313,10 +313,6 @@ func TestUnmocked(t *testing.T) {
 }
 
 func TestEnv(t *testing.T) {
-	buildEnv := map[string]string{
-		"GOPATH": "/go/path",
-	}
-
 	baseEnv := []string{
 		"var1=foo",
 		"var2=bar",
@@ -324,10 +320,9 @@ func TestEnv(t *testing.T) {
 	}
 
 	want := map[string]string{
-		"var1":   "foo",
-		"var2":   "bar",
-		"VAR3":   "baz",
-		"GOPATH": "/go/path",
+		"var1": "foo",
+		"var2": "bar",
+		"VAR3": "baz",
 	}
 
 	cmds := []screwdriver.CommandDef{
@@ -338,9 +333,8 @@ func TestEnv(t *testing.T) {
 	}
 
 	testBuild := screwdriver.Build{
-		ID: "build",
-		Commands:    cmds,
-		Environment: buildEnv,
+		ID:       "build",
+		Commands: cmds,
 	}
 
 	execCommand = exec.Command
@@ -401,7 +395,7 @@ func TestEmitter(t *testing.T) {
 	}
 
 	testBuild := screwdriver.Build{
-		ID: "build",
+		ID:       "build",
 		Commands: []screwdriver.CommandDef{},
 	}
 	for _, test := range tests {

--- a/launch.go
+++ b/launch.go
@@ -216,7 +216,7 @@ func launch(api screwdriver.API, buildID, rootDir, emitterPath string) error {
 		return fmt.Errorf("Fetching secrets for build %s", b.ID)
 	}
 
-	env := createEnvironment(defaultEnv, secrets)
+	env := createEnvironment(defaultEnv, secrets, b)
 
 	if err := api.UpdateStepStop(buildID, "sd-setup", 0); err != nil {
 		return fmt.Errorf("updating sd-setup stop: %v", err)
@@ -229,7 +229,7 @@ func launch(api screwdriver.API, buildID, rootDir, emitterPath string) error {
 	return nil
 }
 
-func createEnvironment(base map[string]string, secrets screwdriver.Secrets) []string {
+func createEnvironment(base map[string]string, secrets screwdriver.Secrets, build screwdriver.Build) []string {
 	combined := map[string]string{}
 
 	// Start with the current environment
@@ -246,7 +246,7 @@ func createEnvironment(base map[string]string, secrets screwdriver.Secrets) []st
 		combined[k] = v
 	}
 
-	// Add the base environment values
+	// Add the default environment values
 	for k, v := range base {
 		combined[k] = v
 	}
@@ -268,6 +268,11 @@ func createEnvironment(base map[string]string, secrets screwdriver.Secrets) []st
 	for k, v := range combined {
 		envStrings = append(envStrings, strings.Join([]string{k, v}, "="))
 	}
+
+	for k, v := range build.Environment {
+		envStrings = append(envStrings, strings.Join([]string{k, v}, "="))
+	}
+
 	return envStrings
 }
 


### PR DESCRIPTION
- Setting build environment variables can be done inside `createEnvironment` since it just reads from `build`. 
- Remove some unused code left from the previous refactoring