### PR TITLE
feat: expose pipeline id in build as environment variable

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -208,6 +208,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath string) error
 		"CI":          "true",
 		"CONTINUOUS_INTEGRATION": "true",
 		"SD_JOB_NAME":            oldJobName,
+		"SD_PIPELINE_ID":         strconv.Itoa(j.PipelineID),
 		"SD_PULL_REQUEST":        pr,
 		"SD_SOURCE_DIR":          w.Src,
 		"SD_ARTIFACTS_DIR":       w.Artifacts,

--- a/launch_test.go
+++ b/launch_test.go
@@ -632,6 +632,7 @@ func TestSetEnv(t *testing.T) {
 		"CI":          "true",
 		"CONTINUOUS_INTEGRATION": "true",
 		"SD_JOB_NAME":            "PR-1",
+		"SD_PIPELINE_ID":         "3456",
 		"SD_PULL_REQUEST":        "1",
 		"SD_SOURCE_DIR":          "/sd/workspace/src/github.com/screwdriver-cd/launcher",
 		"SD_ARTIFACTS_DIR":       "/sd/workspace/artifacts",


### PR DESCRIPTION
In addition to the various Screwdriver-related environment variables, this PR aims to expose the Pipeline ID in an environment variable as well.