### PR TITLE
fix: add path to teardown bookends

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -118,7 +118,7 @@ func doRunCommand(guid, path string, emitter screwdriver.Emitter, f *os.File, fR
 // Executes teardown commands
 func doRunTeardownCommand(cmd screwdriver.CommandDef, emitter screwdriver.Emitter, env []string, path, shellBin string) (int, error) {
 	shargs := []string{"-e", "-c"}
-	shargs = append(shargs, cmd.Cmd)
+	shargs = append(shargs, "PATH=$PATH:/opt/sd && " + cmd.Cmd)
 	c := exec.Command(shellBin, shargs...)
 
 	emitter.StartCmd(cmd)
@@ -139,6 +139,7 @@ func doRunTeardownCommand(cmd screwdriver.CommandDef, emitter screwdriver.Emitte
 
 			return waitStatus.ExitStatus(), ErrStatus{waitStatus.ExitStatus()}
 		}
+
 		return ExitUnknown, fmt.Errorf("Running command %q: %v", cmd.Cmd, err)
 	}
 


### PR DESCRIPTION
Each teardown bookend runs in a separate shell. So we need to reappend the `PATH`, otherwise it doesn't have access to `sd-step` and other things inside `/opt/sd`