### PR TITLE
fix: GoReleaser bug and Alternative Shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ $ go get github.com/screwdriver-cd/launcher
 $ launch --api-uri http://localhost:8080/v4 buildId
 ```
 
+If you want to use an alternative shell (instead of `/bin/sh`) you can set the environment variable
+`SD_SHELL_BIN` to what you want to use.
+
+```bash
+$ SD_SHELL_BIN=/bin/bash launch --api-url http://localhost:8080/v4 buildId
+```
+
 ## Testing
 
 ```bash

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-architect

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/kr/pty"
-	"github.com/myesui/uuid"
 	"github.com/screwdriver-cd/launcher/screwdriver"
+	"gopkg.in/kr/pty.v1"
+	"gopkg.in/myesui/uuid.v1"
 )
 
 var osGetEnv = os.Getenv

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -17,6 +17,8 @@ import (
 	"github.com/screwdriver-cd/launcher/screwdriver"
 )
 
+var osGetEnv = os.Getenv
+
 const (
 	// ExitLaunch is the exit code when a step fails to launch
 	ExitLaunch = 255
@@ -37,8 +39,14 @@ func (e ErrStatus) Error() string {
 
 // Create a sh file
 func createShFile(path string, cmd screwdriver.CommandDef) error {
-	defaultStart := "#!/bin/sh -e"
-	return ioutil.WriteFile(path, []byte(defaultStart+"\n"+cmd.Cmd), 0755)
+	defaultShell := osGetEnv("SD_SHELL_BIN")
+
+	// Default to /bin/sh if we don't have an injected path
+	if defaultShell == "" {
+		defaultShell = "/bin/sh"
+	}
+
+	return ioutil.WriteFile(path, []byte("#!"+defaultShell+" -e\n"+cmd.Cmd), 0755)
 }
 
 // Returns a single line (without the ending \n) from the input buffered reader

--- a/launch.go
+++ b/launch.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/screwdriver-cd/launcher/executor"
 	"github.com/screwdriver-cd/launcher/screwdriver"
-	"github.com/urfave/cli"
+	"gopkg.in/urfave/cli.v1"
 )
 
 // These variables get set by the build script via the LDFLAGS

--- a/launch.go
+++ b/launch.go
@@ -19,8 +19,13 @@ import (
 	"github.com/urfave/cli"
 )
 
-// VERSION gets set by the build script via the LDFLAGS
-var VERSION string
+// These variables get set by the build script via the LDFLAGS
+// Detail about these variables are here: https://goreleaser.com/#builds
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
 
 var mkdirAll = os.MkdirAll
 var stat = os.Stat
@@ -42,12 +47,12 @@ func exit(status screwdriver.BuildStatus, buildID int, api screwdriver.API, meta
 		var metaInterface map[string]interface{}
 
 		log.Printf("Loading meta from %q/meta.json", metaSpace)
-		metaJson, err := readFile(metaSpace + "/meta.json")
+		metaJSON, err := readFile(metaSpace + "/meta.json")
 		if err != nil {
 			log.Printf("Failed to load %q/meta.json: %v", metaSpace, err)
 			metaInterface = make(map[string]interface{})
 		} else {
-			err = unmarshal(metaJson, &metaInterface)
+			err = unmarshal(metaJSON, &metaInterface)
 			if err != nil {
 				log.Printf("Failed to load %q/meta.json: %v", metaSpace, err)
 				metaInterface = make(map[string]interface{})
@@ -408,12 +413,14 @@ func main() {
 	app.Name = "launcher"
 	app.Usage = "launch a Screwdriver build"
 	app.UsageText = "launch [options] build-id"
-	app.Copyright = "(c) 2016 Yahoo Inc."
+	app.Version = fmt.Sprintf("%v, commit %v, built at %v", version, commit, date)
 
-	if VERSION == "" {
-		VERSION = "0.0.0"
+	if date != "unknown" {
+		// date is passed in from GoReleaser which uses RFC3339 format
+		t, _ := time.Parse(time.RFC3339, date)
+		date = t.Format("2006")
 	}
-	app.Version = VERSION
+	app.Copyright = "(c) 2016-" + date + " Yahoo Inc."
 
 	app.Flags = []cli.Flag{
 		cli.StringFlag{

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,3 @@
-workflow:
-    - deploy
 
 shared:
     image: golang
@@ -8,6 +6,7 @@ shared:
 
 jobs:
     main:
+        requires: [~pr, ~commit]
         steps:
             - get: go get -t ./...
             - vet: go vet ./...
@@ -15,14 +14,13 @@ jobs:
             - test: go test ./...
             - build: go build -a -o launch
 
-    deploy:
+    publish:
+        requires: [main]
         steps:
             - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
             - get: go get -t ./...
-            - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
             - tag: ./ci/git-tag.sh
-            - release: |
-                curl -sL https://git.io/goreleaser | bash
+            - release: "curl -sL https://git.io/goreleaser | bash"
         secrets:
             # Pushing tags to Git
             - GIT_KEY


### PR DESCRIPTION
## Context

Our launcher is not getting shipped with the version number anymore due to the variable naming.  We also have the wrong date in the copyright.

Additionally, I changed the launcher to allow us to pass an alternative shell path and switching to `gopkg.in` for semver dependencies.