### PR TITLE
	fix(#525): Move from bufio.Scanner to bufio.Reader

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -134,6 +134,8 @@ func TestUnmocked(t *testing.T) {
 		{"ls", nil},
 		{"sleep 1", nil},
 		{"ls && ls ", nil},
+		// Large single-line
+		{"openssl rand -hex 1000000", nil},
 		{"doesntexist", fmt.Errorf("Launching command exit with code: %v", 127)},
 		{"ls && sh -c 'exit 5' && sh -c 'exit 2'", fmt.Errorf("Launching command exit with code: %v", 5)},
 	}


### PR DESCRIPTION
Fixed the problem of reading long-lines.

See [this](https://golang.org/pkg/bufio/#Scanner) for more info:  
> Programs that need more control over error handling or large tokens, 
> or must run sequential scans on a reader, should use bufio.Reader 
> instead.

I pulled the helper function from: https://stackoverflow.com/a/12206365