### PR TITLE
fix: Make the binary static

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,8 +8,10 @@ builds:
       - amd64
     # Include the default settings from https://goreleaser.com/#builds
     # Also include static compilation
-    ldflags: -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -extldflags "-static"
-
+    ldflags: -d -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -extldflags "-static"
+    # Ensure the binary is static
+    env:
+      - CGO_ENABLED=0
 archive:
   format: binary
   name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"


### PR DESCRIPTION
This removes the dependency on local libraries.  Basically making it work in an alpine container.

```
  -d	disable dynamic executable
  -s	disable symbol table
  -w	disable DWARF generation
```

Also disable C linking: https://golang.org/cmd/cgo/