### PR TITLE
fix(293): type of previous meta to map[string]interface{}

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -29,6 +29,7 @@ var executorRun = executor.Run
 var writeFile = ioutil.WriteFile
 var readFile = ioutil.ReadFile
 var newEmitter = screwdriver.NewEmitter
+var marshal = json.Marshal
 var unmarshal = json.Unmarshal
 
 var cleanExit = func() {
@@ -211,9 +212,13 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath string, metaS
 		}
 
 		log.Printf("Fetching Parent Build Meta JSON %v", pb.Meta)
-		err = writeFile(metaSpace+"/meta.json", []byte(pb.Meta), 0666)
+		pbMetaByte, err := marshal(pb.Meta)
 		if err != nil {
-			return fmt.Errorf("fetching Parent Build Meta JSON %d: %v", pb.ParentBuildID, err)
+			return fmt.Errorf("parsing Parent Build(%d) Meta JSON: %v", pb.ParentBuildID, err)
+		}
+		err = writeFile(metaSpace+"/meta.json", (pbMetaByte), 0666)
+		if err != nil {
+			return fmt.Errorf("writing Parent Build(%d) Meta JSON: %v", pb.ParentBuildID, err)
 		}
 	}
 

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -115,13 +115,13 @@ type CommandDef struct {
 
 // Build is a Screwdriver Build
 type Build struct {
-	ID            int               `json:"id"`
-	JobID         int               `json:"jobId"`
-	SHA           string            `json:"sha"`
-	Commands      []CommandDef      `json:"steps"`
-	Environment   map[string]string `json:"environment"`
-	ParentBuildID int               `json:"parentBuildId"`
-	Meta          string            `json:"meta"`
+	ID            int                    `json:"id"`
+	JobID         int                    `json:"jobId"`
+	SHA           string                 `json:"sha"`
+	Commands      []CommandDef           `json:"steps"`
+	Environment   map[string]string      `json:"environment"`
+	ParentBuildID int                    `json:"parentBuildId"`
+	Meta          map[string]interface{} `json:"meta"`
 }
 
 // Secret is a Screwdriver build secret.


### PR DESCRIPTION
`Build.Meta` is string and it caused JSON parse error when fetch previous Meta.

This PR provides:
- The type of `Build.Meta` to map[string]interface{} from string.
- Update tests for above fix.

Related: 
- https://github.com/screwdriver-cd/screwdriver/issues/293
- https://github.com/screwdriver-cd/screwdriver/pull/494