### PR TITLE
feat: Switching to new naming convention `sd-setup-*` for startup commands [minor]

### DIFF
--- a/data/emitter
+++ b/data/emitter
@@ -1,0 +1,3 @@
+{"t":1482188362433,"m":"Workspace created in /var/folders/d6/rwx8bw4s4773s5v75z185j4r001ttj/T/ArtifactDir701279641","s":"sd-setup-launcher"}
+{"t":1482188362433,"m":"Source Dir: /var/folders/d6/rwx8bw4s4773s5v75z185j4r001ttj/T/ArtifactDir701279641/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
+{"t":1482188362433,"m":"Artifacts Dir: /var/folders/d6/rwx8bw4s4773s5v75z185j4r001ttj/T/ArtifactDir701279641/artifacts","s":"sd-setup-launcher"}

--- a/launch.go
+++ b/launch.go
@@ -143,8 +143,8 @@ func launch(api screwdriver.API, buildID, rootDir, emitterPath string) error {
 	}
 	defer emitter.Close()
 
-	if err = api.UpdateStepStart(buildID, "sd-setup"); err != nil {
-		return fmt.Errorf("updating sd-setup start: %v", err)
+	if err = api.UpdateStepStart(buildID, "sd-setup-launcher"); err != nil {
+		return fmt.Errorf("updating sd-setup-launcher start: %v", err)
 	}
 
 	log.Print("Setting Build Status to RUNNING")
@@ -218,8 +218,8 @@ func launch(api screwdriver.API, buildID, rootDir, emitterPath string) error {
 
 	env := createEnvironment(defaultEnv, secrets, b)
 
-	if err := api.UpdateStepStop(buildID, "sd-setup", 0); err != nil {
-		return fmt.Errorf("updating sd-setup stop: %v", err)
+	if err := api.UpdateStepStop(buildID, "sd-setup-launcher", 0); err != nil {
+		return fmt.Errorf("updating sd-setup-launcher stop: %v", err)
 	}
 
 	if err := executorRun(w.Src, env, emitter, b, api, buildID); err != nil {

--- a/screwdriver/emitter.go
+++ b/screwdriver/emitter.go
@@ -71,7 +71,7 @@ func NewEmitter(path string) (Emitter, error) {
 	}
 
 	cmd := CommandDef{
-		Name: "sd-setup",
+		Name: "sd-setup-launcher",
 	}
 
 	e := &emitter{

--- a/screwdriver/emitter_test.go
+++ b/screwdriver/emitter_test.go
@@ -49,7 +49,7 @@ func TestEmitter(t *testing.T) {
 		{"line4", "step2"},
 	}
 
-	fmt.Fprintln(emitter, "running sd-setup step")
+	fmt.Fprintln(emitter, "running sd-setup-launcher step")
 	time.Sleep(1 * time.Millisecond)
 	for _, test := range tests {
 		emitter.StartCmd(fakeCmd(test.step))
@@ -58,7 +58,7 @@ func TestEmitter(t *testing.T) {
 	}
 	emitter.Write([]byte("This should not be processed. It has no newline."))
 
-	tests = append(testlist{{"running sd-setup step", "sd-setup"}}, tests...)
+	tests = append(testlist{{"running sd-setup-launcher step", "sd-setup-launcher"}}, tests...)
 
 	f, err := os.Open(emitterpath)
 	if err != nil {


### PR DESCRIPTION
In the API we're naming all setup steps with `sd-setup-`

PRs needed:
 - https://github.com/screwdriver-cd/build-bookend/pull/4
 - https://github.com/screwdriver-cd/models/pull/143