### PR TITLE
Revert "fix: defer emitter creation to container start-up"

### DIFF
--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-# Create FIFO for emitter
-# https://github.com/screwdriver-cd/screwdriver/issues/979
-mkfifo -m 666 /opt/sd/emitter
-
-# Entrypoint
-/opt/sd/tini -- /opt/sd/launch "$@"

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,14 +76,13 @@ RUN set -x \
    && find /hab -name docs -exec rm -r {} + \
    && find /hab -name man -exec rm -r {} + \
 
+   # Create FIFO
+   && mkfifo -m 666 emitter \
    # Cleanup packages
    && apk del --purge .build-dependencies
-
-# Copy entrypoint script into /opt/sd/
-COPY Docker/launcher_entrypoint.sh /opt/sd/launcher_entrypoint.sh
 
 VOLUME /opt/sd
 VOLUME /hab
 
 # Set Entrypoint
-ENTRYPOINT ["/opt/sd/launcher_entrypoint.sh"]
+ENTRYPOINT ["/opt/sd/tini", "--", "/opt/sd/launch"]


### PR DESCRIPTION
## Context
I'd like to fix the launcher so I can test out my change (https://github.com/screwdriver-cd/launcher/pull/180) but the launcher is broken from Darren's change, screwdriver-cd/launcher#177 (> v4.0.103).

See Darren's comment https://github.com/screwdriver-cd/screwdriver/issues/979#issuecomment-394546810

## Objective
Reverts screwdriver-cd/launcher#177

