### PR TITLE
fix(1015): Deep merge metadata for join jobs

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/peterbourgon/mergemap"
 	"github.com/screwdriver-cd/launcher/executor"
 	"github.com/screwdriver-cd/launcher/screwdriver"
 	"gopkg.in/fatih/color.v1"
@@ -28,6 +29,7 @@ var (
 	date    = "unknown"
 )
 
+var deepMergeJSON = mergemap.Merge
 var mkdirAll = os.MkdirAll
 var stat = os.Stat
 var open = os.Open
@@ -251,10 +253,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 					return fmt.Errorf("Fetching Parent Build ID %d: %v", pbID, err)
 				}
 
-				// Save meta to mergedMeta object
-				for key, value := range pb.Meta {
-					mergedMeta[key] = value
-				}
+				mergedMeta = deepMergeJSON(pb.Meta, mergedMeta)
 			}
 
 			log.Printf("Marshalling Merged Meta JSON %v", parentBuildIDs)

--- a/launch_test.go
+++ b/launch_test.go
@@ -991,12 +991,25 @@ func TestFetchParentBuildsMeta(t *testing.T) {
 	for i, s := range TestParentBuildIDs {
 		IDs[i] = s
 	}
+	TestMetaDeep1 := map[string]interface{}{
+		"cat":  "meow",
+		"bird": "chirp",
+	}
+	TestMetaDeep2 := map[string]interface{}{
+		"dog":  "woof",
+		"bird": "twitter",
+	}
+	ExpectedMetaDeep := map[string]interface{}{
+		"cat":  "meow",
+		"dog":  "woof",
+		"bird": "chirp",
+	}
 	TestMeta1 := map[string]interface{}{
-		"foo":    "bar",
+		"foo":    TestMetaDeep1,
 		"batman": "robin",
 	}
 	TestMeta2 := map[string]interface{}{
-		"foo":    "baz",
+		"foo":    TestMetaDeep2,
 		"wonder": "woman",
 	}
 
@@ -1020,8 +1033,8 @@ func TestFetchParentBuildsMeta(t *testing.T) {
 
 	_ = launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin, TestBuildTimeout)
 
-	if actual["foo"] != "baz" {
-		t.Errorf("Error is wrong, got '%v', expected '%v'", actual["foo"], "baz")
+	if !reflect.DeepEqual(actual["foo"], ExpectedMetaDeep) {
+		t.Errorf("Error is wrong, got '%v', expected '%v'", actual["foo"], ExpectedMetaDeep)
 	}
 	if actual["batman"] != "robin" {
 		t.Errorf("Error is wrong, got '%v', expected '%v'", actual["batman"], "robin")


### PR DESCRIPTION
## Context
Currently only the first layer of JSON is merged when parallel jobs are joined together. Deeper layers replace each other. 

## Objective
This PR uses a deep merge so that all parts of the metadata are preserved.

_Note: One caveat is that the second job will not overwrite the first's metadata if they have the same key. I think it's okay to have this behavior, since users cannot reasonably expect a certain result if they override the same meta key._

## Related links
- Resolves https://github.com/screwdriver-cd/screwdriver/issues/1015
- Golang package: https://godoc.org/github.com/peterbourgon/mergemap