### PR TITLE
fix: launcher release name got changed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN set -x \
    && apk add --virtual .build-dependencies gpgme \
    # Download Launcher
    && wget -q -O - https://github.com/screwdriver-cd/launcher/releases/latest \
-      | egrep -o '/screwdriver-cd/launcher/releases/download/v[0-9.]*/launch_linux_amd64' \
+      | egrep -o '/screwdriver-cd/launcher/releases/download/v[0-9.]*/launcher_linux_amd64' \
       | wget --base=http://github.com/ -i - -O launch \
    && chmod +x launch \
    # Download Log Service

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN set -x \
    && chmod +x logservice \
    # Download Meta CLI
    && wget -q -O - https://github.com/screwdriver-cd/meta-cli/releases/latest \
-      | egrep -o '/screwdriver-cd/meta-cli/releases/download/v[0-9.]*/meta_linux_amd64' \
+      | egrep -o '/screwdriver-cd/meta-cli/releases/download/v[0-9.]*/meta-cli_linux_amd64' \
       | wget --base=http://github.com/ -i - -O meta\
    && chmod +x meta\
    # Download Tini Static

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN set -x \
    && chmod +x launch \
    # Download Log Service
    && wget -q -O - https://github.com/screwdriver-cd/log-service/releases/latest \
-      | egrep -o '/screwdriver-cd/log-service/releases/download/v[0-9.]*/logservice_linux_amd64' \
+      | egrep -o '/screwdriver-cd/log-service/releases/download/v[0-9.]*/log-service_linux_amd64' \
       | wget --base=http://github.com/ -i - -O logservice \
    && chmod +x logservice \
    # Download Meta CLI


### PR DESCRIPTION
Currently, builds cannot run because it cannot download launcher's binary. So inside the build, `launch` is empty. 
for beta pods: `-rwxr-xr-x 1 root root       0 Jan  5 19:16 launch`
for prod pods: `-rwxr-xr-x 1 root root 5760224 Dec 12 01:18 launch`

Somehow this name got changed, probably by the `go-releaser`