### PR TITLE
feat(habitat): Pull in Bash Habitat.sh package

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,11 +1,18 @@
 builds:
   - binary: launch
+    # Build for Linux and OSX
     goos:
       - linux
       - darwin
     goarch:
       - amd64
+    # Include the default settings from https://goreleaser.com/#builds
+    # Also include static compilation
+    ldflags: -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -extldflags "-static"
 
 archive:
   format: binary
   name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+
+# Put the packages in the artifacts dir (but it won't eval environment variables)
+dist: /sd/workspace/artifacts/dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,13 @@ RUN set -x \
    # Download Meta CLI
    && wget -q -O - https://github.com/screwdriver-cd/meta-cli/releases/latest \
       | egrep -o '/screwdriver-cd/meta-cli/releases/download/v[0-9.]*/meta-cli_linux_amd64' \
-      | wget --base=http://github.com/ -i - -O meta\
-   && chmod +x meta\
+      | wget --base=http://github.com/ -i - -O meta \
+   && chmod +x meta \
+   # Download sd-step
+   && wget -q -O - https://github.com/screwdriver-cd/sd-step/releases/latest \
+      | egrep -o '/screwdriver-cd/sd-step/releases/download/v[0-9.]*/sd-step_linux_amd64' \
+      | wget --base=http://github.com/ -i - -O sd-step \
+   && chmod +x sd-step \
    # Download Tini Static
    && wget -q -O - https://github.com/krallin/tini/releases/latest \
       | egrep -o '/krallin/tini/releases/download/v[0-9.]*/tini-static' \
@@ -53,11 +58,11 @@ RUN set -x \
    && mv /opt/sd/hab-*-x86_64-linux/hab /opt/sd/bin/hab \
    && chmod +x /opt/sd/bin/hab \
    && rm -rf hab-* \
-   # Download sd-step
-   && wget -q -O - https://github.com/screwdriver-cd/sd-step/releases/latest \
-      | egrep -o '/screwdriver-cd/sd-step/releases/download/v[0-9.]*/sd-step_linux_amd64' \
-      | wget --base=http://github.com/ -i - -O sd-step\
-   && chmod +x sd-step \
+   # Install Habitat packages
+   && /opt/sd/bin/hab pkg install core/bash \
+   && rm -rf /hab/cache \
+   && mv /hab /opt/sd/hab-cache \
+   && ln -s /opt/sd/hab-cache /hab \
    # Create FIFO
    && mkfifo -m 666 emitter \
    # Cleanup packages

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -3,6 +3,7 @@ pkg_origin=screwdriver-cd
 pkg_scaffolding=core/scaffolding-go
 pkg_license=('BSD 3-clause')
 pkg_maintainer=('St. John Johnson <st.john.johnson@gmail.com>')
+pkg_upstream_url=('https://github.com/${pkg_origin}/${pkg_name}')
 pkg_deps=(core/bash)
 pkg_build_deps=(
     core/curl

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -12,7 +12,10 @@ jobs:
             - vet: go vet ./...
             - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
             - test: go test ./...
+            # The emitter file is changed by a test, but we want to ignore it
+            - ignore-git: git update-index --assume-unchanged data/emitter
             - build: go build -a -o $SD_ARTIFACTS_DIR/launch
+            - test-release: "curl -sL https://git.io/goreleaser | bash -s -- --snapshot"
 
     publish:
         requires: [main]


### PR DESCRIPTION
This is to enable the Launcher container to now have a copy of Habitat-packaged Bash.  It doesn't change anything for the builds yet, but gives us the option of using it.

You could now use it by setting the following environment variable:

```bash 
$ SD_SHELL_BIN=`/opt/sd/bin/hab pkg path core/bash`/bin/bash
```

Also fixed it so that the Launcher is statically compiled and doesn't depend on the hack here: https://github.com/screwdriver-cd/launcher/blob/b8ff0ec9428c099c78dcb2710db17c8b1e109b3f/Dockerfile#L8-L9

We can remove that after all the other binaries are updated to be statically compiled.