### PR TITLE
fix: add /opt/sd to PATH instead of creating symlink

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -100,6 +100,7 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 	// Run setup commands
 	setupCommands := []string{
 		"set -e",
+		"PATH=$PATH:/opt/sd",
 		"finish() { echo $SD_STEP_ID $?; }",
 		"trap finish EXIT;\n",
 	}

--- a/launch.go
+++ b/launch.go
@@ -25,7 +25,6 @@ var VERSION string
 var mkdirAll = os.MkdirAll
 var stat = os.Stat
 var open = os.Open
-var symlink = os.Symlink
 var executorRun = executor.Run
 var writeFile = ioutil.WriteFile
 var readFile = ioutil.ReadFile
@@ -221,12 +220,6 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath string, metaS
 		if err != nil {
 			return fmt.Errorf("writing Parent Build(%d) Meta JSON: %v", pb.ParentBuildID, err)
 		}
-	}
-
-	log.Printf("Create symlink of meta binary to /usr/bin")
-	err = symlink("/opt/sd/meta", "/usr/bin/meta")
-	if err != nil {
-		return fmt.Errorf("create symlink of meta: %v", err)
 	}
 
 	scm, err := parseScmURI(p.ScmURI, p.ScmRepo.Name)


### PR DESCRIPTION
Add `/opt/sd` to PATH instead of creating symlink.
Because creating symlink requires root but it is not always the case.

Tested locally and works fine:
<img width="1017" alt="screen shot 2017-04-18 at 4 16 49 pm" src="https://cloud.githubusercontent.com/assets/20427140/25156896/7cd40c48-2452-11e7-8911-29c83cf8f392.png">
