### PR TITLE
Give all users RW permission to /opt/sd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN set -x \
    && mv tini-static tini \
    && chmod +x tini \
    # Create FIFO
-   && mkfifo emitter \
+   && mkfifo -m 666 emitter \
    # Cleanup packages
    && apk del --purge .build-dependencies
 


### PR DESCRIPTION
/opt/sd is currently owned by root and when we try to write to it as any
other user (for example, to create the emitter directory), we run into
permission denied errors. We want Screwdriver to be able to be run as a
non-root user, so we need to give all users permissions to this
directory.