### PR TITLE
[DNM] fix: allow blocked status

### DIFF
--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -25,6 +25,7 @@ const (
 	Success             = "SUCCESS"
 	Failure             = "FAILURE"
 	Aborted             = "ABORTED"
+	Blocked             = "BLOCKED"
 )
 
 const maxAttempts = 5
@@ -384,6 +385,7 @@ func (a api) UpdateBuildStatus(status BuildStatus, meta map[string]interface{}, 
 	case Success:
 	case Failure:
 	case Aborted:
+	case Blocked:
 	default:
 		return fmt.Errorf("Invalid build status: %s", status)
 	}


### PR DESCRIPTION
Needs this so that `BLOCKED` can proceed to `RUNNING`
Related: https://github.com/screwdriver-cd/screwdriver/issues/653