### PR TITLE
feat: using meta-cli in launcher

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,11 @@ RUN set -x \
       | egrep -o '/screwdriver-cd/log-service/releases/download/v[0-9.]*/logservice' \
       | wget --base=http://github.com/ -i - -O logservice \
    && chmod +x logservice \
+   # Download Meta CLI
+   && wget -q -O - https://github.com/screwdriver-cd/meta-cli/releases/latest \
+      | egrep -o '/screwdriver-cd/meta-cli/releases/download/v[0-9.]*/meta-cli' \
+      | wget --base=http://github.com/ -i - -O meta-cli\
+   && chmod +x meta-cli\
    # Download Tini Static
    && wget -q -O - https://github.com/krallin/tini/releases/latest \
       | egrep -o '/krallin/tini/releases/download/v[0-9.]*/tini-static' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,9 @@ RUN set -x \
    && chmod +x logservice \
    # Download Meta CLI
    && wget -q -O - https://github.com/screwdriver-cd/meta-cli/releases/latest \
-      | egrep -o '/screwdriver-cd/meta-cli/releases/download/v[0-9.]*/meta-cli' \
-      | wget --base=http://github.com/ -i - -O meta-cli\
-   && chmod +x meta-cli\
+      | egrep -o '/screwdriver-cd/meta-cli/releases/download/v[0-9.]*/meta' \
+      | wget --base=http://github.com/ -i - -O meta\
+   && chmod +x meta\
    # Download Tini Static
    && wget -q -O - https://github.com/krallin/tini/releases/latest \
       | egrep -o '/krallin/tini/releases/download/v[0-9.]*/tini-static' \

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -32,7 +32,7 @@ func (f MockAPI) PipelineFromID(pipelineID int) (screwdriver.Pipeline, error) {
 	return screwdriver.Pipeline{}, nil
 }
 
-func (f MockAPI) UpdateBuildStatus(status screwdriver.BuildStatus, buildID int) error {
+func (f MockAPI) UpdateBuildStatus(status screwdriver.BuildStatus, meta map[string]interface{}, buildID int) error {
 	return nil
 }
 

--- a/launch.go
+++ b/launch.go
@@ -195,22 +195,26 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath string, metaS
 		return fmt.Errorf("fetching Pipeline ID %d: %v", j.PipelineID, err)
 	}
 
-	log.Printf("Fetching Parent Build %d for Meta", b.ParentBuildID)
-	pb, err := api.BuildFromID(b.ParentBuildID)
-	if err != nil {
-		return fmt.Errorf("fetching parent build ID %d: %v", pb.ParentBuildID, err)
-	}
+	if b.ParentBuildID == 0 {
+		log.Printf("This build has no Parent Build, so fetching Meta is skiped")
+	} else {
+		log.Printf("Fetching Parent Build %d for Meta", b.ParentBuildID)
+		pb, err := api.BuildFromID(b.ParentBuildID)
+		if err != nil {
+			return fmt.Errorf("fetching parent build ID %d: %v", pb.ParentBuildID, err)
+		}
 
-	log.Printf("Creating Meta Space in %v", metaSpace)
-	err = createMetaSpace(metaSpace)
-	if err != nil {
-		return err
-	}
+		log.Printf("Creating Meta Space in %v", metaSpace)
+		err = createMetaSpace(metaSpace)
+		if err != nil {
+			return err
+		}
 
-	log.Printf("Fetching Parent Build Meta JSON %v", pb.Meta)
-	err = writeFile(metaSpace+"/meta.json", []byte(pb.Meta), 0666)
-	if err != nil {
-		return fmt.Errorf("fetching Parent Build Meta JSON %d: %v", pb.ParentBuildID, err)
+		log.Printf("Fetching Parent Build Meta JSON %v", pb.Meta)
+		err = writeFile(metaSpace+"/meta.json", []byte(pb.Meta), 0666)
+		if err != nil {
+			return fmt.Errorf("fetching Parent Build Meta JSON %d: %v", pb.ParentBuildID, err)
+		}
 	}
 
 	scm, err := parseScmURI(p.ScmURI, p.ScmRepo.Name)

--- a/launch.go
+++ b/launch.go
@@ -44,20 +44,19 @@ func exit(status screwdriver.BuildStatus, buildID int, api screwdriver.API, meta
 		metaJson, err := readFile(metaSpace + "/meta.json")
 		if err != nil {
 			log.Printf("Failed to load %q/meta.json: %v", metaSpace, err)
-			metaJson = nil
+			metaInterface = make(map[string]interface{})
 		} else {
 			err = unmarshal(metaJson, &metaInterface)
 			if err != nil {
 				log.Printf("Failed to Load %q/meta.json: %v", metaSpace, err)
+				metaInterface = make(map[string]interface{})
 			}
-			metaJson = nil
 		}
 		log.Printf("Setting build status to %s", status)
 		if err := api.UpdateBuildStatus(status, metaInterface, buildID); err != nil {
 			log.Printf("Failed updating the build status: %v", err)
 		}
 	}
-
 	cleanExit()
 }
 
@@ -173,7 +172,8 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath string, metaS
 	}
 
 	log.Print("Setting Build Status to RUNNING")
-	if err = api.UpdateBuildStatus(screwdriver.Running, nil, buildID); err != nil {
+	emptyMeta := make(map[string]interface{}) // {"meta":null} are not accepted. This will be {"meta":{}}
+	if err = api.UpdateBuildStatus(screwdriver.Running, emptyMeta, buildID); err != nil {
 		return fmt.Errorf("updating build status to RUNNING: %v", err)
 	}
 

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -120,7 +120,7 @@ type Build struct {
 	SHA           string            `json:"sha"`
 	Commands      []CommandDef      `json:"steps"`
 	Environment   map[string]string `json:"environment"`
-	ParentBuildID string            `json:"parentBuildId"`
+	ParentBuildID int               `json:"parentBuildId"`
 	Meta          string            `json:"meta"`
 }
 

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -291,17 +291,22 @@ func TestPipelineFromID(t *testing.T) {
 }
 
 func TestUpdateBuildStatus(t *testing.T) {
+	var meta map[string]interface{}
+	mockJson := []byte("{\"hoge\":\"fuga\"}")
+	_ = json.Unmarshal(mockJson, &meta)
+
 	tests := []struct {
 		status     BuildStatus
+		meta       map[string]interface{}
 		statusCode int
 		err        error
 	}{
-		{Success, 200, nil},
-		{Failure, 200, nil},
-		{Aborted, 200, nil},
-		{Running, 200, nil},
-		{"NOTASTATUS", 200, errors.New("invalid build status: NOTASTATUS")},
-		{Success, 500, errors.New("posting to Build Status: after 5 attempts, " +
+		{Success, meta, 200, nil},
+		{Failure, meta, 200, nil},
+		{Aborted, meta, 200, nil},
+		{Running, meta, 200, nil},
+		{"NOTASTATUS", meta, 200, errors.New("invalid build status: NOTASTATUS")},
+		{Success, meta, 500, errors.New("posting to Build Status: after 5 attempts, " +
 			"last error: retries exhausted: 500 returned from http://fakeurl/v4/builds/15")},
 	}
 
@@ -309,7 +314,7 @@ func TestUpdateBuildStatus(t *testing.T) {
 		http := makeFakeHTTPClient(t, test.statusCode, "{}")
 		testAPI := api{"http://fakeurl", "faketoken", http}
 
-		err := testAPI.UpdateBuildStatus(test.status, 15)
+		err := testAPI.UpdateBuildStatus(test.status, test.meta, 15)
 
 		if !reflect.DeepEqual(err, test.err) {
 			t.Errorf("Unexpected error from UpdateBuildStatus: %v, want %v", err, test.err)


### PR DESCRIPTION
To use meta-cli, `meta` of previous build is load from API and stored to temporary file before a build starting.
Also current `meta` is added to API payload with `UpdateBuildStatus`.

Related: https://github.com/screwdriver-cd/screwdriver/issues/293