### PR TITLE
fix(470): Add API URL environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ artifacts/
 .DS_STORE
 .*.swp
 launcher
+data/emitter

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -40,6 +40,10 @@ func (f MockAPI) SecretsForBuild(build screwdriver.Build) (screwdriver.Secrets, 
 	return nil, nil
 }
 
+func (f MockAPI) GetAPIURL() (string, error) {
+	return "http://foo.bar", nil
+}
+
 func (f MockAPI) UpdateStepStart(buildID int, stepName string) error {
 	if f.updateStepStart != nil {
 		return f.updateStepStart(buildID, stepName)

--- a/launch.go
+++ b/launch.go
@@ -260,6 +260,8 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath string, metaS
 		return fmt.Errorf("creating environment.json artifact: %v", err)
 	}
 
+	apiURL, _ := api.GetAPIURL()
+
 	defaultEnv := map[string]string{
 		"PS1":         "",
 		"SCREWDRIVER": "true",
@@ -271,6 +273,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath string, metaS
 		"SD_SOURCE_DIR":          w.Src,
 		"SD_ARTIFACTS_DIR":       w.Artifacts,
 		"SD_BUILD_ID":            strconv.Itoa(buildID),
+		"SD_API_URL":             apiURL,
 	}
 
 	secrets, err := api.SecretsForBuild(b)

--- a/launch_test.go
+++ b/launch_test.go
@@ -72,6 +72,9 @@ func mockAPI(t *testing.T, testBuildID, testJobID, testPipelineID int, testStatu
 			}
 			return nil
 		},
+		getAPIURL: func() (string, error) {
+			return "http://foo.bar", nil
+		},
 	}
 }
 
@@ -83,6 +86,11 @@ type MockAPI struct {
 	updateStepStart   func(buildID int, stepName string) error
 	updateStepStop    func(buildID int, stepName string, exitCode int) error
 	secretsForBuild   func(build screwdriver.Build) (screwdriver.Secrets, error)
+	getAPIURL         func() (string, error)
+}
+
+func (f MockAPI) GetAPIURL() (string, error) {
+	return f.getAPIURL()
 }
 
 func (f MockAPI) SecretsForBuild(build screwdriver.Build) (screwdriver.Secrets, error) {

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -42,6 +42,7 @@ type API interface {
 	UpdateStepStart(buildID int, stepName string) error
 	UpdateStepStop(buildID int, stepName string, exitCode int) error
 	SecretsForBuild(build Build) (Secrets, error)
+	GetAPIURL() (string, error)
 }
 
 // SDError is an error response from the Screwdriver API
@@ -268,6 +269,11 @@ func (a api) post(url *url.URL, bodyType string, payload io.Reader) ([]byte, err
 
 func (a api) put(url *url.URL, bodyType string, payload io.Reader) ([]byte, error) {
 	return a.write(url, "PUT", bodyType, payload)
+}
+
+func (a api) GetAPIURL() (string, error) {
+	url, err := a.makeURL("")
+	return url.String(), err
 }
 
 // BuildFromID fetches and returns a Build object from its ID

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -358,6 +358,23 @@ func TestUpdateStepStop(t *testing.T) {
 	}
 }
 
+func TestGetAPIURL(t *testing.T) {
+	http := makeValidatedFakeHTTPClient(t, 200, "{}", func(r *http.Request) {
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(r.Body)
+		want := regexp.MustCompile(`{"endTime":"[\d-]+T[\d:.Z-]+","code":10}`)
+		if !want.MatchString(buf.String()) {
+			t.Errorf("buf.String() = %q", buf.String())
+		}
+	})
+	testAPI := api{"http://fakeurl", "faketoken", http}
+	url, _ := testAPI.GetAPIURL()
+
+	if !reflect.DeepEqual(url, "http://fakeurl/v4/") {
+		t.Errorf(`api.GetAPIURL() expected to return: "%v", instead returned "%v"`, "http://fakeurl/v4/", url)
+	}
+}
+
 func TestSecretsForBuild(t *testing.T) {
 	testBuild := Build{
 		ID:    1555,


### PR DESCRIPTION
This environment variable (`SD_API_URL`) will be read when publishing or validating a template in https://github.com/screwdriver-cd/template-main/pull/2