### PR TITLE
fix: pin golang version to 1.8.3

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -2,7 +2,7 @@ workflow:
     - deploy
 
 shared:
-    image: golang
+    image: golang:1.8.3
     environment:
         GOPATH: /sd/workspace
 


### PR DESCRIPTION
 pin golang version to 1.8.3 for now as a temp fix so that we can roll out stjohn's change.

Related to https://github.com/screwdriver-cd/screwdriver/issues/729