### PR TITLE
feat: Adding Habitat package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,12 @@ launcher
 data/emitter
 
 # Generated while deploying
-
 /ci/
-/VERSION
 
 # goreleaser
-
 /dist/
+
+# habitat
+/results/
+/src/
+/VERSION

--- a/README.md
+++ b/README.md
@@ -8,9 +8,25 @@
 
 ## Usage
 
+### Go
+
 ```bash
 $ go get github.com/screwdriver-cd/launcher
-$ launch --api-uri http://localhost:8080/v4 buildId
+$ launcher --api-uri http://localhost:8080/v4 buildId
+```
+
+### Habitat
+
+```bash
+$ hab package install screwdriver-cd/launcher
+$ hab package exec screwdriver-cd/launcher launcher --api-uri http://localhost:8080/v4 buildId
+```
+
+### Docker
+
+```bash
+$ docker pull screwdrivercd/launcher
+$ docker run screwdrivercd/launcher --api-uri http://localhost:8080/v4 buildId
 ```
 
 If you want to use an alternative shell (instead of `/bin/sh`) you can set the environment variable
@@ -25,6 +41,16 @@ $ SD_SHELL_BIN=/bin/bash launch --api-url http://localhost:8080/v4 buildId
 ```bash
 $ go get github.com/screwdriver-cd/launcher
 $ go test -cover github.com/screwdriver-cd/launcher/...
+```
+
+## Building
+
+### Habitat
+
+```bash
+$ habitat studio enter
+$ build
+$ hab pkg exec $HAB_ORIGIN/launcher launcher --help
 ```
 
 ## License

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,0 +1,42 @@
+pkg_name=launcher
+pkg_origin=screwdriver-cd
+pkg_version=`git describe --abbrev=0 --tags`
+pkg_scaffolding=core/scaffolding-go
+pkg_license=('BSD 3-clause')
+pkg_maintainer=('St. John Johnson <st.john.johnson@gmail.com>')
+pkg_deps=(core/bash)
+pkg_bin_dirs=(bin)
+
+scaffolding_go_base_path="github.com/screwdriver-cd"
+scaffolding_go_build_deps=(
+    gopkg.in/kr/pty.v1
+    gopkg.in/myesui/uuid.v1
+    gopkg.in/urfave/cli.v1
+)
+
+do_install() {
+    export VERSION="${pkg_version}"
+    export DATE=`date -u '+%Y-%m-%dT%T.00Z'`
+
+    pushd "$scaffolding_go_pkg_path"
+    go install -ldflags "-X main.version=${VERSION} -X main.date=${DATE}"
+    popd
+    cp -r "${scaffolding_go_gopath:?}/bin" "${pkg_prefix}/${bin}"
+
+    wrap_bin "${pkg_prefix}/bin/launcher"
+}
+
+wrap_bin() {
+    local bin="$1"
+    build_line "Adding wrapper $bin to ${bin}.real"
+    mv -v "$bin" "${bin}.real"
+    cat <<EOF > "${bin}"
+#!$(pkg_path_for bash)/bin/bash
+set -e
+if test -n "$DEBUG"; then set -x; fi
+export SD_SHELL_BIN="$(pkg_path_for bash)/bin/bash"
+
+exec ${bin}.real \$@
+EOF
+    chmod -v 755 "$bin"
+}


### PR DESCRIPTION
## Context

Right now our launcher depends on `/bin/sh` to be available in the container.  This will allow users to use `/bin/bash` as it can be bundled with the launcher via Habitat.

## Implementation

So this is accomplished by adding a wrapper script (`launcher`) that calls the real launcher (`launcher.real`) and passes the full path to the `/bin/bash` dependency.  It's based on how Habitat does [`bundler`](https://bldr.habitat.sh/#/pkgs/core/bundler/1.16.0/20171129183702).

More information about the GoScaffolding can be found [here](https://github.com/habitat-sh/core-plans/tree/master/scaffolding-go).