### PR TITLE
fix: defer emitter creation to container start-up

### DIFF
--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Create FIFO for emitter
+# https://github.com/screwdriver-cd/screwdriver/issues/979
+mkfifo -m 666 /opt/sd/emitter
+
+# Entrypoint
+/opt/sd/tini -- /opt/sd/launch "$@"

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,13 +76,14 @@ RUN set -x \
    && find /hab -name docs -exec rm -r {} + \
    && find /hab -name man -exec rm -r {} + \
 
-   # Create FIFO
-   && mkfifo -m 666 emitter \
    # Cleanup packages
    && apk del --purge .build-dependencies
+
+# Copy entrypoint script into /opt/sd/
+COPY Docker/launcher_entrypoint.sh /opt/sd/launcher_entrypoint.sh
 
 VOLUME /opt/sd
 VOLUME /hab
 
 # Set Entrypoint
-ENTRYPOINT ["/opt/sd/tini", "--", "/opt/sd/launch"]
+ENTRYPOINT ["/opt/sd/launcher_entrypoint.sh"]


### PR DESCRIPTION
## Context

Docker 1.18 is unsupported due to a dependency's-dependency update in `containerd/continuity` where it fails to handle fifos files (which the `emitter` is).

## Objective 

Create the FIFO emitter at container start-up instead of creating it during the Docker image compilation. This should address issues with Docker 1.18 being unable to handle fifos files

Fixes screwdriver-cd/screwdriver#979

## References

* screwdriver-cd/screwdriver#979