### PR TITLE
fix: allow to use API without coverage plugin

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -387,7 +387,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 	// Add coverage env vars
 	coverageInfo, err := api.GetCoverageInfo()
 	if err != nil {
-		return fmt.Errorf("Getting coverage info for build %v", build.ID)
+		log.Printf("Failed to get coverage info for build %v so skip it\n", build.ID)
 	}
 
 	for key, value := range coverageInfo.EnvVars {

--- a/launch.go
+++ b/launch.go
@@ -388,10 +388,10 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 	coverageInfo, err := api.GetCoverageInfo()
 	if err != nil {
 		log.Printf("Failed to get coverage info for build %v so skip it\n", build.ID)
-	}
-
-	for key, value := range coverageInfo.EnvVars {
-		defaultEnv[key] = value
+	} else {
+		for key, value := range coverageInfo.EnvVars {
+			defaultEnv[key] = value
+		}
 	}
 
 	// Get secrets for build

--- a/launch_test.go
+++ b/launch_test.go
@@ -712,6 +712,8 @@ func TestSetEnv(t *testing.T) {
 		"SD_BUILD_ID":            "1234",
 		"SD_BUILD_SHA":           "abc123",
 		"SD_STORE_URL":           "http://store.screwdriver.cd/v1/",
+		"SD_SONAR_AUTH_URL":      "https://api.screwdriver.cd/v4/coverage/token",
+		"SD_SONAR_HOST":          "https://sonar.screwdriver.cd",
 	}
 
 	api := mockAPI(t, TestBuildID, TestJobID, TestPipelineID, "RUNNING")
@@ -737,6 +739,21 @@ func TestSetEnv(t *testing.T) {
 	}
 
 	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin, TestBuildTimeout)
+	if err != nil {
+		t.Fatalf("Unexpected error from launch: %v", err)
+	}
+	for k, v := range tests {
+		if foundEnv[k] != v {
+			t.Fatalf("foundEnv[%s] = %s, want %s", k, foundEnv[k], v)
+		}
+	}
+
+	// in case of no coverage plugins
+	delete(tests, "SD_SONAR_AUTH_URL")
+	delete(tests, "SD_SONAR_HOST")
+	TestEnvVars = map[string]string{}
+	foundEnv = map[string]string{}
+	err = launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin, TestBuildTimeout)
 	if err != nil {
 		t.Fatalf("Unexpected error from launch: %v", err)
 	}


### PR DESCRIPTION
Launcher failed to launch a build by getting coverage info failure with API which doesn't have coverage plugin.  
This PR allows to use API without coverage plugin.