### PR TITLE
fix: export $PATH

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -118,7 +118,7 @@ func doRunCommand(guid, path string, emitter screwdriver.Emitter, f *os.File, fR
 // Executes teardown commands
 func doRunTeardownCommand(cmd screwdriver.CommandDef, emitter screwdriver.Emitter, env []string, path, shellBin string) (int, error) {
 	shargs := []string{"-e", "-c"}
-	shargs = append(shargs, "PATH=$PATH:/opt/sd && " + cmd.Cmd)
+	shargs = append(shargs, "export PATH=$PATH:/opt/sd && " + cmd.Cmd)
 	c := exec.Command(shellBin, shargs...)
 
 	emitter.StartCmd(cmd)
@@ -215,7 +215,7 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 	// Run setup commands
 	setupCommands := []string{
 		"set -e",
-		"PATH=$PATH:/opt/sd",
+		"export PATH=$PATH:/opt/sd",
 		"finish() { echo $SD_STEP_ID $?; }",
 		"trap finish EXIT;\n",
 	}


### PR DESCRIPTION
In the artifact-bookend, one of the cmd is doing `find .... -exec sh` which starts a new child process and loses the context of PATH. To make PATH available inside that cmd, we need to do export it.

Related PR: https://github.com/screwdriver-cd/artifact-bookend/pull/19