### PR TITLE
fix: Add SD_BUILD_ID to default environment

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -212,6 +212,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath string) error
 		"SD_PULL_REQUEST":        pr,
 		"SD_SOURCE_DIR":          w.Src,
 		"SD_ARTIFACTS_DIR":       w.Artifacts,
+		"SD_BUILD_ID":            strconv.Itoa(buildID),
 	}
 
 	secrets, err := api.SecretsForBuild(b)

--- a/launch_test.go
+++ b/launch_test.go
@@ -636,6 +636,7 @@ func TestSetEnv(t *testing.T) {
 		"SD_PULL_REQUEST":        "1",
 		"SD_SOURCE_DIR":          "/sd/workspace/src/github.com/screwdriver-cd/launcher",
 		"SD_ARTIFACTS_DIR":       "/sd/workspace/artifacts",
+		"SD_BUILD_ID":            "1234",
 	}
 
 	api := mockAPI(t, TestBuildID, TestJobID, TestPipelineID, "RUNNING")


### PR DESCRIPTION
Adding the Build ID to the default environment that is exported from launcher. This is needed to be able to upload artifacts to the right Build directory (by ID) in S3.