### PR TITLE
fix: Cleanup GoReleaser and support alternative shells

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-architect

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -17,6 +17,8 @@ import (
 	"github.com/screwdriver-cd/launcher/screwdriver"
 )
 
+var osGetEnv = os.Getenv
+
 const (
 	// ExitLaunch is the exit code when a step fails to launch
 	ExitLaunch = 255
@@ -37,8 +39,14 @@ func (e ErrStatus) Error() string {
 
 // Create a sh file
 func createShFile(path string, cmd screwdriver.CommandDef) error {
-	defaultStart := "#!/bin/sh -e"
-	return ioutil.WriteFile(path, []byte(defaultStart+"\n"+cmd.Cmd), 0755)
+	defaultShell := osGetEnv("BASH_PATH")
+
+	// Default to /bin/sh if we don't have an injected path
+	if defaultShell == "" {
+		defaultShell = "/bin/sh"
+	}
+
+	return ioutil.WriteFile(path, []byte("#!"+defaultShell+" -e\n"+cmd.Cmd), 0755)
 }
 
 // Returns a single line (without the ending \n) from the input buffered reader

--- a/launch.go
+++ b/launch.go
@@ -19,8 +19,13 @@ import (
 	"github.com/urfave/cli"
 )
 
-// VERSION gets set by the build script via the LDFLAGS
-var VERSION string
+// These variables get set by the build script via the LDFLAGS
+// Detail about these variables are here: https://goreleaser.com/#builds
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
 
 var mkdirAll = os.MkdirAll
 var stat = os.Stat
@@ -42,12 +47,12 @@ func exit(status screwdriver.BuildStatus, buildID int, api screwdriver.API, meta
 		var metaInterface map[string]interface{}
 
 		log.Printf("Loading meta from %q/meta.json", metaSpace)
-		metaJson, err := readFile(metaSpace + "/meta.json")
+		metaJSON, err := readFile(metaSpace + "/meta.json")
 		if err != nil {
 			log.Printf("Failed to load %q/meta.json: %v", metaSpace, err)
 			metaInterface = make(map[string]interface{})
 		} else {
-			err = unmarshal(metaJson, &metaInterface)
+			err = unmarshal(metaJSON, &metaInterface)
 			if err != nil {
 				log.Printf("Failed to load %q/meta.json: %v", metaSpace, err)
 				metaInterface = make(map[string]interface{})
@@ -408,12 +413,14 @@ func main() {
 	app.Name = "launcher"
 	app.Usage = "launch a Screwdriver build"
 	app.UsageText = "launch [options] build-id"
-	app.Copyright = "(c) 2016 Yahoo Inc."
+	app.Version = fmt.Sprintf("%v, commit %v, built at %v", version, commit, date)
 
-	if VERSION == "" {
-		VERSION = "0.0.0"
+	if date != "unknown" {
+		// date is passed in from GoReleaser which uses RFC3339 format
+		t, _ := time.Parse(time.RFC3339, date)
+		date = t.Format("2006")
 	}
-	app.Version = VERSION
+	app.Copyright = "(c) 2016-" + date + " Yahoo Inc."
 
 	app.Flags = []cli.Flag{
 		cli.StringFlag{


### PR DESCRIPTION
## Context

We want to be able to use `bash` but it's not always included in images (or has a different version).  This setup allows us to ship `bash` with the binary in a simple setup.

## Changes

 - Removed Jekyll config
 - Fixed version and date from GoReleaser
 - Switched to new workflow
 - Added Habitat building