### PR TITLE
[3] feat(1113): Write event meta if it exists

### DIFF
--- a/launch_test.go
+++ b/launch_test.go
@@ -1044,8 +1044,8 @@ func TestFetchParentBuildsMeta(t *testing.T) {
 		"wonder": "woman",
 	}
 
-	oldWriteFile := writeFile
-	defer func() { writeFile = oldWriteFile }()
+	oldMarshal := marshal
+	defer func() { marshal = oldMarshal }()
 
 	api := mockAPI(t, TestBuildID, TestJobID, 0, "RUNNING")
 	api.buildFromID = func(buildID int) (screwdriver.Build, error) {
@@ -1098,6 +1098,9 @@ func TestFetchParentEventMetaWriteError(t *testing.T) {
 	oldWriteFile := writeFile
 	defer func() { writeFile = oldWriteFile }()
 
+	oldMarshal := marshal
+	defer func() { marshal = oldMarshal }()
+
 	api := mockAPI(t, TestEventID, TestJobID, 0, "RUNNING")
 	api.eventFromID = func(eventID int) (screwdriver.Event, error) {
 		if eventID == TestParentEventID {
@@ -1126,6 +1129,62 @@ func TestFetchParentEventMetaWriteError(t *testing.T) {
 
 	err := launch(screwdriver.API(api), TestEventID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin, TestBuildTimeout)
 	expected := fmt.Sprintf(`Writing Parent Event(%d) Meta JSON: Testing writing parent event meta`, TestParentEventID)
+
+	if err.Error() != expected {
+		t.Errorf("Error is wrong, got '%v', expected '%v'", err, expected)
+	}
+}
+
+func TestFetchEventMeta(t *testing.T) {
+	oldWriteFile := writeFile
+	defer func() { writeFile = oldWriteFile }()
+
+	mockMeta := make(map[string]interface{})
+	mockMeta["spooky"] = "ghost"
+	var eventMeta []byte
+
+	api := mockAPI(t, TestBuildID, TestJobID, 0, "RUNNING")
+	api.eventFromID = func(eventID int) (screwdriver.Event, error) {
+		if eventID == TestEventID {
+			return screwdriver.Event(FakeEvent{ID: TestEventID, Meta:mockMeta}), nil
+		}
+		return screwdriver.Event(FakeEvent{ID: TestEventID, ParentEventID: TestParentEventID}), nil
+	}
+	writeFile = func(path string, data []byte, perm os.FileMode) (err error) {
+		if path == "./data/meta/meta.json" {
+			eventMeta = data
+		}
+		return nil
+	}
+
+	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin, TestBuildTimeout)
+	want := []byte("{\"spooky\":\"ghost\"}")
+
+	if err != nil || string(eventMeta) != string(want) {
+		t.Errorf("Expected eventMeta is %v, but: %v", want, eventMeta)
+	}
+}
+
+func TestFetchEventMetaMarshalError(t *testing.T) {
+	oldMarshal := marshal
+	defer func() { marshal = oldMarshal }()
+
+	mockMeta := make(map[string]interface{})
+	mockMeta["spooky"] = "ghost"
+
+	api := mockAPI(t, TestBuildID, TestJobID, 0, "RUNNING")
+	api.eventFromID = func(eventID int) (screwdriver.Event, error) {
+		if eventID == TestEventID {
+			return screwdriver.Event(FakeEvent{ID: TestEventID, Meta: mockMeta}), nil
+		}
+		return screwdriver.Event(FakeEvent{ID: TestEventID, ParentEventID: TestParentEventID}), nil
+	}
+	marshal = func(v interface{}) (result []byte, err error) {
+		return nil, fmt.Errorf("Testing parsing event meta")
+	}
+
+	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestShellBin, TestBuildTimeout)
+	expected := fmt.Sprintf(`Parsing Event(%d) Meta JSON: Testing parsing event meta`, TestEventID)
 
 	if err.Error() != expected {
 		t.Errorf("Error is wrong, got '%v', expected '%v'", err, expected)


### PR DESCRIPTION
## Context

Since we are supporting `meta` as a payload attribute for POST `v4/events`, we need to write that value  into `metaFile` as part of the launch process

## Objective

If the event contains `meta` it should be written into `/sd/meta/meta.json`. 

If for some reason the event contains `meta` AND it has a `parentEventId` OR `parentBuildId`. The `meta` of the parents should take precedence.

Additionally cleaning up a few other tests.

## Reference
https://github.com/screwdriver-cd/screwdriver/issues/1113