### PR TITLE
fix(1084): Remove extra slash

### DIFF
--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -296,7 +296,7 @@ func (a api) GetAPIURL() (string, error) {
 
 // Get coverage object with coverage information
 func (a api) GetCoverageInfo() (coverage Coverage, err error) {
-	url, err := a.makeURL(fmt.Sprintf("/coverage/info"))
+	url, err := a.makeURL(fmt.Sprintf("coverage/info"))
 	body, err := a.get(url)
 	if err != nil {
 		return coverage, err

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -246,7 +246,7 @@ func TestGetCoverageInfo(t *testing.T) {
 			coverage:   Coverage{},
 			statusCode: 500,
 			err: errors.New("After 5 attempts, Last error: " +
-				"GET retries exhausted: 500 returned from GET http://fakeurl/v4//coverage/info"),
+				"GET retries exhausted: 500 returned from GET http://fakeurl/v4/coverage/info"),
 		},
 		{
 			coverage:   Coverage{},


### PR DESCRIPTION
Remove extra slash in coverage/info endpoint

Related to https://github.com/screwdriver-cd/screwdriver/issues/1084