### PR TITLE
fix: copy optional entrypoint script to launcher image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,9 @@ RUN set -x \
    # Cleanup packages
    && apk del --purge .build-dependencies
 
+# Copy optional entrypoint script to the image
+COPY Docker/launcher_entrypoint.sh /opt/sd/launcher_entrypoint.sh
+
 VOLUME /opt/sd
 VOLUME /hab
 


### PR DESCRIPTION
Otherwise it won't work here: https://github.com/screwdriver-cd/executor-k8s/blob/master/config/pod.yaml.tim#L22