### PR TITLE
Launcher passes env variables between steps

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1,23 +1,27 @@
 package executor
 
 import (
+	"bufio"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
 	"os/exec"
-	"syscall"
+	"regexp"
+	"strconv"
+	"strings"
 
+	"github.com/kr/pty"
+	"github.com/myesui/uuid"
 	"github.com/screwdriver-cd/launcher/screwdriver"
 )
 
 const (
-	// ExitLaunch is the exit code when a step fails to launch
-	ExitLaunch = 255
 	// ExitUnknown is the exit code when a step doesn't return an exit code (for some weird reason)
 	ExitUnknown = 254
 	// ExitOk is the exit code when a step runs successfully
 	ExitOk = 0
 )
-
-var execCommand = exec.Command
 
 // ErrStatus is an error that holds an exit status code
 type ErrStatus struct {
@@ -28,53 +32,114 @@ func (e ErrStatus) Error() string {
 	return fmt.Sprintf("exit %d", e.Status)
 }
 
-// doRun executes the command
-func doRun(cmd screwdriver.CommandDef, emitter screwdriver.Emitter, env []string, path string) (int, error) {
-	shargs := []string{"-e", "-c"}
-	shargs = append(shargs, cmd.Cmd)
-	c := execCommand("sh", shargs...)
+// Create a sh file
+func createShFile(path string, cmd screwdriver.CommandDef) error {
+	defaultStart := "#!/bin/sh -e"
+	return ioutil.WriteFile(path, []byte(defaultStart+"\n"+cmd.Cmd), 0755)
+}
 
-	emitter.StartCmd(cmd)
-	fmt.Fprintf(emitter, "$ %s\n", cmd.Cmd)
-	c.Stdout = emitter
-	c.Stderr = emitter
-
-	c.Dir = path
-	c.Env = append(env, c.Env...)
-
-	if err := c.Start(); err != nil {
-		return ExitLaunch, fmt.Errorf("launching command %q: %v", cmd.Cmd, err)
-	}
-
-	if err := c.Wait(); err != nil {
-		if exitError, ok := err.(*exec.ExitError); ok {
-			waitStatus := exitError.Sys().(syscall.WaitStatus)
-			return waitStatus.ExitStatus(), ErrStatus{waitStatus.ExitStatus()}
+// Copy lines until match string
+func copyLinesUntil(r io.Reader, w io.Writer, match string) (int, error) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		t := scanner.Text()
+		// Match the guid and exitCode
+		regex := fmt.Sprintf("(%s) ([0-9]+)", match)
+		re := regexp.MustCompile(regex)
+		parts := re.FindStringSubmatch(t)
+		if len(parts) != 0 {
+			exitCode, err := strconv.Atoi(parts[2])
+			if err != nil {
+				return ExitUnknown, fmt.Errorf("Error converting the exit code to int: %v", err)
+			}
+			if exitCode != 0 {
+				return exitCode, fmt.Errorf("Launching command exit with code: %v", exitCode)
+			}
+			return ExitOk, nil
 		}
-		return ExitUnknown, fmt.Errorf("running command %q: %v", cmd.Cmd, err)
+		// Match the export SD_STEP_ID command and if not match print it to emitter
+		reExport := regexp.MustCompile("export SD_STEP_ID=(" + match + ")")
+		exportCmd := reExport.FindStringSubmatch(t)
+		if len(exportCmd) == 0 {
+			fmt.Fprintln(w, t)
+		}
 	}
-
+	if err := scanner.Err(); err != nil {
+		return ExitUnknown, fmt.Errorf("Error with scanner: %v", err)
+	}
 	return ExitOk, nil
+}
+
+// Source script file from the path
+func doRunCommand(guid, path string, emitter screwdriver.Emitter, f *os.File, fReader io.Reader) (int, error) {
+	executionCommand := []string{
+		"export SD_STEP_ID=" + guid,
+		";. " + path,
+		";echo " + guid + " $?\n",
+	}
+	shargs := strings.Join(executionCommand, " ")
+
+	f.Write([]byte(shargs))
+
+	return copyLinesUntil(fReader, emitter, guid)
 }
 
 // Run executes a slice of CommandDefs
 func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriver.Build, api screwdriver.API, buildID int) error {
+	// Set up a single pseudo-terminal
+	c := exec.Command("sh")
+	c.Dir = path
+	c.Env = append(env, c.Env...)
+
+	f, err := pty.Start(c)
+	if err != nil {
+		return fmt.Errorf("Cannot start shell: %v", err)
+	}
+
+	// Run setup commands
+	setupCommands := []string{
+		"set -e",
+		"finish() { echo $SD_STEP_ID $?; }",
+		"trap finish EXIT;\n",
+	}
+	shargs := strings.Join(setupCommands, " && ")
+
+	f.Write([]byte(shargs))
+
 	cmds := build.Commands
 
 	for _, cmd := range cmds {
 		if err := api.UpdateStepStart(buildID, cmd.Name); err != nil {
-			return fmt.Errorf("updating step start %q: %v", cmd.Name, err)
+			return fmt.Errorf("Updating step start %q: %v", cmd.Name, err)
 		}
 
-		code, cmdErr := doRun(cmd, emitter, env, path)
+		// Create step script file
+		stepFilePath := "/tmp/step.sh"
+		if err := createShFile(stepFilePath, cmd); err != nil {
+			return fmt.Errorf("Writing to step script file: %v", err)
+		}
+
+		// Generate guid for the step
+		guid := uuid.NewV4().String()
+
+		// Set current running step in emitter
+		emitter.StartCmd(cmd)
+		fmt.Fprintf(emitter, "$ %s\n", cmd.Cmd)
+
+		fReader := bufio.NewReader(f)
+
+		// Execute command
+		code, cmdErr := doRunCommand(guid, stepFilePath, emitter, f, fReader)
 		if err := api.UpdateStepStop(buildID, cmd.Name, code); err != nil {
-			return fmt.Errorf("updating step stop %q: %v", cmd.Name, err)
+			return fmt.Errorf("Updating step stop %q: %v", cmd.Name, err)
 		}
 
 		if cmdErr != nil {
 			return cmdErr
 		}
 	}
+
+	f.Write([]byte{4}) // EOT
 
 	return nil
 }

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -4,8 +4,8 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"os"
-	"os/exec"
 	"reflect"
 	"strings"
 	"testing"
@@ -13,22 +13,7 @@ import (
 	"github.com/screwdriver-cd/launcher/screwdriver"
 )
 
-type execFunc func(command string, args ...string) *exec.Cmd
-
-func getFakeExecCommand(validator func(string, ...string)) execFunc {
-	return func(command string, args ...string) *exec.Cmd {
-		validator(command, args...)
-		return fakeExecCommand(command, args...)
-	}
-}
-
-func fakeExecCommand(command string, args ...string) *exec.Cmd {
-	cs := []string{"-test.run=TestHelperProcess", "--", command}
-	cs = append(cs, args...)
-	cmd := exec.Command(os.Args[0], cs...)
-	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
-	return cmd
-}
+var stepFilePath = "/tmp/step.sh"
 
 type MockAPI struct {
 	updateStepStart func(buildID int, stepName string) error
@@ -117,16 +102,10 @@ func TestHelperProcess(*testing.T) {
 		}
 	}
 
-	if len(args) == 4 {
-		switch args[3] {
-		case "make":
-			os.Exit(0)
-		case "npm install":
-			os.Exit(0)
-		case "failer":
-			os.Exit(7)
-		}
+	if strings.HasPrefix(args[2], "source") {
+		os.Exit(0)
 	}
+
 	os.Exit(255)
 }
 
@@ -134,151 +113,25 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestRunSingle(t *testing.T) {
-	var tests = []struct {
-		command string
-		err     error
-	}{
-		{"make", nil},
-		{"npm install", nil},
-		{"failer", ErrStatus{7}},
+func ReadCommand(file string) string {
+	// read the file that was written for the command
+	fileread, err := ioutil.ReadFile(file)
+	if err != nil {
+		panic(fmt.Errorf("Couldn't read file: %v", err))
 	}
-
-	for _, test := range tests {
-		testCmds := []screwdriver.CommandDef{
-			{
-				Name: "test",
-				Cmd:  test.command,
-			},
-		}
-
-		called := false
-		execCommand = getFakeExecCommand(func(cmd string, args ...string) {
-			called = true
-			if cmd != "sh" {
-				t.Errorf("Run() ran %v, want 'sh'", cmd)
-			}
-
-			if len(args) != 3 {
-				t.Errorf("Expected 3 arguments to exec, got %d: %v", len(args), args)
-			}
-
-			if args[0] != "-e" {
-				t.Errorf("Expected sh [-e -c] to be called, got sh %v", args)
-			}
-
-			if args[1] != "-c" {
-				t.Errorf("Expected sh [-e -c] to be called, got sh %v", args)
-			}
-
-			if args[2] != test.command {
-				t.Errorf("sh -e -c %v called, want sh -e -c %v", args[1], test.command)
-			}
-		})
-
-		testBuild := screwdriver.Build{
-			ID:          1234,
-			Commands:    testCmds,
-			Environment: map[string]string{},
-		}
-		testAPI := screwdriver.API(MockAPI{
-			updateStepStart: func(buildID int, stepName string) error {
-				if buildID != testBuild.ID {
-					t.Errorf("wrong build id got %v, want %v", buildID, testBuild.ID)
-				}
-				if stepName != "test" {
-					t.Errorf("wrong step name got %v, want %v", stepName, "test")
-				}
-				return nil
-			},
-		})
-		err := Run("", nil, &MockEmitter{}, testBuild, testAPI, testBuild.ID)
-
-		if !reflect.DeepEqual(err, test.err) {
-			t.Errorf("Unexpected error from Run(%#v): %v", testCmds, err)
-		}
-
-		if !called {
-			t.Errorf("Exec command was never called for %q.", test.command)
-		}
-	}
-}
-
-func TestRunMulti(t *testing.T) {
-	var tests = []struct {
-		command string
-		err     error
-	}{
-		{"make", nil},
-		{"npm install", nil},
-		{"failer", fmt.Errorf("exit 7")},
-		{"neverexecuted", nil},
-	}
-
-	testEnv := map[string]string{
-		"foo": "bar",
-		"baz": "bah",
-	}
-
-	testCmds := []screwdriver.CommandDef{}
-	for _, test := range tests {
-		testCmds = append(testCmds, screwdriver.CommandDef{
-			Name: "test",
-			Cmd:  test.command,
-		})
-	}
-
-	called := []string{}
-	execCommand = getFakeExecCommand(func(cmd string, args ...string) {
-		called = append(called, args[2:]...)
-	})
-
-	testBuild := screwdriver.Build{
-		ID:          12345,
-		Commands:    testCmds,
-		Environment: testEnv,
-	}
-	testAPI := screwdriver.API(MockAPI{
-		updateStepStart: func(buildID int, stepName string) error {
-			if buildID != testBuild.ID {
-				t.Errorf("wrong build id got %v, want %v", buildID, testBuild.ID)
-			}
-			if stepName != "test" {
-				t.Errorf("wrong step name got %v, want %v", stepName, "test")
-			}
-			return nil
-		},
-	})
-	err := Run("", nil, &MockEmitter{}, testBuild, testAPI, testBuild.ID)
-
-	if len(called) < len(tests)-1 {
-		t.Fatalf("%d commands called, want %d", len(called), len(tests)-1)
-	}
-
-	if !reflect.DeepEqual(err, ErrStatus{7}) {
-		t.Errorf("Unexpected error: %v", err)
-	}
-
-	for i, test := range tests {
-		if i >= len(tests)-1 {
-			break
-		}
-		if called[i] != test.command {
-			t.Errorf("Exec called with %v, want %v", called[i], test.command)
-		}
-	}
+	return strings.Split(string(fileread), "\n")[1] // expected input: "#!/bin/sh -e\n<COMMAND>"
 }
 
 func TestUnmocked(t *testing.T) {
-	execCommand = exec.Command
 	var tests = []struct {
 		command string
 		err     error
 	}{
 		{"ls", nil},
-		{"doesntexist", ErrStatus{127}},
-		{"ls && ls", nil},
-		{"ls && sh -c 'exit 5' && sh -c 'exit 2'", ErrStatus{5}},
+		{"sleep 1", nil},
+		{"ls && ls ", nil},
+		{"doesntexist", fmt.Errorf("Launching command exit with code: %v", 127)},
+		{"ls && sh -c 'exit 5' && sh -c 'exit 2'", fmt.Errorf("Launching command exit with code: %v", 5)},
 	}
 
 	for _, test := range tests {
@@ -305,15 +158,52 @@ func TestUnmocked(t *testing.T) {
 			},
 		})
 		err := Run("", nil, &MockEmitter{}, testBuild, testAPI, testBuild.ID)
+		command := ReadCommand(stepFilePath)
 
 		if !reflect.DeepEqual(err, test.err) {
-			t.Errorf("Unexpected error: %v, want %v", err, test.err)
+			t.Fatalf("Unexpected error: (%v) - should be (%v)", err, test.err)
 		}
+
+		if !reflect.DeepEqual(command, test.command) {
+			t.Errorf("Unexpected command from Run(%#v): %v", tests, command)
+		}
+	}
+}
+
+func TestUnmockedMulti(t *testing.T) {
+	commands := []screwdriver.CommandDef{
+		{Cmd: "ls", Name: "test ls"},
+		{Cmd: "export FOO=BAR", Name: "test export env"},
+		{Cmd: `if [ -z "$FOO" ] ; then exit 1; fi`, Name: "test if env set"},
+		{Cmd: "doesnotexit", Name: "test doesnotexit err"},
+		{Cmd: "sleep 1", Name: "test sleep 1"},
+	}
+	testBuild := screwdriver.Build{
+		ID:          12345,
+		Commands:    commands,
+		Environment: map[string]string{},
+	}
+	testAPI := screwdriver.API(MockAPI{
+		updateStepStart: func(buildID int, stepName string) error {
+			if buildID != testBuild.ID {
+				t.Errorf("wrong build id got %v, want %v", buildID, testBuild.ID)
+			}
+			if stepName == "test sleep 1" {
+				t.Errorf("step should never execute: %v", stepName)
+			}
+			return nil
+		},
+	})
+	err := Run("", nil, &MockEmitter{}, testBuild, testAPI, testBuild.ID)
+	expectedErr := fmt.Errorf("Launching command exit with code: %v", 127)
+	if !reflect.DeepEqual(err, expectedErr) {
+		t.Fatalf("Unexpected error: %v - should be %v", err, expectedErr)
 	}
 }
 
 func TestEnv(t *testing.T) {
 	baseEnv := []string{
+		"var0=xxx",
 		"var1=foo",
 		"var2=bar",
 		"VAR3=baz",
@@ -337,7 +227,6 @@ func TestEnv(t *testing.T) {
 		Commands: cmds,
 	}
 
-	execCommand = exec.Command
 	output := MockEmitter{}
 	testAPI := screwdriver.API(MockAPI{
 		updateStepStart: func(buildID int, stepName string) error {
@@ -367,7 +256,10 @@ func TestEnv(t *testing.T) {
 		line := scanner.Text()
 		split := strings.Split(line, "=")
 		if len(split) != 2 {
-			foundCmd = line
+			// Capture that "$ env" output line
+			if strings.HasPrefix(line, "$") {
+				foundCmd = line
+			}
 			continue
 		}
 		found[split[0]] = split[1]
@@ -385,7 +277,6 @@ func TestEnv(t *testing.T) {
 }
 
 func TestEmitter(t *testing.T) {
-	execCommand = exec.Command
 	var tests = []struct {
 		command string
 		name    string
@@ -437,12 +328,5 @@ func TestEmitter(t *testing.T) {
 		if found[i] != test.name {
 			t.Errorf("Unexpected order. Want %v. Got %v", found[i], test.name)
 		}
-	}
-}
-
-func TestErrStatus(t *testing.T) {
-	errText := ErrStatus{5}.Error()
-	if errText != "exit 5" {
-		t.Errorf("ErrStatus{5}.Error() == %q, want %q", errText, "exit 5")
 	}
 }

--- a/launch.go
+++ b/launch.go
@@ -203,6 +203,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath string) error
 	}
 
 	defaultEnv := map[string]string{
+		"PS1": "",
 		"SCREWDRIVER": "true",
 		"CI":          "true",
 		"CONTINUOUS_INTEGRATION": "true",


### PR DESCRIPTION
Writing each command in the YAML to a temporary file in launcher. Instead of running the commands from YAML, source the temporary file to run the command.

Related to: screwdriver-cd/screwdriver#393