### PR TITLE
fix(293): add symlink of meta to /usr/bin

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -25,6 +25,7 @@ var VERSION string
 var mkdirAll = os.MkdirAll
 var stat = os.Stat
 var open = os.Open
+var symlink = os.Symlink
 var executorRun = executor.Run
 var writeFile = ioutil.WriteFile
 var readFile = ioutil.ReadFile
@@ -220,6 +221,12 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath string, metaS
 		if err != nil {
 			return fmt.Errorf("writing Parent Build(%d) Meta JSON: %v", pb.ParentBuildID, err)
 		}
+	}
+
+	log.Printf("Create symlink of meta binary to /usr/bin")
+	err = symlink("/opt/sd/meta", "/usr/bin/meta")
+	if err != nil {
+		return fmt.Errorf("create symlink of meta: %v", err)
 	}
 
 	scm, err := parseScmURI(p.ScmURI, p.ScmRepo.Name)

--- a/launch_test.go
+++ b/launch_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path"
 	"reflect"
 	"strconv"
@@ -185,6 +186,7 @@ func TestMain(m *testing.M) {
 	open = func(f string) (*os.File, error) {
 		return os.Open("data/screwdriver.yaml")
 	}
+	symlink = func(oldname, newname string) (err error) { return nil }
 	executorRun = func(path string, env []string, emitter screwdriver.Emitter, build screwdriver.Build, api screwdriver.API, buildID int) error {
 		return nil
 	}
@@ -841,5 +843,32 @@ func TestFetchParentBuildMetaWriteError(t *testing.T) {
 
 	if err.Error() != want {
 		t.Errorf("Error is wrong, got '%v', want '%v'", err, want)
+	}
+}
+
+func TestCreateMetaSymlink(t *testing.T) {
+	oldSymlink := symlink
+	defer func() {
+		os.Remove("/opt/sd/meta")
+		os.Remove("/usr/bin/meta")
+		symlink = oldSymlink
+	}()
+	symlink = func(oldname, newname string) error {
+		exec.Command("touch", "/opt/sd/meta").Run()
+		return os.Symlink(oldname, newname)
+	}
+	mockMeta := make(map[string]interface{})
+
+	api := mockAPI(t, TestBuildID, TestJobID, 0, "RUNNING")
+	api.buildFromID = func(buildID int) (screwdriver.Build, error) {
+		return screwdriver.Build(FakeBuild{ID: TestBuildID, JobID: TestJobID, ParentBuildID: TestParentBuildID, Meta: mockMeta}), nil
+	}
+
+	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace)
+
+	fi, err := os.Lstat("/usr/bin/meta")
+	if fi.Mode()&os.ModeSymlink == os.ModeSymlink && err == nil {
+	} else {
+		t.Errorf("expected created symlink")
 	}
 }

--- a/launch_test.go
+++ b/launch_test.go
@@ -790,14 +790,16 @@ func TestFetchParentBuildMeta(t *testing.T) {
 		return screwdriver.Build(FakeBuild{ID: TestBuildID, JobID: TestJobID, ParentBuildID: TestParentBuildID, Meta: mockMeta}), nil
 	}
 	writeFile = func(path string, data []byte, perm os.FileMode) (err error) {
-		previousMeta = data
+		if path == "./data/meta/meta.json" {
+			previousMeta = data
+		}
 		return nil
 	}
 
 	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace)
 	want := []byte("{\"hoge\":\"fuga\"}")
 
-	if err != nil || string(previousMeta) == string(want) {
+	if err != nil || string(previousMeta) != string(want) {
 		t.Errorf("expected previousMeta is %v, but: %v", want, previousMeta)
 	}
 }


### PR DESCRIPTION
This PR created symlink of `meta` to /usr/bin.
`meta` is executable in build (not only `/opt/sd/meta`).
<img width="590" alt="2017-03-21 16 27 10" src="https://cloud.githubusercontent.com/assets/3445553/24136686/453b73e4-0e53-11e7-8724-855273348a14.png">

I also tried to add `/opt/sd/` to PATH via `exec.Command("export", "PATH=$PATH:/opt/sd")`, but couldn't. So I used symlink.
<img width="691" alt="2017-03-21 16 32 36" src="https://cloud.githubusercontent.com/assets/3445553/24136822/0a030d40-0e54-11e7-83d1-9e63388de5a4.png">

<br>

This PR also fixed `TestFetchParentBuildMeta` condition of success.

Related: https://github.com/screwdriver-cd/screwdriver/issues/293