### PR TITLE
chore: ignore glide.lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ data/emitter
 
 # glide vendors
 vendor/
+# we dont want to maintain partial updates
+glide.lock


### PR DESCRIPTION
## Objective

Completely ignore the `glide.lock` file, since we don't leverage it in our build pipeline