### PR TITLE
fix: Moving SD_SHELL_BIN to args and adding debug info to start

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -3,7 +3,7 @@ pkg_origin=screwdriver-cd
 pkg_scaffolding=core/scaffolding-go
 pkg_license=('BSD 3-clause')
 pkg_maintainer=('St. John Johnson <st.john.johnson@gmail.com>')
-pkg_upstream_url=('https://github.com/${pkg_origin}/${pkg_name}')
+pkg_upstream_url=("https://github.com/${pkg_origin}/${pkg_name}")
 pkg_deps=(core/bash)
 pkg_build_deps=(
     core/curl
@@ -18,6 +18,7 @@ scaffolding_go_build_deps=(
     gopkg.in/kr/pty.v1
     gopkg.in/myesui/uuid.v1
     gopkg.in/urfave/cli.v1
+    gopkg.in/fatih/color.v1
 )
 
 # Extract the version from the last published GitHub release

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -14,7 +14,9 @@ jobs:
             - test: go test ./...
             # The emitter file is changed by a test, but we want to ignore it
             - ignore-git: git update-index --assume-unchanged data/emitter
-            - build: go build -a -o $SD_ARTIFACTS_DIR/launch
+            # Ensure we can compile
+            - build: go build -a -o /dev/null
+            # Test cross-compiling as well
             - test-release: "curl -sL https://git.io/goreleaser | bash -s -- --snapshot"
 
     publish:

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -293,8 +293,8 @@ func TestPipelineFromID(t *testing.T) {
 
 func TestUpdateBuildStatus(t *testing.T) {
 	var meta map[string]interface{}
-	mockJson := []byte("{\"hoge\":\"fuga\"}")
-	_ = json.Unmarshal(mockJson, &meta)
+	mockJSON := []byte("{\"hoge\":\"fuga\"}")
+	_ = json.Unmarshal(mockJSON, &meta)
 
 	tests := []struct {
 		status     BuildStatus


### PR DESCRIPTION
I moved `SD_SHELL_BIN` from a hidden environment variable to an argument that can be passed on the command line.

Also fixed startup and teardown to use the shell that was specified.

Finally, added some extra output to the start of the build to know more about the running job.