### PR TITLE
feat: write external triggered metadata to a separate file

### DIFF
--- a/screwdriver/emitter.go
+++ b/screwdriver/emitter.go
@@ -75,14 +75,14 @@ func (e *emitter) processPipe() {
 			Step:    e.cmd.Name,
 		}
 		if err := encoder.Encode(newLine); err != nil {
-			e.err = fmt.Errorf("encoding json: %v", err)
+			e.err = fmt.Errorf("Encoding json: %v", err)
 		}
 
 		line, readErr = readln(reader)
 	}
 
 	if readErr != nil && readErr.Error() != "EOF" {
-		e.err = fmt.Errorf("piping log line to emiiter: %v", readErr)
+		e.err = fmt.Errorf("Piping log line to emitter: %v", readErr)
 	}
 
 	if err := e.file.Close(); err != nil {
@@ -95,7 +95,7 @@ func NewEmitter(path string) (Emitter, error) {
 	r, w := io.Pipe()
 	file, err := os.OpenFile(path, os.O_WRONLY, 0600)
 	if err != nil {
-		return nil, fmt.Errorf("failed opening emitter path %q: %v", path, err)
+		return nil, fmt.Errorf("Failed opening emitter path %q: %v", path, err)
 	}
 
 	cmd := CommandDef{

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -148,14 +148,14 @@ func tokenHeader(token string) string {
 func handleResponse(res *http.Response) ([]byte, error) {
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		return nil, fmt.Errorf("reading response Body from Screwdriver: %v", err)
+		return nil, fmt.Errorf("Reading response Body from Screwdriver: %v", err)
 	}
 
 	if res.StatusCode/100 != 2 {
 		var err SDError
 		parserr := json.Unmarshal(body, &err)
 		if parserr != nil {
-			return nil, fmt.Errorf("unparseable error response from Screwdriver: %v", parserr)
+			return nil, fmt.Errorf("Unparseable error response from Screwdriver: %v", parserr)
 		}
 		return nil, err
 	}
@@ -177,13 +177,13 @@ func retry(attempts int, callback func() error) (err error) {
 		duration := time.Duration(math.Pow(2, float64(i+1)))
 		sleep(duration * time.Second)
 	}
-	return fmt.Errorf("after %d attempts, last error: %s", attempts, err)
+	return fmt.Errorf("After %d attempts, Last error: %s", attempts, err)
 }
 
 func (a api) get(url *url.URL) ([]byte, error) {
 	req, err := http.NewRequest("GET", url.String(), nil)
 	if err != nil {
-		return nil, fmt.Errorf("generating request to Screwdriver: %v", err)
+		return nil, fmt.Errorf("Generating request to Screwdriver: %v", err)
 	}
 	req.Header.Set("Authorization", tokenHeader(a.token))
 
@@ -296,7 +296,7 @@ func (a api) BuildFromID(buildID int) (build Build, err error) {
 func (a api) JobFromID(jobID int) (job Job, err error) {
 	u, err := a.makeURL(fmt.Sprintf("jobs/%d", jobID))
 	if err != nil {
-		return job, fmt.Errorf("generating Screwdriver url for Job %d: %v", jobID, err)
+		return job, fmt.Errorf("Generating Screwdriver url for Job %d: %v", jobID, err)
 	}
 
 	body, err := a.get(u)
@@ -337,7 +337,7 @@ func (a api) UpdateBuildStatus(status BuildStatus, meta map[string]interface{}, 
 	case Failure:
 	case Aborted:
 	default:
-		return fmt.Errorf("invalid build status: %s", status)
+		return fmt.Errorf("Invalid build status: %s", status)
 	}
 
 	u, err := a.makeURL(fmt.Sprintf("builds/%d", buildID))
@@ -351,12 +351,12 @@ func (a api) UpdateBuildStatus(status BuildStatus, meta map[string]interface{}, 
 	}
 	payload, err := json.Marshal(bs)
 	if err != nil {
-		return fmt.Errorf("marshaling JSON for Build Status: %v", err)
+		return fmt.Errorf("Marshaling JSON for Build Status: %v", err)
 	}
 
 	_, err = a.put(u, "application/json", bytes.NewReader(payload))
 	if err != nil {
-		return fmt.Errorf("posting to Build Status: %v", err)
+		return fmt.Errorf("Posting to Build Status: %v", err)
 	}
 
 	return nil
@@ -365,7 +365,7 @@ func (a api) UpdateBuildStatus(status BuildStatus, meta map[string]interface{}, 
 func (a api) UpdateStepStart(buildID int, stepName string) error {
 	u, err := a.makeURL(fmt.Sprintf("builds/%d/steps/%s", buildID, stepName))
 	if err != nil {
-		return fmt.Errorf("creating url: %v", err)
+		return fmt.Errorf("Creating url: %v", err)
 	}
 
 	bs := StepStartPayload{
@@ -373,12 +373,12 @@ func (a api) UpdateStepStart(buildID int, stepName string) error {
 	}
 	payload, err := json.Marshal(bs)
 	if err != nil {
-		return fmt.Errorf("marshaling JSON for Step Start: %v", err)
+		return fmt.Errorf("Marshaling JSON for Step Start: %v", err)
 	}
 
 	_, err = a.put(u, "application/json", bytes.NewReader(payload))
 	if err != nil {
-		return fmt.Errorf("posting to Step Start: %v", err)
+		return fmt.Errorf("Posting to Step Start: %v", err)
 	}
 
 	return nil
@@ -387,7 +387,7 @@ func (a api) UpdateStepStart(buildID int, stepName string) error {
 func (a api) UpdateStepStop(buildID int, stepName string, exitCode int) error {
 	u, err := a.makeURL(fmt.Sprintf("builds/%d/steps/%s", buildID, stepName))
 	if err != nil {
-		return fmt.Errorf("creating url: %v", err)
+		return fmt.Errorf("Creating url: %v", err)
 	}
 
 	bs := StepStopPayload{
@@ -396,12 +396,12 @@ func (a api) UpdateStepStop(buildID int, stepName string, exitCode int) error {
 	}
 	payload, err := json.Marshal(bs)
 	if err != nil {
-		return fmt.Errorf("marshaling JSON for Step Stop: %v", err)
+		return fmt.Errorf("Marshaling JSON for Step Stop: %v", err)
 	}
 
 	_, err = a.put(u, "application/json", bytes.NewReader(payload))
 	if err != nil {
-		return fmt.Errorf("posting to Step Stop: %v", err)
+		return fmt.Errorf("Posting to Step Stop: %v", err)
 	}
 
 	return nil

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -118,7 +118,7 @@ func TestBuildFromID(t *testing.T) {
 		{
 			build:      Build{},
 			statusCode: 500,
-			err: errors.New("after 5 attempts, last error: " +
+			err: errors.New("After 5 attempts, Last error: " +
 				"GET retries exhausted: 500 returned from GET http://fakeurl/v4/builds/0"),
 		},
 		{
@@ -181,7 +181,7 @@ func TestJobFromID(t *testing.T) {
 		{
 			job:        Job{},
 			statusCode: 500,
-			err: errors.New("after 5 attempts, last error: " +
+			err: errors.New("After 5 attempts, Last error: " +
 				"GET retries exhausted: 500 returned from GET http://fakeurl/v4/jobs/0"),
 		},
 		{
@@ -246,7 +246,7 @@ func TestPipelineFromID(t *testing.T) {
 		{
 			pipeline:   Pipeline{},
 			statusCode: 500,
-			err: errors.New("after 5 attempts, last error: " +
+			err: errors.New("After 5 attempts, Last error: " +
 				"GET retries exhausted: 500 returned from GET http://fakeurl/v4/pipelines/0"),
 		},
 		{
@@ -306,9 +306,9 @@ func TestUpdateBuildStatus(t *testing.T) {
 		{Failure, meta, 200, nil},
 		{Aborted, meta, 200, nil},
 		{Running, meta, 200, nil},
-		{"NOTASTATUS", meta, 200, errors.New("invalid build status: NOTASTATUS")},
-		{Success, meta, 500, errors.New("posting to Build Status: after 5 attempts, " +
-			"last error: retries exhausted: 500 returned from http://fakeurl/v4/builds/15")},
+		{"NOTASTATUS", meta, 200, errors.New("Invalid build status: NOTASTATUS")},
+		{Success, meta, 500, errors.New("Posting to Build Status: After 5 attempts, " +
+			"Last error: retries exhausted: 500 returned from http://fakeurl/v4/builds/15")},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Make extra API calls to check if the triggering build and the current build belong to the same pipeline. If they belong to the same pipeline, then we store `metadata` into the same `meta.json`. 
If the belong to different pipelines (meaning this is an external trigger), we store `metadata` into the triggering job `sd@123:component.json`

More implementation details here: https://github.com/screwdriver-cd/screwdriver/issues/771