### PR TITLE
feat: Merge parentBuildId metas

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -190,7 +190,7 @@ func convertToArray(i interface{}) (array []int) {
 	}
 }
 
-func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, storeURL, shellBin string) error {
+func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, storeURL, shellBin string, buildTimeout int) error {
 	emitter, err := newEmitter(emitterPath)
 	if err != nil {
 		return err
@@ -394,7 +394,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		return fmt.Errorf("Updating sd-setup-launcher stop: %v", err)
 	}
 
-	return executorRun(w.Src, env, emitter, build, api, buildID, shellBin, DefaultTimeout)
+	return executorRun(w.Src, env, emitter, build, api, buildID, shellBin, buildTimeout)
 }
 
 func createEnvironment(base map[string]string, secrets screwdriver.Secrets, build screwdriver.Build) []string {
@@ -438,10 +438,10 @@ func createEnvironment(base map[string]string, secrets screwdriver.Secrets, buil
 }
 
 // Executes the command based on arguments from the CLI
-func launchAction(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, storeURI, shellBin string) error {
+func launchAction(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, storeURI, shellBin string, buildTimeout int) error {
 	log.Printf("Starting Build %v\n", buildID)
 
-	if err := launch(api, buildID, rootDir, emitterPath, metaSpace, storeURI, shellBin); err != nil {
+	if err := launch(api, buildID, rootDir, emitterPath, metaSpace, storeURI, shellBin, buildTimeout); err != nil {
 		if _, ok := err.(executor.ErrStatus); ok {
 			log.Printf("Failure due to non-zero exit code: %v\n", err)
 		} else {
@@ -536,6 +536,12 @@ func main() {
 			Value:  "/bin/sh",
 			EnvVar: "SD_SHELL_BIN",
 		},
+		cli.IntFlag{
+			Name:   "build-timeout",
+			Usage:  "Maximum number of seconds to allow a build to run",
+			Value:  DefaultTimeout,
+			EnvVar: "SD_BUILD_TIMEOUT",
+		},
 	}
 
 	app.Action = func(c *cli.Context) error {
@@ -547,6 +553,7 @@ func main() {
 		storeURL := c.String("store-uri")
 		shellBin := c.String("shell-bin")
 		buildID, err := strconv.Atoi(c.Args().Get(0))
+		buildTimeout := c.Int("build-timeout")
 
 		if err != nil {
 			return cli.ShowAppHelp(c)
@@ -560,7 +567,7 @@ func main() {
 
 		defer recoverPanic(buildID, api, metaSpace)
 
-		launchAction(api, buildID, workspace, emitterPath, metaSpace, storeURL, shellBin)
+		launchAction(api, buildID, workspace, emitterPath, metaSpace, storeURL, shellBin, buildTimeout)
 
 		// This should never happen...
 		log.Println("Unexpected return in launcher. Failing the build.")

--- a/launch_test.go
+++ b/launch_test.go
@@ -34,7 +34,9 @@ const (
 )
 
 var TestParentBuildIDFloat interface{} = float64(1111)
-
+var TestParentBuildIDs = []float64{1111, 2222}
+var IDs = make([]interface{}, len(TestParentBuildIDs))
+var actual = make(map[string]interface{})
 var TestScmRepo = screwdriver.ScmRepo(FakeScmRepo{
 	Name: "screwdriver-cd/launcher",
 })
@@ -868,8 +870,6 @@ func TestFetchParentBuildMeta(t *testing.T) {
 }
 
 func TestFetchParentBuildsMetaParseError(t *testing.T) {
-	TestParentBuildIDs := []float64{1111, 2222}
-	IDs := make([]interface{}, len(TestParentBuildIDs))
 	for i, s := range TestParentBuildIDs {
 		IDs[i] = s
 	}
@@ -987,9 +987,6 @@ func TestFetchParentBuildMetaWriteError(t *testing.T) {
 }
 
 func TestFetchParentBuildsMeta(t *testing.T) {
-	actual := make(map[string]interface{})
-	TestParentBuildIDs := []float64{1111, 2222}
-	IDs := make([]interface{}, len(TestParentBuildIDs))
 	for i, s := range TestParentBuildIDs {
 		IDs[i] = s
 	}
@@ -1038,6 +1035,9 @@ func TestNoParentEventID(t *testing.T) {
 	defer func() { marshal = oldMarshal }()
 
 	api := mockAPI(t, TestBuildID, TestJobID, 0, "RUNNING")
+	api.buildFromID = func(buildID int) (screwdriver.Build, error) {
+		return screwdriver.Build(FakeBuild{ID: TestBuildID, JobID: TestJobID}), nil
+	}
 	api.eventFromID = func(eventID int) (screwdriver.Event, error) {
 		return screwdriver.Event(FakeEvent{ID: TestEventID}), nil
 	}

--- a/launch_test.go
+++ b/launch_test.go
@@ -1033,27 +1033,6 @@ func TestFetchParentBuildsMeta(t *testing.T) {
 	}
 }
 
-func TestMergedMetaFromParentBuildsIDs(t *testing.T) {
-	TestParentBuildIDs := []float64{1111, 2222}
-	IDs := make([]interface{}, len(TestParentBuildIDs))
-	for i, s := range TestParentBuildIDs {
-		IDs[i] = s
-	}
-	oldMarshal := marshal
-	defer func() { marshal = oldMarshal }()
-
-	api := mockAPI(t, TestBuildID, TestJobID, 0, "RUNNING")
-	api.buildFromID = func(buildID int) (screwdriver.Build, error) {
-		return screwdriver.Build(FakeBuild{ID: TestBuildID, JobID: TestJobID, ParentBuildID: IDs}), nil
-	}
-
-	marshal = func(v interface{}) (result []byte, err error) {
-		return nil, fmt.Errorf("Testing parsing parent builds meta")
-	}
-
-	launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin)
-}
-
 func TestNoParentEventID(t *testing.T) {
 	oldMarshal := marshal
 	defer func() { marshal = oldMarshal }()

--- a/launch_test.go
+++ b/launch_test.go
@@ -18,6 +18,7 @@ const (
 	TestWorkspace        = "/sd/workspace"
 	TestEmitter          = "./data/emitter"
 	TestBuildID          = 1234
+	TestBuildTimeout     = 60
 	TestEventID          = 2234
 	TestJobID            = 2345
 	TestParentBuildID    = 1111
@@ -228,7 +229,7 @@ func TestMain(m *testing.M) {
 func TestBuildJobPipelineFromID(t *testing.T) {
 	testPipelineID := 9999
 	api := mockAPI(t, TestBuildID, TestJobID, testPipelineID, "RUNNING")
-	launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin)
+	launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin, TestBuildTimeout)
 }
 
 func TestBuildFromIdError(t *testing.T) {
@@ -239,7 +240,7 @@ func TestBuildFromIdError(t *testing.T) {
 		},
 	}
 
-	err := launch(screwdriver.API(api), 0, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin)
+	err := launch(screwdriver.API(api), 0, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin, TestBuildTimeout)
 	if err == nil {
 		t.Errorf("err should not be nil")
 	}
@@ -258,7 +259,7 @@ func TestEventFromIdError(t *testing.T) {
 		},
 	}
 
-	err := launch(screwdriver.API(api), 0, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin)
+	err := launch(screwdriver.API(api), 0, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin, TestBuildTimeout)
 	if err == nil {
 		t.Errorf("err should not be nil")
 	}
@@ -276,7 +277,7 @@ func TestJobFromIdError(t *testing.T) {
 		return screwdriver.Job(FakeJob{}), err
 	}
 
-	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin)
+	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin, TestBuildTimeout)
 	if err == nil {
 		t.Errorf("err should not be nil")
 	}
@@ -295,7 +296,7 @@ func TestPipelineFromIdError(t *testing.T) {
 		return screwdriver.Pipeline(FakePipeline{}), err
 	}
 
-	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin)
+	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin, TestBuildTimeout)
 	if err == nil {
 		t.Fatalf("err should not be nil")
 	}
@@ -402,7 +403,7 @@ func TestCreateWorkspaceError(t *testing.T) {
 		return nil
 	}
 
-	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin)
+	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin, TestBuildTimeout)
 
 	if err.Error() != "Cannot create workspace path \"/sd/workspace/src/github.com/screwdriver-cd/launcher\": Spooky error" {
 		t.Errorf("Error is wrong, got %v", err)
@@ -436,7 +437,7 @@ func TestUpdateBuildStatusError(t *testing.T) {
 		return fmt.Errorf("Spooky error")
 	}
 
-	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin)
+	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin, TestBuildTimeout)
 
 	want := "Updating build status to RUNNING: Spooky error"
 	if err.Error() != want {
@@ -464,7 +465,7 @@ func TestUpdateBuildStatusSuccess(t *testing.T) {
 	tmp, cleanup := setupTempDirectoryAndSocket(t)
 	defer cleanup()
 
-	if err := launchAction(screwdriver.API(api), 0, tmp, path.Join(tmp, "socket"), TestMetaSpace, TestStoreURL, TestShellBin); err != nil {
+	if err := launchAction(screwdriver.API(api), 0, tmp, path.Join(tmp, "socket"), TestMetaSpace, TestStoreURL, TestShellBin, TestBuildTimeout); err != nil {
 		t.Errorf("Unexpected error from launch: %v", err)
 	}
 
@@ -501,7 +502,7 @@ func TestUpdateBuildNonZeroFailure(t *testing.T) {
 		return executor.ErrStatus{Status: 1}
 	}
 
-	err = launchAction(screwdriver.API(api), 1, tmp, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin)
+	err = launchAction(screwdriver.API(api), 1, tmp, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin, TestBuildTimeout)
 	if err != nil {
 		t.Errorf("Unexpected error from launch: %v", err)
 	}
@@ -671,7 +672,7 @@ func TestEmitterClose(t *testing.T) {
 		}, nil
 	}
 
-	if err := launchAction(screwdriver.API(api), 1, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin); err != nil {
+	if err := launchAction(screwdriver.API(api), 1, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin, TestBuildTimeout); err != nil {
 		t.Errorf("Unexpected error from launch: %v", err)
 	}
 
@@ -720,7 +721,7 @@ func TestSetEnv(t *testing.T) {
 		return nil
 	}
 
-	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin)
+	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin, TestBuildTimeout)
 	if err != nil {
 		t.Fatalf("Unexpected error from launch: %v", err)
 	}
@@ -769,7 +770,7 @@ func TestEnvSecrets(t *testing.T) {
 		return nil
 	}
 
-	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin)
+	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin, TestBuildTimeout)
 	if err != nil {
 		t.Fatalf("Unexpected error from launch: %v", err)
 	}
@@ -861,7 +862,7 @@ func TestFetchParentBuildMeta(t *testing.T) {
 		return nil
 	}
 
-	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin)
+	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin, TestBuildTimeout)
 	want := []byte("{\"hoge\":\"fuga\"}")
 
 	if err != nil || string(parentMeta) != string(want) {
@@ -885,7 +886,7 @@ func TestFetchParentBuildsMetaParseError(t *testing.T) {
 		return nil, fmt.Errorf("Testing parsing parent builds meta")
 	}
 
-	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin)
+	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin, TestBuildTimeout)
 	expected := fmt.Sprintf(`Parsing Parent Builds(%v) Meta JSON: Testing parsing parent builds meta`, IDs)
 
 	if err.Error() != expected {
@@ -908,7 +909,7 @@ func TestFetchParentEventMetaParseError(t *testing.T) {
 		return nil, fmt.Errorf("Testing parsing parent event meta")
 	}
 
-	err := launch(screwdriver.API(api), TestEventID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin)
+	err := launch(screwdriver.API(api), TestEventID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin, TestBuildTimeout)
 	expected := fmt.Sprintf(`Parsing Parent Event(%d) Meta JSON: Testing parsing parent event meta`, TestParentEventID)
 
 	if err.Error() != expected {
@@ -943,7 +944,7 @@ func TestFetchParentBuildMetaParseError(t *testing.T) {
 		return nil, fmt.Errorf("Testing parsing parent build meta")
 	}
 
-	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin)
+	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin, TestBuildTimeout)
 	expected := fmt.Sprintf(`Parsing Parent Build(%d) Meta JSON: Testing parsing parent build meta`, TestParentBuildID)
 
 	if err.Error() != expected {
@@ -978,7 +979,7 @@ func TestFetchParentBuildMetaWriteError(t *testing.T) {
 		return fmt.Errorf("Testing writing parent build meta")
 	}
 
-	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin)
+	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin, TestBuildTimeout)
 	expected := fmt.Sprintf(`Writing Parent Build(%d) Meta JSON: Testing writing parent build meta`, TestParentBuildID)
 
 	if err.Error() != expected {
@@ -1017,7 +1018,7 @@ func TestFetchParentBuildsMeta(t *testing.T) {
 		return nil, fmt.Errorf("Testing parsing parent event meta")
 	}
 
-	_ = launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin)
+	_ = launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin, TestBuildTimeout)
 
 	if actual["foo"] != "baz" {
 		t.Errorf("Error is wrong, got '%v', expected '%v'", actual["foo"], "baz")
@@ -1046,7 +1047,7 @@ func TestNoParentEventID(t *testing.T) {
 		return nil, fmt.Errorf("Testing parsing parent event meta")
 	}
 
-	launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin)
+	launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin, TestBuildTimeout)
 }
 
 func TestFetchParentEventMetaWriteError(t *testing.T) {
@@ -1079,7 +1080,7 @@ func TestFetchParentEventMetaWriteError(t *testing.T) {
 		return fmt.Errorf("Testing writing parent event meta")
 	}
 
-	err := launch(screwdriver.API(api), TestEventID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin)
+	err := launch(screwdriver.API(api), TestEventID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin, TestBuildTimeout)
 	expected := fmt.Sprintf(`Writing Parent Event(%d) Meta JSON: Testing writing parent event meta`, TestParentEventID)
 
 	if err.Error() != expected {

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -117,14 +117,15 @@ type CommandDef struct {
 
 // Build is a Screwdriver Build
 type Build struct {
-	ID            int                    `json:"id"`
-	JobID         int                    `json:"jobId"`
-	SHA           string                 `json:"sha"`
-	Commands      []CommandDef           `json:"steps"`
-	Environment   map[string]string      `json:"environment"`
-	ParentBuildID int                    `json:"parentBuildId"`
-	Meta          map[string]interface{} `json:"meta"`
-	EventID       int                    `json:"eventId"`
+	ID             int                    `json:"id"`
+	JobID          int                    `json:"jobId"`
+	SHA            string                 `json:"sha"`
+	Commands       []CommandDef           `json:"steps"`
+	Environment    map[string]string      `json:"environment"`
+	ParentBuildID  int                    `json:"parentBuildId"`
+	ParentBuildIDs []int                  `json:"parentBuildIds"`
+	Meta           map[string]interface{} `json:"meta"`
+	EventID        int                    `json:"eventId"`
 }
 
 // Event is a Screwdriver Event

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -115,17 +115,19 @@ type CommandDef struct {
 	Cmd  string `json:"command"`
 }
 
+// Need a generic interface to take in an int or array of ints
+type IntOrArray interface{}
+
 // Build is a Screwdriver Build
 type Build struct {
-	ID             int                    `json:"id"`
-	JobID          int                    `json:"jobId"`
-	SHA            string                 `json:"sha"`
-	Commands       []CommandDef           `json:"steps"`
-	Environment    map[string]string      `json:"environment"`
-	ParentBuildID  int                    `json:"parentBuildId"`
-	ParentBuildIDs []int                  `json:"parentBuildIds"`
-	Meta           map[string]interface{} `json:"meta"`
-	EventID        int                    `json:"eventId"`
+	ID            int                    `json:"id"`
+	JobID         int                    `json:"jobId"`
+	SHA           string                 `json:"sha"`
+	Commands      []CommandDef           `json:"steps"`
+	Environment   map[string]string      `json:"environment"`
+	ParentBuildID IntOrArray             `json:"parentBuildId"`
+	Meta          map[string]interface{} `json:"meta"`
+	EventID       int                    `json:"eventId"`
 }
 
 // Event is a Screwdriver Event


### PR DESCRIPTION
## Context
When a join occurs, we're currently just using the meta from the last build that triggered the join job to start. For example, if C requires A and B, if A finishes running first, B will trigger C to start after it is done. C would then be run with whatever metadata B had.
```
A 
     -->  C
B
```
We would like to merge all the metadata from all parent builds so that C can run using metadata from both A and B.

## Objective
This PR checks for multiple parent build IDs and merges the metadata for all of them.

## Related Links
Related to https://github.com/screwdriver-cd/screwdriver/issues/904
Blocked by https://github.com/screwdriver-cd/data-schema/pull/210