### PR TITLE
fix: pull in new sd-cmd

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,4 +1,3 @@
-
 shared:
     image: golang
     environment:


### PR DESCRIPTION
Pull in new sd-cmd to use habitat format sd-cmd.
Related: https://github.com/screwdriver-cd/sd-cmd/pull/18 