### PR TITLE
feat: support user-teardown

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -189,8 +189,8 @@ func filterTeardowns(build screwdriver.Build) ([]screwdriver.CommandDef, []screw
 	userTeardownCommands := []screwdriver.CommandDef{}
 
 	for _, cmd := range build.Commands {
-		isSdTeardown, _ := regexp.MatchString("sd-teardown-*", cmd.Name)
-		isUserTeardown, _ := regexp.MatchString("teardown-*", cmd.Name)
+		isSdTeardown, _ := regexp.MatchString("^sd-teardown-*", cmd.Name)
+		isUserTeardown, _ := regexp.MatchString("^teardown-*", cmd.Name)
 
 		if isSdTeardown {
 			sdTeardownCommands = append(sdTeardownCommands, cmd)

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -190,7 +190,7 @@ func filterTeardowns(build screwdriver.Build) ([]screwdriver.CommandDef, []screw
 
 	for _, cmd := range build.Commands {
 		isSdTeardown, _ := regexp.MatchString("sd-teardown-*", cmd.Name)
-		isUserTeardown, _ := regexp.MatchString("user-teardown-*", cmd.Name)
+		isUserTeardown, _ := regexp.MatchString("teardown-*", cmd.Name)
 
 		if isSdTeardown {
 			sdTeardownCommands = append(sdTeardownCommands, cmd)

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -183,21 +183,25 @@ func handleBuildTimeout(f *os.File, timeoutErr error) {
 	f.Write([]byte{4})
 }
 
-func filterTeardowns(build screwdriver.Build) ([]screwdriver.CommandDef, []screwdriver.CommandDef) {
+func filterTeardowns(build screwdriver.Build) ([]screwdriver.CommandDef, []screwdriver.CommandDef, []screwdriver.CommandDef) {
 	userCommands := []screwdriver.CommandDef{}
-	teardownCommands := []screwdriver.CommandDef{}
+	sdTeardownCommands := []screwdriver.CommandDef{}
+	userTeardownCommands := []screwdriver.CommandDef{}
 
 	for _, cmd := range build.Commands {
-		isTeardown, _ := regexp.MatchString("sd-teardown-*", cmd.Name)
+		isSdTeardown, _ := regexp.MatchString("sd-teardown-*", cmd.Name)
+		isUserTeardown, _ := regexp.MatchString("user-teardown-*", cmd.Name)
 
-		if isTeardown {
-			teardownCommands = append(teardownCommands, cmd)
+		if isSdTeardown {
+			sdTeardownCommands = append(sdTeardownCommands, cmd)
+		} else if isUserTeardown {
+			userTeardownCommands = append(userTeardownCommands, cmd)
 		} else {
 			userCommands = append(userCommands, cmd)
 		}
 	}
 
-	return userCommands, teardownCommands
+	return userCommands, sdTeardownCommands, userTeardownCommands
 }
 
 // Run executes a slice of CommandDefs
@@ -233,7 +237,7 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 	// start build timeout timer
 	go initBuildTimeout(timeout, invokeTimeout)
 
-	userCommands, teardownCommands := filterTeardowns(build)
+	userCommands, sdTeardownCommands, userTeardownCommands := filterTeardowns(build)
 
 	for _, cmd := range userCommands {
 		// Start set up & user steps if previous steps succeed
@@ -289,6 +293,8 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 			return fmt.Errorf("Updating step stop %q: %v", cmd.Name, err)
 		}
 	}
+
+	teardownCommands := append(userTeardownCommands, sdTeardownCommands...);
 
 	for index, cmd := range teardownCommands {
 		if index == 0 && firstError == nil {

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -206,7 +206,7 @@ func TestUnmockedMulti(t *testing.T) {
 		{Cmd: "export FOO=BAR", Name: "test export env"},
 		{Cmd: `if [ -z "$FOO" ] ; then exit 1; fi`, Name: "test if env set"},
 		{Cmd: "doesnotexit", Name: "test doesnotexit err"},
-		{Cmd: "echo user teardown step", Name: "user-teardown-echo"},
+		{Cmd: "echo user teardown step", Name: "teardown-echo"},
 		{Cmd: "sleep 1", Name: "test sleep 1"},
 		{Cmd: "echo upload artifacts", Name: "sd-teardown-artifacts"},
 	}
@@ -240,7 +240,7 @@ func TestUnmockedMulti(t *testing.T) {
 			if stepName == "test sleep 1" {
 				t.Errorf("Should not update step that never run: %v", stepName)
 			}
-			if stepName == "user-teardown-echo" {
+			if stepName == "teardown-echo" {
 				runUserTeardown = true
 			}
 			if stepName == "sd-teardown-artifacts" {

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -206,6 +206,7 @@ func TestUnmockedMulti(t *testing.T) {
 		{Cmd: "export FOO=BAR", Name: "test export env"},
 		{Cmd: `if [ -z "$FOO" ] ; then exit 1; fi`, Name: "test if env set"},
 		{Cmd: "doesnotexit", Name: "test doesnotexit err"},
+		{Cmd: "echo user teardown step", Name: "user-teardown-echo"},
 		{Cmd: "sleep 1", Name: "test sleep 1"},
 		{Cmd: "echo upload artifacts", Name: "sd-teardown-artifacts"},
 	}
@@ -215,6 +216,7 @@ func TestUnmockedMulti(t *testing.T) {
 		Environment: map[string]string{},
 	}
 	runTeardown := false
+	runUserTeardown := false
 	testAPI := screwdriver.API(MockAPI{
 		updateStepStart: func(buildID int, stepName string) error {
 			if buildID != testBuild.ID {
@@ -222,6 +224,9 @@ func TestUnmockedMulti(t *testing.T) {
 			}
 			if stepName == "test sleep 1" {
 				t.Errorf("step should never execute: %v", stepName)
+			}
+			if stepName == "user-teardown-echo" {
+				runUserTeardown = true
 			}
 			if stepName == "sd-teardown-artifacts" {
 				runTeardown = true
@@ -235,6 +240,9 @@ func TestUnmockedMulti(t *testing.T) {
 			if stepName == "test sleep 1" {
 				t.Errorf("Should not update step that never run: %v", stepName)
 			}
+			if stepName == "user-teardown-echo" {
+				runUserTeardown = true
+			}
 			if stepName == "sd-teardown-artifacts" {
 				runTeardown = true
 			}
@@ -243,6 +251,9 @@ func TestUnmockedMulti(t *testing.T) {
 	})
 	err := Run("", nil, &MockEmitter{}, testBuild, testAPI, testBuild.ID, "/bin/sh", TestBuildTimeout)
 	expectedErr := fmt.Errorf("Launching command exit with code: %v", 127)
+	if !runUserTeardown {
+		t.Errorf("step user teardown should run")
+	}
 	if !runTeardown {
 		t.Errorf("step teardown should run")
 	}

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -225,7 +225,7 @@ func TestUnmockedMulti(t *testing.T) {
 			if stepName == "test sleep 1" {
 				t.Errorf("step should never execute: %v", stepName)
 			}
-			if stepName == "user-teardown-echo" {
+			if stepName == "teardown-echo" {
 				runUserTeardown = true
 			}
 			if stepName == "sd-teardown-artifacts" {


### PR DESCRIPTION
Allow user-defined teardown steps. They will be run in separate shells, just like the screwdriver teardown steps. 

_**Will look into passing environment variables in a second pass.**_ 

Related: https://github.com/screwdriver-cd/screwdriver/issues/1126