### PR TITLE
fix: Set word boundary to regular expression for latest binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,26 +13,26 @@ RUN set -x \
    && apk add --virtual .build-dependencies gpgme \
    # Download Launcher
    && wget -q -O - https://github.com/screwdriver-cd/launcher/releases/latest \
-      | egrep -o '/screwdriver-cd/launcher/releases/download/v[0-9.]*/launch' \
+      | egrep -o '/screwdriver-cd/launcher/releases/download/v[0-9.]*/launch\b' \
       | wget --base=http://github.com/ -i - -O launch \
    && chmod +x launch \
    # Download Log Service
    && wget -q -O - https://github.com/screwdriver-cd/log-service/releases/latest \
-      | egrep -o '/screwdriver-cd/log-service/releases/download/v[0-9.]*/logservice' \
+      | egrep -o '/screwdriver-cd/log-service/releases/download/v[0-9.]*/logservice\b' \
       | wget --base=http://github.com/ -i - -O logservice \
    && chmod +x logservice \
    # Download Meta CLI
    && wget -q -O - https://github.com/screwdriver-cd/meta-cli/releases/latest \
-      | egrep -o '/screwdriver-cd/meta-cli/releases/download/v[0-9.]*/meta' \
+      | egrep -o '/screwdriver-cd/meta-cli/releases/download/v[0-9.]*/meta\b' \
       | wget --base=http://github.com/ -i - -O meta\
    && chmod +x meta\
    # Download Tini Static
    && wget -q -O - https://github.com/krallin/tini/releases/latest \
-      | egrep -o '/krallin/tini/releases/download/v[0-9.]*/tini-static' \
+      | egrep -o '/krallin/tini/releases/download/v[0-9.]*/tini-static\b' \
       | head -1 \
       | wget --base=http://github.com/ -i - -O tini-static \
    && wget -q -O - https://github.com/krallin/tini/releases/latest \
-      | egrep -o '/krallin/tini/releases/download/v[0-9.]*/tini-static.asc' \
+      | egrep -o '/krallin/tini/releases/download/v[0-9.]*/tini-static.asc\b' \
       | wget --base=http://github.com/ -i - -O tini-static.asc \
    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
    && gpg --verify tini-static.asc \
@@ -48,7 +48,7 @@ RUN set -x \
    && rm -rf hab-* \
    # Download sd-step
    && wget -q -O - https://github.com/screwdriver-cd/sd-step/releases/latest \
-      | egrep -o '/screwdriver-cd/sd-step/releases/download/v[0-9.]*/sd-step' \
+      | egrep -o '/screwdriver-cd/sd-step/releases/download/v[0-9.]*/sd-step\b' \
       | wget --base=http://github.com/ -i - -O sd-step\
    && chmod +x sd-step \
    # Create FIFO


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Docker build would have little problem when multiple binaries are uploaded to GitHub Release.
https://github.com/screwdriver-cd/log-service/pull/12


## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

When multiple binaries are uploaded to GitHub Release such as follows,
![image](https://user-images.githubusercontent.com/282077/29169899-4a0c177e-7e11-11e7-8e6c-5a479f39a2d9.png)

current egrep matches more than once and output incorrect portions.
```
% wget -q -O - https://github.com/taisukeh/log-service/releases/latest | egrep -o '/taisukeh/log-service/releases/download/v[0-9.]*/logservice'
/taisukeh/log-service/releases/download/v1.1/logservice
/taisukeh/log-service/releases/download/v1.1/logservice
```

So I fixed the regex to match exactly the filename.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/log-service/pull/12