### PR TITLE
feat(habitat): Expose Habitat as volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,7 @@ RUN set -x \
    && apk del --purge .build-dependencies
 
 VOLUME /opt/sd
+VOLUME /hab
 
 # Set Entrypoint
 ENTRYPOINT ["/opt/sd/tini", "--", "/opt/sd/launch"]


### PR DESCRIPTION
This will allow the docker-executor to automatically mount this volume.

Related issue: https://github.com/screwdriver-cd/screwdriver/issues/877