### PR TITLE
feat: Build darwin/amd64 binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,12 @@ artifacts/
 .*.swp
 launcher
 data/emitter
+
+# Generated while deploying
+
+/ci/
+/VERSION
+
+# goreleaser
+
+/dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,11 @@
+builds:
+  - binary: launch
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+
+archive:
+  format: binary
+  name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,17 +13,17 @@ RUN set -x \
    && apk add --virtual .build-dependencies gpgme \
    # Download Launcher
    && wget -q -O - https://github.com/screwdriver-cd/launcher/releases/latest \
-      | egrep -o '/screwdriver-cd/launcher/releases/download/v[0-9.]*/launch' \
+      | egrep -o '/screwdriver-cd/launcher/releases/download/v[0-9.]*/launch_linux_amd64' \
       | wget --base=http://github.com/ -i - -O launch \
    && chmod +x launch \
    # Download Log Service
    && wget -q -O - https://github.com/screwdriver-cd/log-service/releases/latest \
-      | egrep -o '/screwdriver-cd/log-service/releases/download/v[0-9.]*/logservice' \
+      | egrep -o '/screwdriver-cd/log-service/releases/download/v[0-9.]*/logservice_linux_amd64' \
       | wget --base=http://github.com/ -i - -O logservice \
    && chmod +x logservice \
    # Download Meta CLI
    && wget -q -O - https://github.com/screwdriver-cd/meta-cli/releases/latest \
-      | egrep -o '/screwdriver-cd/meta-cli/releases/download/v[0-9.]*/meta' \
+      | egrep -o '/screwdriver-cd/meta-cli/releases/download/v[0-9.]*/meta_linux_amd64' \
       | wget --base=http://github.com/ -i - -O meta\
    && chmod +x meta\
    # Download Tini Static
@@ -48,7 +48,7 @@ RUN set -x \
    && rm -rf hab-* \
    # Download sd-step
    && wget -q -O - https://github.com/screwdriver-cd/sd-step/releases/latest \
-      | egrep -o '/screwdriver-cd/sd-step/releases/download/v[0-9.]*/sd-step' \
+      | egrep -o '/screwdriver-cd/sd-step/releases/download/v[0-9.]*/sd-step_linux_amd64' \
       | wget --base=http://github.com/ -i - -O sd-step\
    && chmod +x sd-step \
    # Create FIFO

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -22,7 +22,6 @@ jobs:
             - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
             - tag: ./ci/git-tag.sh
             - release: |
-                rm -f ./VERSION
                 curl -sL https://git.io/goreleaser | bash
         secrets:
             # Pushing tags to Git

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -20,14 +20,12 @@ jobs:
             - setup-ci: git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci
             - get: go get -t ./...
             - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
-            - build: go build -a -o launch
-            - get-bzip2: apt-get update && apt-get install -y --no-install-recommends bzip2
             - tag: ./ci/git-tag.sh
-            - release: ./ci/git-release.sh
+            - release: |
+                rm -f ./VERSION
+                curl -sL https://git.io/goreleaser | bash
         secrets:
             # Pushing tags to Git
             - GIT_KEY
             # Pushing releases to GitHub
             - GITHUB_TOKEN
-        environment:
-            RELEASE_FILE: launch


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

We'd like to build iOS apps in MacOS VMs.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Build and release for 64-bit macos. This PR uses goreleaser, see https://github.com/screwdriver-cd/log-service/pull/12 .

Please merge this PR after https://github.com/screwdriver-cd/log-service/pull/12, https://github.com/screwdriver-cd/meta-cli/pull/8, https://github.com/screwdriver-cd/sd-step/pull/4, otherwise the docker build fails.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
Use jenkins executor for macos node : https://github.com/screwdriver-cd/executor-j5s/pull/12