### PR TITLE
fix: Add SD_META env variable

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -376,6 +376,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		"SD_SOURCE_DIR":          w.Src,
 		"SD_ROOT_DIR":            w.Root,
 		"SD_ARTIFACTS_DIR":       w.Artifacts,
+		"SD_META_PATH":           metaSpace + "/" + metaFile,
 		"SD_API_URL":             apiURL,
 		"SD_BUILD_URL":           apiURL + "builds/" + strconv.Itoa(buildID),
 		"SD_BUILD_SHA":           build.SHA,

--- a/launch.go
+++ b/launch.go
@@ -372,6 +372,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		"SD_PIPELINE_ID":         strconv.Itoa(job.PipelineID),
 		"SD_EVENT_ID":            strconv.Itoa(build.EventID),
 		"SD_JOB_NAME":            oldJobName,
+		"SD_PIPELINE_NAME":       pipeline.ScmRepo.Name,
 		"SD_PULL_REQUEST":        pr,
 		"SD_SOURCE_DIR":          w.Src,
 		"SD_ROOT_DIR":            w.Root,

--- a/launch_test.go
+++ b/launch_test.go
@@ -690,6 +690,7 @@ func TestSetEnv(t *testing.T) {
 		"CI":          "true",
 		"CONTINUOUS_INTEGRATION": "true",
 		"SD_JOB_NAME":            "PR-1",
+		"SD_PIPELINE_NAME":       "screwdriver-cd/launcher",
 		"SD_PIPELINE_ID":         "3456",
 		"SD_PULL_REQUEST":        "1",
 		"SD_SOURCE_DIR":          "/sd/workspace/src/github.com/screwdriver-cd/launcher",

--- a/launch_test.go
+++ b/launch_test.go
@@ -694,6 +694,7 @@ func TestSetEnv(t *testing.T) {
 		"SD_PULL_REQUEST":        "1",
 		"SD_SOURCE_DIR":          "/sd/workspace/src/github.com/screwdriver-cd/launcher",
 		"SD_ARTIFACTS_DIR":       "/sd/workspace/artifacts",
+		"SD_META_PATH":           "./data/meta/meta.json",
 		"SD_BUILD_ID":            "1234",
 		"SD_BUILD_SHA":           "abc123",
 		"SD_STORE_URL":           "http://store.screwdriver.cd/v1/",


### PR DESCRIPTION
## Context
Some users would like to know what's in their metadata at the end of each build.

## Objective
This PR exposes a path to the metadata file so users can cat it out or save it to artifacts if they choose.

Notes: Not sure what's a better name for it since there's already SD_ARTIFACTS_DIR, SD_SOURCE_DIR, SD_SOURCE_PATHS. Some ideas:
- SD_META
- SD_META_DIR
- SD_META_PATH
- SD_META_FILE
???

## Related links
- Related to https://github.com/screwdriver-cd/launcher/pull/174
- Current environment variables: https://docs.screwdriver.cd/user-guide/environment-variables