### PR TITLE
feat(1084): Add Sonar coverage env vars [2]

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -51,6 +51,10 @@ func (f MockAPI) GetAPIURL() (string, error) {
 	return "http://foo.bar", nil
 }
 
+func (f MockAPI) GetCoverageInfo() (screwdriver.Coverage, error) {
+	return screwdriver.Coverage{}, nil
+}
+
 func (f MockAPI) UpdateStepStart(buildID int, stepName string) error {
 	if f.updateStepStart != nil {
 		return f.updateStepStart(buildID, stepName)

--- a/launch.go
+++ b/launch.go
@@ -384,6 +384,17 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		"SD_STORE_URL":           fmt.Sprintf("%s/%s/", storeURL, "v1"),
 	}
 
+	// Add coverage env vars
+	coverageInfo, err := api.GetCoverageInfo()
+	if err != nil {
+		return fmt.Errorf("Getting coverage info for build %v", build.ID)
+	}
+
+	for key, value := range coverageInfo.EnvVars {
+		defaultEnv[key] = value
+	}
+
+	// Get secrets for build
 	secrets, err := api.SecretsForBuild(build)
 	if err != nil {
 		return fmt.Errorf("Fetching secrets for build %v", build.ID)

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -225,6 +225,71 @@ func TestEventFromID(t *testing.T) {
 	}
 }
 
+func TestGetCoverageInfo(t *testing.T) {
+	envVars := map[string]string{
+		"SD_SONAR_AUTH_URL": "https://api.screwdriver.cd/v4/coverage/token",
+		"SD_SONAR_HOST":     "https://sonar.screwdriver.cd",
+	}
+	tests := []struct {
+		coverage   Coverage
+		statusCode int
+		err        error
+	}{
+		{
+			coverage: Coverage{
+				EnvVars: envVars,
+			},
+			statusCode: 200,
+			err:        nil,
+		},
+		{
+			coverage:   Coverage{},
+			statusCode: 500,
+			err: errors.New("After 5 attempts, Last error: " +
+				"GET retries exhausted: 500 returned from GET http://fakeurl/v4//coverage/info"),
+		},
+		{
+			coverage:   Coverage{},
+			statusCode: 404,
+			err: SDError{
+				StatusCode: 404,
+				Reason:     "Not Found",
+				Message:    "Coverage info does not exist",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		JSON := []byte{}
+		err := errors.New("")
+
+		if reflect.TypeOf(test.err) == reflect.TypeOf(SDError{}) {
+			JSON, err = json.Marshal(test.err)
+			if err != nil {
+				t.Fatalf("Unable to Marshal JSON for SDErr: %v", err)
+			}
+		} else {
+			JSON, err = json.Marshal(test.coverage)
+			if err != nil {
+				t.Fatalf("Unable to Marshal JSON for SDErr: %v", err)
+			}
+		}
+
+		http := makeFakeHTTPClient(t, test.statusCode, string(JSON))
+		testAPI := api{"http://fakeurl", "faketoken", http}
+
+		coverage, err := testAPI.GetCoverageInfo()
+
+		if !reflect.DeepEqual(err, test.err) {
+			t.Errorf("Unexpected error from GetCoverageInfo: \n%v\n want \n%v", err.Error(), test.err.Error())
+		}
+
+		if !reflect.DeepEqual(coverage, test.coverage) {
+			t.Errorf("coverage == %#v, want %#v", coverage, test.coverage)
+		}
+	}
+}
+
 func TestJobFromID(t *testing.T) {
 	tests := []struct {
 		job        Job


### PR DESCRIPTION
## Context
Calling Screwdriver API to get env vars from coverage plugins

## Related links
Blocked by https://github.com/screwdriver-cd/coverage-sonar/pull/7
Related to https://github.com/screwdriver-cd/screwdriver/issues/1084