### PR TITLE
fix: force a newline after sourcing step file

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -75,6 +75,7 @@ func doRunCommand(guid, path string, emitter screwdriver.Emitter, f *os.File, fR
 	executionCommand := []string{
 		"export SD_STEP_ID=" + guid,
 		";. " + path,
+		";echo",
 		";echo " + guid + " $?\n",
 	}
 	shargs := strings.Join(executionCommand, " ")


### PR DESCRIPTION
Currently, if there is no newline in the output of `sourcing a step file`, the output will not be logged.
Because the output will be printed in the same line with  `guid  exitCode` which is filtered out of the log intentionally.

https://github.com/screwdriver-cd/launcher/blob/master/executor/executor.go#L47

Related to discussion in the end of the issue: https://github.com/screwdriver-cd/screwdriver/issues/293

Previously:
![image](https://cloud.githubusercontent.com/assets/20427140/23630443/f6356726-026f-11e7-8b94-0f596b4475d8.png)

Now:
<img width="1168" alt="screen shot 2017-03-06 at 12 44 56 pm" src="https://cloud.githubusercontent.com/assets/20427140/23630399/d063a6c0-026f-11e7-8d01-827788c3ba42.png">
