### PR TITLE
fix: switch from bufio.Scanner to bufio.Reader for emitter

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -84,7 +84,7 @@ func copyLinesUntil(r io.Reader, w io.Writer, match string) (int, error) {
 		if len(exportCmd) == 0 {
 			_, werr := fmt.Fprintln(w, t)
 			if werr != nil {
-				return ExitUnknown, fmt.Errorf("Error pipling logs to emitter: %v", werr)
+				return ExitUnknown, fmt.Errorf("Error piping logs to emitter: %v", werr)
 			}
 		}
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -82,7 +82,10 @@ func copyLinesUntil(r io.Reader, w io.Writer, match string) (int, error) {
 		// Filter out the export command from the output
 		exportCmd := reExport.FindStringSubmatch(t)
 		if len(exportCmd) == 0 {
-			fmt.Fprintln(w, t)
+			_, werr := fmt.Fprintln(w, t)
+			if werr != nil {
+				return ExitUnknown, fmt.Errorf("Error pipling logs to emitter: %v", werr)
+			}
 		}
 
 		t, err = readln(reader)


### PR DESCRIPTION
We have switched to `bufio.Reader` in the `executor.go` already.

But the log emitter inside launcher is still using `bufio.Scanner`. And there is no err handling for 
`fmt.Fprintln(w, t)` which is writing the log line to emitter. So now no err will be caught and the build will get stuck because emitter crashes.

Build image locally and tested it out, it works fine with long line now.
<img width="1303" alt="screen shot 2017-08-31 at 3 44 29 pm" src="https://user-images.githubusercontent.com/20427140/29948371-54cc999c-8e63-11e7-8a6c-8ed922245670.png">


Related to https://github.com/screwdriver-cd/screwdriver/issues/525