### PR TITLE
refactor docker entrypoint command

### DIFF
--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Create FIFO for emitter
+# https://github.com/screwdriver-cd/screwdriver/issues/979
+mkfifo -m 666 /opt/sd/emitter
+
+# Entrypoint
+/opt/sd/tini -- /bin/sh -c "$@"


### PR DESCRIPTION
## Context

We want the Docker entrypoint script to be what the executor's entrypoint is hardcode at (e.g., https://github.com/screwdriver-cd/executor-k8s/blob/master/config/pod.yaml.tim#L21). This way, we can incorporate some pre-launch steps before starting the `launcher` and `logservice` processes. 

This needs either a *major* or a *minor* version bump

## Objective

Update the command to perform the exact same command that all (as of today) executor libraries use to initiate the build.

## Reference

* screwdriver-cd/screwdriver#979
* Executor entrypoints
   * `executor-k8s` - https://github.com/screwdriver-cd/executor-k8s/blob/master/config/pod.yaml.tim#L21
   * `hyperctl-image` - https://github.com/screwdriver-cd/hyperctl-image/blob/master/scripts/hyper-pod-template.json#L12