### PR TITLE
feat(473): Always run steps with the alwaysRun flag true

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -109,39 +109,52 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 	f.Write([]byte(shargs))
 
 	cmds := build.Commands
+	var exitErr error
 
 	for _, cmd := range cmds {
-		if err := api.UpdateStepStart(buildID, cmd.Name); err != nil {
-			return fmt.Errorf("Updating step start %q: %v", cmd.Name, err)
-		}
+		if exitErr == nil || cmd.AlwaysRun {
+			if err := api.UpdateStepStart(buildID, cmd.Name); err != nil {
+				if exitErr == nil {
+					exitErr = fmt.Errorf("Updating step start %q: %v", cmd.Name, err)
+				}
+				continue
+			}
 
-		// Create step script file
-		stepFilePath := "/tmp/step.sh"
-		if err := createShFile(stepFilePath, cmd); err != nil {
-			return fmt.Errorf("Writing to step script file: %v", err)
-		}
+			// Create step script file
+			stepFilePath := "/tmp/step.sh"
+			if err := createShFile(stepFilePath, cmd); err != nil {
+				exitErr = fmt.Errorf("Writing to step script file: %v", err)
+				continue
+			}
 
-		// Generate guid for the step
-		guid := uuid.NewV4().String()
+			// Generate guid for the step
+			guid := uuid.NewV4().String()
 
-		// Set current running step in emitter
-		emitter.StartCmd(cmd)
-		fmt.Fprintf(emitter, "$ %s\n", cmd.Cmd)
+			// Set current running step in emitter
+			emitter.StartCmd(cmd)
+			fmt.Fprintf(emitter, "$ %s\n", cmd.Cmd)
 
-		fReader := bufio.NewReader(f)
+			fReader := bufio.NewReader(f)
 
-		// Execute command
-		code, cmdErr := doRunCommand(guid, stepFilePath, emitter, f, fReader)
-		if err := api.UpdateStepStop(buildID, cmd.Name, code); err != nil {
-			return fmt.Errorf("Updating step stop %q: %v", cmd.Name, err)
-		}
+			// Execute command
+			code, cmdErr := doRunCommand(guid, stepFilePath, emitter, f, fReader)
+			if err := api.UpdateStepStop(buildID, cmd.Name, code); err != nil {
+				if exitErr == nil {
+					exitErr = fmt.Errorf("Updating step stop %q: %v", cmd.Name, err)
+				}
+				continue
+			}
 
-		if cmdErr != nil {
-			return cmdErr
+			if cmdErr != nil {
+				if exitErr == nil {
+					exitErr = cmdErr
+				}
+				continue
+			}
 		}
 	}
 
 	f.Write([]byte{4}) // EOT
 
-	return nil
+	return exitErr
 }

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -205,6 +205,33 @@ func TestUnmockedMulti(t *testing.T) {
 	}
 }
 
+func TestAlwaysRun(t *testing.T) {
+	commands := []screwdriver.CommandDef{
+		{Cmd: "doesnotexit", Name: "test doesnotexit err"},
+		{Cmd: "sleep 1", Name: "test sleep 1", AlwaysRun: false},
+		{Cmd: "echo hello", Name: "test alwaysRun", AlwaysRun: true},
+	}
+	testBuild := screwdriver.Build{
+		ID:          12345,
+		Commands:    commands,
+		Environment: map[string]string{},
+	}
+	testAPI := screwdriver.API(MockAPI{
+		updateStepStart: func(buildID int, stepName string) error {
+			if stepName == "test sleep 1" {
+				t.Errorf("step should never execute: %v", stepName)
+			}
+			if stepName == "test alwaysRun" {
+				fmt.Printf("Testing alwaysRun: step \"%v\" successfully ran despite an earlier step failing.\n", stepName)
+				t.SkipNow()
+			}
+			return nil
+		},
+	})
+	Run("", nil, &MockEmitter{}, testBuild, testAPI, testBuild.ID)
+	t.Fatalf("Always Run step did not run")
+}
+
 func TestEnv(t *testing.T) {
 	baseEnv := []string{
 		"var0=xxx",
@@ -221,8 +248,9 @@ func TestEnv(t *testing.T) {
 
 	cmds := []screwdriver.CommandDef{
 		{
-			Cmd:  "env",
-			Name: "test",
+			Cmd:       "env",
+			Name:      "test",
+			AlwaysRun: false,
 		},
 	}
 

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -110,8 +110,9 @@ type Job struct {
 
 // CommandDef is the definition of a single executable command.
 type CommandDef struct {
-	Name string `json:"name"`
-	Cmd  string `json:"command"`
+	Name      string `json:"name"`
+	Cmd       string `json:"command"`
+	AlwaysRun bool   `json:"alwaysRun"`
 }
 
 // Build is a Screwdriver Build

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -94,8 +94,9 @@ func TestBuildFromID(t *testing.T) {
 	testCmds := []CommandDef{}
 	for _, test := range commands {
 		testCmds = append(testCmds, CommandDef{
-			Name: "test",
-			Cmd:  test.command,
+			Name:      "test",
+			Cmd:       test.command,
+			AlwaysRun: false,
 		})
 	}
 	tests := []struct {


### PR DESCRIPTION
Have the executor run always run steps that have the `alwaysRun` flag set as `true`.

Pull requests to define the `alwaysRun` flag in steps (all should be merged together): 

https://github.com/screwdriver-cd/models/pull/155
https://github.com/screwdriver-cd/build-bookend/pull/8
https://github.com/screwdriver-cd/config-parser/pull/34

Related: https://github.com/screwdriver-cd/screwdriver/issues/473