### PR TITLE
fix: can get prNumber even if job name is PR-1:main

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -152,7 +152,7 @@ func writeArtifact(aDir string, fName string, artifact interface{}) error {
 
 // prNumber checks to see if the job name is a pull request and returns its number
 func prNumber(jobName string) string {
-	r := regexp.MustCompile("^PR-([0-9]+)$")
+	r := regexp.MustCompile("^PR-([0-9]+)(?::[\\w-]+)?$")
 	matched := r.FindStringSubmatch(jobName)
 	if matched == nil || len(matched) != 2 {
 		return ""

--- a/launch_test.go
+++ b/launch_test.go
@@ -337,7 +337,7 @@ func TestCreateWorkspace(t *testing.T) {
 }
 
 func TestPRNumber(t *testing.T) {
-	testJobName := "PR-1"
+	testJobName := "PR-1:main"
 	wantPrNumber := "1"
 
 	prNumber := prNumber(testJobName)


### PR DESCRIPTION
## Context
Now, `PR-1:main` is allowed as job name in job model.
However, when job name is `PR-1:main`, SD_PULL_REQUEST is empty because prNumber's regexp doesn't match `PR-1:main`.
<img width="1159" alt="2017-10-27 15 48 16" src="https://user-images.githubusercontent.com/8113204/32091270-6229c2c0-bb2e-11e7-8bd1-b7491ec719f6.png">


## Objective
Fix prNumber's regexp