### PR TITLE
feat: unmodifiable timeout

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -44,6 +44,8 @@ var cleanExit = func() {
 	os.Exit(0)
 }
 
+const DefaultTimeout = 5400 // 90 minutes in seconds
+
 // exit sets the build status and exits successfully
 func exit(status screwdriver.BuildStatus, buildID int, api screwdriver.API, metaSpace string) {
 	if api != nil {
@@ -253,7 +255,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 
 			metaSource = "Build"
 			parentID = parentBuild.ID
-		} else {	// If has parent event, fetch meta from parent event
+		} else { // If has parent event, fetch meta from parent event
 			log.Printf("Fetching Parent Event %d", event.ParentEventID)
 			parentEvent, err := api.EventFromID(event.ParentEventID)
 			if err != nil {
@@ -352,7 +354,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		return fmt.Errorf("Updating sd-setup-launcher stop: %v", err)
 	}
 
-	return executorRun(w.Src, env, emitter, build, api, buildID, shellBin)
+	return executorRun(w.Src, env, emitter, build, api, buildID, shellBin, DefaultTimeout)
 }
 
 func createEnvironment(base map[string]string, secrets screwdriver.Secrets, build screwdriver.Build) []string {

--- a/launch_test.go
+++ b/launch_test.go
@@ -210,7 +210,7 @@ func TestMain(m *testing.M) {
 	open = func(f string) (*os.File, error) {
 		return os.Open("data/screwdriver.yaml")
 	}
-	executorRun = func(path string, env []string, emitter screwdriver.Emitter, build screwdriver.Build, api screwdriver.API, buildID int, shellBin string) error {
+	executorRun = func(path string, env []string, emitter screwdriver.Emitter, build screwdriver.Build, api screwdriver.API, buildID int, shellBin string, timeout int) error {
 		return nil
 	}
 	cleanExit = func() {}
@@ -493,7 +493,7 @@ func TestUpdateBuildNonZeroFailure(t *testing.T) {
 
 	oldRun := executorRun
 	defer func() { executorRun = oldRun }()
-	executorRun = func(path string, env []string, out screwdriver.Emitter, build screwdriver.Build, a screwdriver.API, buildID int, shellBin string) error {
+	executorRun = func(path string, env []string, out screwdriver.Emitter, build screwdriver.Build, a screwdriver.API, buildID int, shellBin string, timeout int) error {
 		return executor.ErrStatus{Status: 1}
 	}
 
@@ -700,7 +700,7 @@ func TestSetEnv(t *testing.T) {
 	}
 
 	foundEnv := map[string]string{}
-	executorRun = func(path string, env []string, emitter screwdriver.Emitter, build screwdriver.Build, api screwdriver.API, buildID int, shellBin string) error {
+	executorRun = func(path string, env []string, emitter screwdriver.Emitter, build screwdriver.Build, api screwdriver.API, buildID int, shellBin string, timeout int) error {
 		if len(env) == 0 {
 			t.Fatalf("Unexpected empty environment passed to executorRun")
 		}
@@ -749,7 +749,7 @@ func TestEnvSecrets(t *testing.T) {
 	foundEnv := map[string]string{}
 	oldExecutorRun := executorRun
 	defer func() { executorRun = oldExecutorRun }()
-	executorRun = func(path string, env []string, emitter screwdriver.Emitter, build screwdriver.Build, api screwdriver.API, buildID int, shellBin string) error {
+	executorRun = func(path string, env []string, emitter screwdriver.Emitter, build screwdriver.Build, api screwdriver.API, buildID int, shellBin string, timeout int) error {
 		if len(env) == 0 {
 			t.Fatalf("Unexpected empty environment passed to executorRun")
 		}


### PR DESCRIPTION
## Context

This is an initial proposal for killing a build after a period of time so they're not eating up system resources.

Further revisions will include:
* The ability to change the timeout limit
* Enforce a range of 15 minutes - 10 hours

## Objective

Use a non-modifiable build timeout for killing builds that take longer than 90 minutes.

## References 

* [Build Timeout issue](screwdriver-cd/screwdriver#545)