### PR TITLE
fix(133): do not update step status for step not run

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -198,6 +198,10 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 			fReader := bufio.NewReader(f)
 
 			code, cmdErr = doRunCommand(guid, stepFilePath, emitter, f, fReader)
+
+			if err := api.UpdateStepStop(buildID, cmd.Name, code); err != nil {
+				return fmt.Errorf("Updating step stop %q: %v", cmd.Name, err)
+			}
 		} else if isTeardown {
 			if !teardownFlag {
 				if firstError == nil {
@@ -212,10 +216,10 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 
 			// Run teardown commands
 			code, cmdErr = doRunTeardownCommand(cmd, emitter, env, path)
-		}
 
-		if err := api.UpdateStepStop(buildID, cmd.Name, code); err != nil {
-			return fmt.Errorf("Updating step stop %q: %v", cmd.Name, err)
+			if err := api.UpdateStepStop(buildID, cmd.Name, code); err != nil {
+				return fmt.Errorf("Updating step stop %q: %v", cmd.Name, err)
+			}
 		}
 
 		// Set first error flag

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -204,6 +204,18 @@ func TestUnmockedMulti(t *testing.T) {
 			}
 			return nil
 		},
+		updateStepStop: func(buildID int, stepName string, code int) error {
+			if buildID != testBuild.ID {
+				t.Errorf("wrong build id got %v, want %v", buildID, testBuild.ID)
+			}
+			if stepName == "test sleep 1" {
+				t.Errorf("Should not update step that never run: %v", stepName)
+			}
+			if stepName == "sd-teardown-artifacts" {
+				runTeardown = true
+			}
+			return nil
+		},
 	})
 	err := Run("", nil, &MockEmitter{}, testBuild, testAPI, testBuild.ID)
 	expectedErr := fmt.Errorf("Launching command exit with code: %v", 127)


### PR DESCRIPTION
 Do not update step status for step not run.
if you have steps like this:
```
        steps:
            - print: echo $SD_PULL_REQUEST
            - exit: exit 1
            - echo: echo hello
            - test: echo world
```
We shouldn't update step status for `echo` and `test`
Related to https://github.com/screwdriver-cd/screwdriver/issues/473

