### PR TITLE
fix: Pass env to teardown

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -243,7 +243,7 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 		// trap EXIT, echo the last step ID and write ENV to /tmp/buildEnv
 		"finish() { " +
 		"EXITCODE=$?; " +
-		exportEnvCmd + " && " +
+		exportEnvCmd + "; " +
 		"echo $SD_STEP_ID $EXITCODE; }",    //mv newfile to file
 		"trap finish EXIT;\n",
 	}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -117,7 +117,7 @@ func doRunCommand(guid, path string, emitter screwdriver.Emitter, f *os.File, fR
 // Executes teardown commands
 func doRunTeardownCommand(cmd screwdriver.CommandDef, emitter screwdriver.Emitter, env []string, path, shellBin string, cleanup bool, envFilepath string) (int, error) {
 	shargs := []string{"-e", "-c"}
-	cmdStr := "export PATH=$PATH:/opt/sd && . " + envFilepath + "_export && " // source the file that exports ENV
+	cmdStr := "export PATH=$PATH:/opt/sd && sleep 5 && . " + envFilepath + "_export && " // source the file that exports ENV
 	cleanupCmd := "rm -f " + envFilepath + " && rm -f " + envFilepath + "_export && "
 	if (cleanup == true) {	// clean up the file
 		fmt.Printf("*******last teardown step, clean up...\n")

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -118,11 +118,14 @@ func doRunCommand(guid, path string, emitter screwdriver.Emitter, f *os.File, fR
 func doRunTeardownCommand(cmd screwdriver.CommandDef, emitter screwdriver.Emitter, env []string, path, shellBin string, cleanup bool, envFilepath string) (int, error) {
 	shargs := []string{"-e", "-c"}
 	cmdStr := "export PATH=$PATH:/opt/sd && . " + envFilepath + "_export && " // source the file that exports ENV
-	cleanupCmd := "rm -f " + envFilepath + " && rm -f " + envFilepath + "_export"
+	cleanupCmd := "rm -f " + envFilepath + " && rm -f " + envFilepath + "_export && "
 	if (cleanup == true) {	// clean up the file
-		cmdStr += cleanupCmd + " && "
+		fmt.Printf("*******last teardown step, clean up...\n")
+		cmdStr += cleanupCmd
 	}
 	cmdStr += cmd.Cmd
+
+	fmt.Printf("cmdStr %v\n", cmdStr)
 
 	shargs = append(shargs, cmdStr)
 	c := exec.Command(shellBin, shargs...)
@@ -323,6 +326,7 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 
 	// Previous user steps ran successfully and there is no teardown step to run, clean up
 	if len(teardownCommands) == 0 && firstError == nil {
+			fmt.Print("cleaning up ")
 			cleanupCmd := "rm -f " + envFilepath + " && rm -f " + envFilepath + "_export"
 			f.Write([]byte(cleanupCmd + "\n"))
 	}
@@ -338,7 +342,7 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 		}
 
 		// Run teardown commands
-		if (index == len(teardownCommands) -1) {
+		if (index == len(teardownCommands) - 1) {
 				// last teardown step, clean up env file
 				cleanup = true;
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -75,7 +75,7 @@ func copyLinesUntil(r io.Reader, w io.Writer, match string) (int, error) {
 		err    error
 		t      string
 		reader = bufio.NewReader(r)
-		// Match the guid and exitCodereExport
+		// Match the guid and exitCode
 		reExit = regexp.MustCompile(fmt.Sprintf("(%s) ([0-9]+)", match))
 		// Match the export SD_STEP_ID command
 		reExport = regexp.MustCompile("export SD_STEP_ID=(" + match + ")")
@@ -323,9 +323,8 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 		if index == 0 && firstError == nil {
 			fmt.Print("PREVIOUS COMMAND PASSED")
 			// Exit shell only if previous user steps ran successfully
-			f.Write([]byte(ExportEnvCmd))
-			f.Write([]byte("sleep 20"))
 			f.Write([]byte{4})
+			fmt.Print("CLOSED")
 		}
 
 		if err := api.UpdateStepStart(buildID, cmd.Name); err != nil {

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -117,9 +117,15 @@ func doRunCommand(guid, path string, emitter screwdriver.Emitter, f *os.File, fR
 // Executes teardown commands
 func doRunTeardownCommand(cmd screwdriver.CommandDef, emitter screwdriver.Emitter, env []string, path, shellBin string, cleanup bool, envFilepath string) (int, error) {
 	shargs := []string{"-e", "-c"}
-	cmdStr := "export PATH=$PATH:/opt/sd && sleep 5 && . " + envFilepath + "_export && " // source the file that exports ENV
+
+	// source the file that exports ENV
+	cmdStr := "export PATH=$PATH:/opt/sd && " +
+						"while ! [ -f " + envFilepath + "_export ]; do sleep 1; done;  && " +
+						". " + envFilepath + "_export && "
+
+	// clean up the files
 	cleanupCmd := "rm -f " + envFilepath + " && rm -f " + envFilepath + "_export && "
-	if (cleanup == true) {	// clean up the file
+	if (cleanup == true) {
 		fmt.Printf("*******last teardown step, clean up...\n")
 		cmdStr += cleanupCmd
 	}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -117,9 +117,9 @@ func doRunCommand(guid, path string, emitter screwdriver.Emitter, f *os.File, fR
 // Executes teardown commands
 func doRunTeardownCommand(cmd screwdriver.CommandDef, emitter screwdriver.Emitter, env []string, path, shellBin string, cleanup bool) (int, error) {
 	shargs := []string{"-e", "-c"}
-	cmdStr := "export PATH=$PATH:/opt/sd && . /tmp/buildEnv; " // source the file that exports ENV
+	cmdStr := "export PATH=$PATH:/opt/sd && . /tmp/exportEnv; " // source the file that exports ENV
 	if (cleanup == true) {	// clean up the file
-		cmdStr += "rm /tmp/buildEnv; "
+		cmdStr += "rm /tmp/exportEnv; "
 	}
 	cmdStr += cmd.Cmd
 
@@ -229,12 +229,12 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 		// trap EXIT, echo the last step ID and write ENV to /tmp/buildEnv
 		"finish() { " +
 		"echo $SD_STEP_ID $?; " +
-		"prefix='export '; file=/tmp/buildEnv; newfile=/tmp/exportEnv; env > $file; " +
-		"while read -r line; do \n" +
-		"escapeQuote=`echo $line | sed 's/\"/\\\\\\\"/g'`;\n" +	//escape double quote
-		"newline=`echo $newline | sed 's/\\([A-Z_][A-Z0-9_]*\\)=\\(.*\\)/\\1=\"\\2\"/'`;\n" +	// add double quote around
-		"echo ${prefix}$line; \n" +
-		"done < $file > $newfile; }",	//mv newfile to file
+    "prefix='export '; file=/tmp/buildEnv; newfile=/tmp/exportEnv; env > $file; " +
+    "while read -r line; do " +
+    "escapeQuote=`echo $line | sed 's/\"/\\\\\\\"/g'`;" +    //escape double quote
+    "newline=`echo $escapeQuote | sed 's/\\([A-Za-z_][A-Za-z0-9_]*\\)=\\(.*\\)/\\1=\"\\2\"/'`;" +    // add double quote around
+    "echo ${prefix}$newline; " +
+    "done < $file > $newfile; }",    //mv newfile to file
 		"trap finish EXIT;\n",
 	}
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -117,15 +117,10 @@ func doRunCommand(guid, path string, emitter screwdriver.Emitter, f *os.File, fR
 // Executes teardown commands
 func doRunTeardownCommand(cmd screwdriver.CommandDef, emitter screwdriver.Emitter, env []string, path, shellBin string, cleanup bool, envFilepath string) (int, error) {
 	shargs := []string{"-e", "-c"}
-
-	// source the file that exports ENV
-	cmdStr := "export PATH=$PATH:/opt/sd && " +
-						"while ! [ -f " + envFilepath + "_export ]; do sleep 1; done;  && " +
-						". " + envFilepath + "_export && "
-
-	// clean up the files
-	cleanupCmd := "rm -f " + envFilepath + " && rm -f " + envFilepath + "_export && "
-	if (cleanup == true) {
+	envExportFilepath := envFilepath + "_export"
+	cmdStr := "export PATH=$PATH:/opt/sd && while ! [ -f  "+ envExportFilepath + " ]; do sleep 1; done && . " + envExportFilepath + " && " // source the file that exports ENV
+	cleanupCmd := "rm -f " + envFilepath + " && rm -f " + envExportFilepath + " && "
+	if (cleanup == true) {	// clean up the file
 		fmt.Printf("*******last teardown step, clean up...\n")
 		cmdStr += cleanupCmd
 	}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -117,7 +117,7 @@ func doRunCommand(guid, path string, emitter screwdriver.Emitter, f *os.File, fR
 // Executes teardown commands
 func doRunTeardownCommand(cmd screwdriver.CommandDef, emitter screwdriver.Emitter, env []string, path, shellBin string, cleanup bool) (int, error) {
 	shargs := []string{"-e", "-c"}
-	cmdStr := "export PATH=$PATH:/opt/sd && . /tmp/def; " // source the file that exports ENV
+	cmdStr := "export PATH=$PATH:/opt/sd && . /tmp/buildEnv; " // source the file that exports ENV
 	if (cleanup == true) {	// clean up the file
 		cmdStr += "rm /tmp/buildEnv; "
 	}
@@ -229,12 +229,12 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 		// trap EXIT, echo the last step ID and write ENV to /tmp/buildEnv
 		"finish() { " +
 		"echo $SD_STEP_ID $?; " +
-		"prefix='export '; file=/tmp/abc; newfile=/tmp/def; env > $file; " +
+		"prefix='export '; file=/tmp/buildEnv; newfile=/tmp/exportEnv; env > $file; " +
 		"while read -r line; do \n" +
 		"escapeQuote=`echo $line | sed 's/\"/\\\\\\\"/g'`;\n" +	//escape double quote
 		"newline=`echo $newline | sed 's/\\([A-Z_][A-Z0-9_]*\\)=\\(.*\\)/\\1=\"\\2\"/'`;\n" +	// add double quote around
 		"echo ${prefix}$line; \n" +
-		"done < $file > $newfile; }",
+		"done < $file > $newfile; }",	//mv newfile to file
 		"trap finish EXIT;\n",
 	}
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -121,12 +121,9 @@ func doRunTeardownCommand(cmd screwdriver.CommandDef, emitter screwdriver.Emitte
 	cmdStr := "export PATH=$PATH:/opt/sd && while ! [ -f  "+ envExportFilepath + " ]; do sleep 1; done && . " + envExportFilepath + " && " // source the file that exports ENV
 	cleanupCmd := "rm -f " + envFilepath + " && rm -f " + envExportFilepath + " && "
 	if (cleanup == true) {	// clean up the file
-		fmt.Printf("*******last teardown step, clean up...\n")
 		cmdStr += cleanupCmd
 	}
 	cmdStr += cmd.Cmd
-
-	fmt.Printf("cmdStr %v\n", cmdStr)
 
 	shargs = append(shargs, cmdStr)
 	c := exec.Command(shellBin, shargs...)
@@ -245,7 +242,7 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 		"export PATH=$PATH:/opt/sd",
 		// trap EXIT, echo the last step ID and write ENV to /tmp/buildEnv
 		"finish() { " +
-    "EXITCODE=$?; " +
+		"EXITCODE=$?; " +
 		exportEnvCmd + " && " +
 		"echo $SD_STEP_ID $EXITCODE; }",    //mv newfile to file
 		"trap finish EXIT;\n",
@@ -327,9 +324,8 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 
 	// Previous user steps ran successfully and there is no teardown step to run, clean up
 	if len(teardownCommands) == 0 && firstError == nil {
-			fmt.Print("cleaning up ")
-			cleanupCmd := "rm -f " + envFilepath + " && rm -f " + envFilepath + "_export"
-			f.Write([]byte(cleanupCmd + "\n"))
+		cleanupCmd := "rm -f " + envFilepath + " && rm -f " + envFilepath + "_export"
+		f.Write([]byte(cleanupCmd + "\n"))
 	}
 
 	for index, cmd := range teardownCommands {
@@ -344,9 +340,8 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 
 		// Run teardown commands
 		if (index == len(teardownCommands) - 1) {
-				// last teardown step, clean up env file
-				cleanup = true;
-
+			// last teardown step, clean up env file
+			cleanup = true;
 		}
 
 		code, cmdErr = doRunTeardownCommand(cmd, emitter, env, path, shellBin, cleanup, envFilepath)

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -122,7 +122,6 @@ func doRunTeardownCommand(cmd screwdriver.CommandDef, emitter screwdriver.Emitte
 		"export PATH=$PATH:/opt/sd && " +
 		"file=/tmp/buildEnv; . $file; rm $file; " + // source the file that exports ENV
 		cmd.Cmd)
-
 	c := exec.Command(shellBin, shargs...)
 	emitter.StartCmd(cmd)
 	fmt.Fprintf(emitter, "$ %s\n", cmd.Cmd)
@@ -219,12 +218,11 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 	setupCommands := []string{
 		"set -e",
 		"export PATH=$PATH:/opt/sd",
-		// trap EXIT, echo the last step ID and export environment variables to /tmp/buildEnv
+		// trap EXIT, echo the last step ID and write ENV to /tmp/buildEnv
 		"finish() { " +
 		"echo $SD_STEP_ID $?; " +
 		"prefix='export '; file=/tmp/buildEnv; newfile=/tmp/exportBuildEnv; env > $file; " +
-		"while read -r line; do echo \"${prefix}$line\"; done < $file > $newfile; mv $newfile $file; " +
-		"	}",
+		"while read -r line; do echo ${prefix}$line; done < $file > $newfile; mv $newfile $file; }",
 		"trap finish EXIT;\n",
 	}
 	shargs := strings.Join(setupCommands, " && ")

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -128,7 +128,6 @@ func doRunTeardownCommand(cmd screwdriver.CommandDef, emitter screwdriver.Emitte
 	c := exec.Command(shellBin, shargs...)
 	emitter.StartCmd(cmd)
 	fmt.Fprintf(emitter, "$ %s\n", cmd.Cmd)
-
 	c.Stdout = emitter
 	c.Stderr = emitter
 	c.Dir = path
@@ -245,7 +244,6 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 	shargs := strings.Join(setupCommands, " && ")
 
 	f.Write([]byte(shargs))
-	// io.Copy(os.Stdout, f)
 
 	var firstError error
 	var code int
@@ -323,7 +321,6 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 			f.Write([]byte(cleanupCmd + "\n"))
 	}
 
-	// io.Copy(os.Stdout, f)
 	for index, cmd := range teardownCommands {
 		if index == 0 && firstError == nil {
 			// Exit shell only if previous user steps ran successfully

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -71,7 +71,6 @@ func copyLinesUntil(r io.Reader, w io.Writer, match string) (int, error) {
 		reExport = regexp.MustCompile("export SD_STEP_ID=(" + match + ")")
 	)
 	t, err = readln(reader)
-	// fmt.Printf("line is %v ", t)
 	for err == nil {
 		parts := reExit.FindStringSubmatch(t)
 		if len(parts) != 0 {
@@ -124,8 +123,6 @@ func doRunTeardownCommand(cmd screwdriver.CommandDef, emitter screwdriver.Emitte
 		cmdStr += cleanupCmd + " && "
 	}
 	cmdStr += cmd.Cmd
-
-	fmt.Println(cmdStr)
 
 	shargs = append(shargs, cmdStr)
 	c := exec.Command(shellBin, shargs...)
@@ -263,7 +260,6 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 	userCommands, sdTeardownCommands, userTeardownCommands := filterTeardowns(build)
 
 	for _, cmd := range userCommands {
-		fmt.Printf("%v\n", cmd.Cmd)
 		// Start set up & user steps if previous steps succeed
 		if firstError != nil {
 			break
@@ -323,17 +319,12 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 
 	// Previous user steps ran successfully and there is no teardown step to run, clean up
 	if len(teardownCommands) == 0 && firstError == nil {
-			fmt.Print("NO TEARDOWN------")
 			cleanupCmd := "rm -f " + envFilepath + " && rm -f " + envFilepath + "_export"
 			f.Write([]byte(cleanupCmd + "\n"))
-			// r := bufio.NewReader(f)
-			//
-			// copyLinesUntil(r, emitter, "1234")
 	}
 
 	// io.Copy(os.Stdout, f)
 	for index, cmd := range teardownCommands {
-		fmt.Print("HAS TEARDOWN------")
 		if index == 0 && firstError == nil {
 			// Exit shell only if previous user steps ran successfully
 			f.Write([]byte{4})

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -223,6 +223,12 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 	// Command to Export Env
 	exportEnvCmd :=
 	"prefix='export '; file="+ envFilepath + "; newfile=" + envFilepath + "_export; env > $file && " +
+
+	// Remove PS1, this gives some issues if exporting to ""
+	"sed '/^PS1=.*/d' $file > $newfile && " +
+	"mv $newfile $file && " +
+
+	// Loops through each line
 	"while read -r line; do " +
 	"escapeQuote=`echo $line | sed 's/\"/\\\\\\\"/g'` && " +    //escape double quote
 	"newline=`echo $escapeQuote | sed 's/\\([A-Za-z_][A-Za-z0-9_]*\\)=\\(.*\\)/\\1=\"\\2\"/'` && " +    // add double quote around

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -65,7 +65,7 @@ func copyLinesUntil(r io.Reader, w io.Writer, match string) (int, error) {
 		err    error
 		t      string
 		reader = bufio.NewReader(r)
-		// Match the guid and exitCode
+		// Match the guid and exitCodereExport
 		reExit = regexp.MustCompile(fmt.Sprintf("(%s) ([0-9]+)", match))
 		// Match the export SD_STEP_ID command
 		reExport = regexp.MustCompile("export SD_STEP_ID=(" + match + ")")
@@ -228,13 +228,14 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 		"export PATH=$PATH:/opt/sd",
 		// trap EXIT, echo the last step ID and write ENV to /tmp/buildEnv
 		"finish() { " +
-		"echo $SD_STEP_ID $?; " +
-    "prefix='export '; file=/tmp/buildEnv; newfile=/tmp/exportEnv; env > $file; " +
+    "EXITCODE=$? " +
+		"prefix='export '; file=/tmp/buildEnv; newfile=/tmp/exportEnv; env > $file; " +
     "while read -r line; do " +
     "escapeQuote=`echo $line | sed 's/\"/\\\\\\\"/g'`;" +    //escape double quote
     "newline=`echo $escapeQuote | sed 's/\\([A-Za-z_][A-Za-z0-9_]*\\)=\\(.*\\)/\\1=\"\\2\"/'`;" +    // add double quote around
     "echo ${prefix}$newline; " +
-    "done < $file > $newfile; }",    //mv newfile to file
+    "done < $file > $newfile; " +
+		"echo $SD_STEP_ID $EXITCODE; }",    //mv newfile to file
 		"trap finish EXIT;\n",
 	}
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -305,15 +305,12 @@ func TestTeardownEnv(t *testing.T) {
 	runSdTeardown := false
 	testAPI := screwdriver.API(MockAPI{
 		updateStepStart: func(buildID int, stepName string) error {
-			fmt.Printf("START %v\n", stepName)
 			if buildID != testBuild.ID {
 				t.Errorf("wrong build id got %v, want %v", buildID, testBuild.ID)
 			}
 			return nil
 		},
 		updateStepStop: func(buildID int, stepName string, code int) error {
-			fmt.Printf("STOP step %v code %v\n", stepName, code)
-			fmt.Printf("=========\n")
 			if buildID != testBuild.ID {
 				t.Errorf("wrong build id got %v, want %v", buildID, testBuild.ID)
 			}

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -159,7 +159,6 @@ func ReadCommand(file string) []string {
 
 func TestUnmocked(t *testing.T) {
 	envFilepath := "/tmp/testUnmocked"
-	setupTestCase(t, envFilepath)
 	var tests = []struct {
 		command string
 		err     error
@@ -177,6 +176,7 @@ func TestUnmocked(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		setupTestCase(t, envFilepath)
 		cmd := screwdriver.CommandDef{
 			Cmd:  test.command,
 			Name: "test",

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -132,8 +132,7 @@ func cleanup(filename string) {
 	_, err := os.Stat(filename)
 
 	if err == nil {
-		err := os.Remove(filename)
-		fmt.Printf("err removing file %v", err)
+		os.Remove(filename)
 	}
 }
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -278,13 +278,13 @@ func TestTeardownEnv(t *testing.T) {
 	runSdTeardown := false
 	testAPI := screwdriver.API(MockAPI{
 		updateStepStart: func(buildID int, stepName string) error {
-			fmt.Println(stepName)
 			if buildID != testBuild.ID {
 				t.Errorf("wrong build id got %v, want %v", buildID, testBuild.ID)
 			}
 			return nil
 		},
 		updateStepStop: func(buildID int, stepName string, code int) error {
+			fmt.Printf("%v %v", stepName, code)
 			if buildID != testBuild.ID {
 				t.Errorf("wrong build id got %v, want %v", buildID, testBuild.ID)
 			}

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -271,7 +271,7 @@ func TestTeardownEnv(t *testing.T) {
 		{Cmd: "echo bye", Name: "teardown-bye"},
 		{Cmd: "if [ \"$FOO\" != 'BAR with spaces' ]; then exit 1; fi", Name: "teardown-foo"},
 		{Cmd: "if [ \"$SINGLE_QUOTE\" != \"my ' single quote\" ]; then exit 1; fi", Name: "teardown-singlequote"},
-		{Cmd: "if [ \"$DOUBLE_QUOTE\" != \"my double quote\" ]; then exit 1; fi", Name: "sd-teardown-doublequote"},
+		{Cmd: "if [ \"$DOUBLE_QUOTE\" != \"my \\\" double quote\" ]; then exit 1; fi", Name: "sd-teardown-doublequote"},
 	}
 	testBuild := screwdriver.Build{
 		ID:          12345,

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -126,6 +126,7 @@ func TestHelperProcess(*testing.T) {
 
 func cleanup(filename string) {
 	os.Remove(filename)
+	os.Remove(filename + "_export")
 }
 
 func setupTestCase(t *testing.T, filename string) func(t *testing.T, filename string) {
@@ -195,7 +196,7 @@ func TestUnmocked(t *testing.T) {
 			},
 		})
 
-		err := Run("", nil, &MockEmitter{}, testBuild, testAPI, testBuild.ID, test.shell, TestBuildTimeout, "/tmp/Unmocked")
+		err := Run("", nil, &MockEmitter{}, testBuild, testAPI, testBuild.ID, test.shell, TestBuildTimeout, envFilepath)
 		commands := ReadCommand(stepFilePath)
 
 		if !reflect.DeepEqual(err, test.err) {

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -251,6 +251,52 @@ func TestUnmockedMulti(t *testing.T) {
 	}
 }
 
+func TestTeardownEnv(t *testing.T) {
+	// commands := []screwdriver.CommandDef{
+	// 	{Cmd: "export FOO=BAR", Name: "env"},
+	// 	{Cmd: "doesnotexit", Name: "doesnotexit"},
+	// 	// {Cmd: "if [ $FOO = BAR ]; then fail; fi", Name: "teardown-user"},
+	// 	// {Cmd: "if [ $FOO = BAR ]; then fail; fi", Name: "sd-teardown-artifacts"},
+	// }
+	// testBuild := screwdriver.Build{
+	// 	ID:          12345,
+	// 	Commands:    commands,
+	// 	Environment: map[string]string{},
+	// }
+	// runTeardown := false
+	// testAPI := screwdriver.API(MockAPI{
+	// 	updateStepStart: func(buildID int, stepName string) error {
+	// 		if buildID != testBuild.ID {
+	// 			t.Errorf("wrong build id got %v, want %v", buildID, testBuild.ID)
+	// 		}
+	// 		if stepName == "sd-teardown-artifacts" {
+	// 			runTeardown = false
+	// 		}
+	// 		return nil
+	// 	},
+	// 	updateStepStop: func(buildID int, stepName string, code int) error {
+	// 		if buildID != testBuild.ID {
+	// 			t.Errorf("wrong build id got %v, want %v", buildID, testBuild.ID)
+	// 		}
+	// 		// if (code != 0) {
+	// 		// 	t.Errorf("step failed with exit code %v", code)
+	// 		// }
+	// 		if stepName == "sd-teardown-artifacts" {
+	// 			runTeardown = true
+	// 		}
+	// 		return nil
+	// 	},
+	// })
+	// err := Run("", nil, &MockEmitter{}, testBuild, testAPI, testBuild.ID, "/bin/sh", TestBuildTimeout)
+	// expectedErr := fmt.Errorf("Launching command exit with code: %v", 127)
+	// if !runTeardown {
+	// 	t.Errorf("step teardown should run")
+	// }
+	// if !reflect.DeepEqual(err, expectedErr) {
+	// 	t.Fatalf("Unexpected error: %v - should be %v", err, expectedErr)
+	// }
+}
+
 func TestTeardownfail(t *testing.T) {
 	commands := []screwdriver.CommandDef{
 		{Cmd: "ls", Name: "test ls"},

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -263,19 +263,28 @@ func TestUnmockedMulti(t *testing.T) {
 }
 
 func TestTeardownEnv(t *testing.T) {
+	// commands := []screwdriver.CommandDef{
+	// 	// {Cmd: "export DOUBLE_QUOTE='my \" double quote'", Name: "env"},
+	// 	// {Cmd: "export SINGLE_QUOTE=\"my ' single quote\"", Name: "envi"},
+	// 	{Cmd: "export SINGLE_QUOTE=BAR", Name: "env"},
+	// 	{Cmd: "cat /tmp/buildEnv", Name: "cat"},
+	// 	{Cmd: "doesnotexit", Name: "doesnotexit"},
+	// 	{Cmd: "echo bye", Name: "teardown-bye"},
+	// 	// {Cmd: "if [ \"$DOUBLE_QUOTE\" = 'my \" double quote' ]; then echo bad; fi", Name: "teardown-user"},
+	// 	// {Cmd: "if [ \"$SINGLE_QUOTE\" != \"my ' single quote\" ]; then exit 1; fi", Name: "sd-teardown-artifacts"},
+	// }
 	commands := []screwdriver.CommandDef{
-		{Cmd: "export DOUBLE_QUOTE='my \" double quote'", Name: "env"},
-		{Cmd: "export SINGLE_QUOTE=\"my ' single quote\"", Name: "env"},
+		{Cmd: "export FOO=BAR", Name: "env"},
 		{Cmd: "doesnotexit", Name: "doesnotexit"},
-		{Cmd: "if [ \"$DOUBLE_QUOTE\" = 'my \" double quote' ]; then echo bad; fi", Name: "teardown-user"},
-		// {Cmd: "if [ \"$SINGLE_QUOTE\" != \"my ' single quote\" ]; then exit 1; fi", Name: "sd-teardown-artifacts"},
+		{Cmd: "if [ $FOO != BAR ]; then fail; fi", Name: "teardown-user"},
+		{Cmd: "if [ $FOO != BAR ]; then fail; fi", Name: "sd-teardown-artifacts"},
 	}
 	testBuild := screwdriver.Build{
 		ID:          12345,
 		Commands:    commands,
 		Environment: map[string]string{},
 	}
-	runUserTeardown := false
+	// runUserTeardown := false
 	// runSdTeardown := false
 	testAPI := screwdriver.API(MockAPI{
 		updateStepStart: func(buildID int, stepName string) error {
@@ -291,9 +300,9 @@ func TestTeardownEnv(t *testing.T) {
 			if buildID != testBuild.ID {
 				t.Errorf("wrong build id got %v, want %v", buildID, testBuild.ID)
 			}
-			if stepName == "teardown-user" {
-				runUserTeardown = true
-			}
+			// if stepName == "teardown-user" {
+			// 	runUserTeardown = true
+			// }
 			// if stepName == "sd-teardown-artifacts" {
 			// 	runSdTeardown = true
 			// }
@@ -305,9 +314,9 @@ func TestTeardownEnv(t *testing.T) {
 	})
 	err := Run("", nil, &MockEmitter{}, testBuild, testAPI, testBuild.ID, "/bin/sh", TestBuildTimeout)
 	expectedErr := fmt.Errorf("Launching command exit with code: %v", 127)
-	if !runUserTeardown {
-		t.Errorf("step user teardown should run")
-	}
+	// if !runUserTeardown {
+	// 	t.Errorf("step user teardown should run")
+	// }
 	// if !runSdTeardown {
 	// 	t.Errorf("step sd teardown should run")
 	// }

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -200,7 +200,7 @@ func TestUnmocked(t *testing.T) {
 	}
 }
 
-func TestUnmockedMulti(t *testing.T) {
+func TestMulti(t *testing.T) {
 	commands := []screwdriver.CommandDef{
 		{Cmd: "ls", Name: "test ls"},
 		{Cmd: "export FOO=BAR", Name: "test export env"},

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -129,17 +129,18 @@ func TestHelperProcess(*testing.T) {
 }
 
 func cleanup(filename string) {
-	os.Remove(filename)
-	os.Remove(filename + "_export")
+	_, err := os.Stat(filename)
+
+	if err == nil {
+		err := os.Remove(filename)
+		fmt.Printf("err removing file %v", err)
+	}
 }
 
-func setupTestCase(t *testing.T, filename string) func(t *testing.T, filename string) {
+func setupTestCase(t *testing.T, filename string) {
 	t.Log("setup test case")
 	cleanup(filename)
-	return func(t *testing.T, filename string) {
-		t.Log("teardown test case")
-		cleanup(filename)
-	}
+	cleanup(filename + "_export")
 }
 
 func TestMain(m *testing.M) {
@@ -158,8 +159,7 @@ func ReadCommand(file string) []string {
 
 func TestUnmocked(t *testing.T) {
 	envFilepath := "/tmp/testUnmocked"
-	teardownTestCase := setupTestCase(t, envFilepath)
-	defer teardownTestCase(t, envFilepath)
+	setupTestCase(t, envFilepath)
 	var tests = []struct {
 		command string
 		err     error
@@ -223,8 +223,7 @@ func TestUnmocked(t *testing.T) {
 
 func TestMulti(t *testing.T) {
 	envFilepath := "/tmp/testMulti"
-	teardownTestCase := setupTestCase(t, envFilepath)
-	defer teardownTestCase(t, envFilepath)
+	setupTestCase(t, envFilepath)
 	commands := []screwdriver.CommandDef{
 		{Cmd: "ls", Name: "test ls"},
 		{Cmd: "export FOO=BAR", Name: "test export env"},
@@ -288,8 +287,7 @@ func TestMulti(t *testing.T) {
 
 func TestTeardownEnv(t *testing.T) {
 	envFilepath := "/tmp/testTeardownEnv"
-	teardownTestCase := setupTestCase(t, envFilepath)
-	defer teardownTestCase(t, envFilepath)
+	setupTestCase(t, envFilepath)
 	commands := []screwdriver.CommandDef{
 		{Cmd: "export FOO=\"BAR with spaces\"", Name: "foo"},
 		{Cmd: "export SINGLE_QUOTE=\"my ' single quote\"", Name: "singlequote"},
@@ -345,8 +343,7 @@ func TestTeardownEnv(t *testing.T) {
 
 func TestTeardownfail(t *testing.T) {
 	envFilepath := "/tmp/testTeardownfail"
-	teardownTestCase := setupTestCase(t, envFilepath)
-	defer teardownTestCase(t, envFilepath)
+	setupTestCase(t, envFilepath)
 	commands := []screwdriver.CommandDef{
 		{Cmd: "ls", Name: "test ls"},
 		{Cmd: "doesnotexit", Name: "sd-teardown-artifacts"},
@@ -373,8 +370,7 @@ func TestTeardownfail(t *testing.T) {
 
 func TestTimeout(t *testing.T) {
 	envFilepath := "/tmp/testTimeout"
-	teardownTestCase := setupTestCase(t, envFilepath)
-	defer teardownTestCase(t, envFilepath)
+	setupTestCase(t, envFilepath)
 	commands := []screwdriver.CommandDef{
 		{Cmd: "echo testing timeout", Name: "test timeout"},
 		{Cmd: "sleep 3", Name: "sleep for a long time"},
@@ -416,8 +412,7 @@ func TestTimeout(t *testing.T) {
 
 func TestEnv(t *testing.T) {
 	envFilepath := "/tmp/testEnv"
-	teardownTestCase := setupTestCase(t, envFilepath)
-	defer teardownTestCase(t, envFilepath)
+	setupTestCase(t, envFilepath)
 	baseEnv := []string{
 		"var0=xxx",
 		"var1=foo",
@@ -494,8 +489,7 @@ func TestEnv(t *testing.T) {
 
 func TestEmitter(t *testing.T) {
 	envFilepath := "/tmp/testEmitter"
-	teardownTestCase := setupTestCase(t, envFilepath)
-	defer teardownTestCase(t, envFilepath)
+	setupTestCase(t, envFilepath)
 	var tests = []struct {
 		command string
 		name    string

--- a/executor/script.sh
+++ b/executor/script.sh
@@ -1,0 +1,6 @@
+prefix='export '; file=/tmp/buildEnv; newfile=/tmp/exportBuildEnv; 
+while read -r line; do
+escapeQuote=`echo $line | sed 's/"/\\\"/g'`;
+newline=`echo $escapeQuote | sed 's/\([A-Z_][A-Z0-9_]*\)=\(.*\)/\1="\2"/'`;
+echo ${prefix}$newline; 
+done < $file > $newfile;

--- a/executor/script.sh
+++ b/executor/script.sh
@@ -2,5 +2,5 @@ prefix='export '; file=/tmp/buildEnv; newfile=/tmp/exportBuildEnv;
 while read -r line; do
 escapeQuote=`echo $line | sed 's/"/\\\"/g'`;
 newline=`echo $escapeQuote | sed 's/\([A-Z_][A-Z0-9_]*\)=\(.*\)/\1="\2"/'`;
-echo ${prefix}$newline; 
+echo ${prefix}$newline;
 done < $file > $newfile;

--- a/executor/script.sh
+++ b/executor/script.sh
@@ -1,6 +1,0 @@
-prefix='export '; file=/tmp/buildEnv; newfile=/tmp/exportBuildEnv; 
-while read -r line; do
-escapeQuote=`echo $line | sed 's/"/\\\"/g'`;
-newline=`echo $escapeQuote | sed 's/\([A-Z_][A-Z0-9_]*\)=\(.*\)/\1="\2"/'`;
-echo ${prefix}$newline;
-done < $file > $newfile;

--- a/launch.go
+++ b/launch.go
@@ -194,6 +194,7 @@ func convertToArray(i interface{}) (array []int) {
 
 func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, storeURL, shellBin string, buildTimeout int) error {
 	emitter, err := newEmitter(emitterPath)
+	envFilepath := "/tmp/exportEnv"
 	if err != nil {
 		return err
 	}
@@ -413,7 +414,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		return fmt.Errorf("Updating sd-setup-launcher stop: %v", err)
 	}
 
-	return executorRun(w.Src, env, emitter, build, api, buildID, shellBin, buildTimeout)
+	return executorRun(w.Src, env, emitter, build, api, buildID, shellBin, buildTimeout, envFilepath)
 }
 
 func createEnvironment(base map[string]string, secrets screwdriver.Secrets, build screwdriver.Build) []string {

--- a/launch_test.go
+++ b/launch_test.go
@@ -228,7 +228,7 @@ func TestMain(m *testing.M) {
 	open = func(f string) (*os.File, error) {
 		return os.Open("data/screwdriver.yaml")
 	}
-	executorRun = func(path string, env []string, emitter screwdriver.Emitter, build screwdriver.Build, api screwdriver.API, buildID int, shellBin string, timeout int) error {
+	executorRun = func(path string, env []string, emitter screwdriver.Emitter, build screwdriver.Build, api screwdriver.API, buildID int, shellBin string, timeout int, envFilepath string) error {
 		return nil
 	}
 	cleanExit = func() {}
@@ -511,7 +511,7 @@ func TestUpdateBuildNonZeroFailure(t *testing.T) {
 
 	oldRun := executorRun
 	defer func() { executorRun = oldRun }()
-	executorRun = func(path string, env []string, out screwdriver.Emitter, build screwdriver.Build, a screwdriver.API, buildID int, shellBin string, timeout int) error {
+	executorRun = func(path string, env []string, out screwdriver.Emitter, build screwdriver.Build, a screwdriver.API, buildID int, shellBin string, timeout int, envFilepath string) error {
 		return executor.ErrStatus{Status: 1}
 	}
 
@@ -722,7 +722,7 @@ func TestSetEnv(t *testing.T) {
 	}
 
 	foundEnv := map[string]string{}
-	executorRun = func(path string, env []string, emitter screwdriver.Emitter, build screwdriver.Build, api screwdriver.API, buildID int, shellBin string, timeout int) error {
+	executorRun = func(path string, env []string, emitter screwdriver.Emitter, build screwdriver.Build, api screwdriver.API, buildID int, shellBin string, timeout int, envFilepath string) error {
 		if len(env) == 0 {
 			t.Fatalf("Unexpected empty environment passed to executorRun")
 		}
@@ -785,7 +785,7 @@ func TestEnvSecrets(t *testing.T) {
 	foundEnv := map[string]string{}
 	oldExecutorRun := executorRun
 	defer func() { executorRun = oldExecutorRun }()
-	executorRun = func(path string, env []string, emitter screwdriver.Emitter, build screwdriver.Build, api screwdriver.API, buildID int, shellBin string, timeout int) error {
+	executorRun = func(path string, env []string, emitter screwdriver.Emitter, build screwdriver.Build, api screwdriver.API, buildID int, shellBin string, timeout int, envFilepath string) error {
 		if len(env) == 0 {
 			t.Fatalf("Unexpected empty environment passed to executorRun")
 		}

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -20,6 +20,7 @@ jobs:
             - build: go build -a -o /dev/null
             # Test cross-compiling as well
             - test-release: "curl -sL https://git.io/goreleaser | bash -s -- --snapshot"
+            - teardown-sleep: sleep 1000
 
     publish:
         requires: [main]

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -13,7 +13,7 @@ jobs:
             - install: glide install
             - vet: go vet ./...
             - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
-            - test: GOCACHE=off go test ./... -p 1
+            - test: GOCACHE=off go test ./...
             # The emitter file is changed by a test, but we want to ignore it
             - ignore-git: git update-index --assume-unchanged data/emitter
             # Ensure we can compile

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -13,7 +13,9 @@ jobs:
             - install: glide install
             - vet: go vet ./...
             - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
-            - test: go test ./...
+            # The executor test involves writing/reading from the same file.
+            # -p 1 to ensure the tests not run concurrently
+            - test: go test ./... -p 1
             # The emitter file is changed by a test, but we want to ignore it
             - ignore-git: git update-index --assume-unchanged data/emitter
             # Ensure we can compile

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -13,9 +13,8 @@ jobs:
             - install: glide install
             - vet: go vet ./...
             - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
-            # The executor test involves writing/reading from the same file.
-            # -p 1 to ensure the tests not run concurrently
-            - test: go test ./... -p 1
+            - sleep: sleep 1000
+            - test: go test ./...
             # The emitter file is changed by a test, but we want to ignore it
             - ignore-git: git update-index --assume-unchanged data/emitter
             # Ensure we can compile

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -13,7 +13,7 @@ jobs:
             - install: glide install
             - vet: go vet ./...
             - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
-            - sleep: sleep 1000
+            - sleep: sleep 5000
             - test: go test ./...
             # The emitter file is changed by a test, but we want to ignore it
             - ignore-git: git update-index --assume-unchanged data/emitter

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -13,7 +13,7 @@ jobs:
             - install: glide install
             - vet: go vet ./...
             - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
-            - test: go test ./...
+            - test: GOCACHE=off go test ./... -p 1
             # The emitter file is changed by a test, but we want to ignore it
             - ignore-git: git update-index --assume-unchanged data/emitter
             # Ensure we can compile

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -21,7 +21,6 @@ jobs:
             - build: go build -a -o /dev/null
             # Test cross-compiling as well
             - test-release: "curl -sL https://git.io/goreleaser | bash -s -- --snapshot"
-            - teardown-sleep: sleep 1000
 
     publish:
         requires: [main]

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -13,7 +13,6 @@ jobs:
             - install: glide install
             - vet: go vet ./...
             - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
-            - sleep: sleep 5000
             - test: go test ./...
             # The emitter file is changed by a test, but we want to ignore it
             - ignore-git: git update-index --assume-unchanged data/emitter

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -13,6 +13,7 @@ jobs:
             - install: glide install
             - vet: go vet ./...
             - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
+            - gover: go version
             - test: GOCACHE=off go test ./...
             # The emitter file is changed by a test, but we want to ignore it
             - ignore-git: git update-index --assume-unchanged data/emitter


### PR DESCRIPTION
Passing environment variables to teardown steps
In `trap`, we do `env` to a file and do proper parsing:
- escape double quote
- add double quotes around the value
In beginning of each teardown, we source the file

Related: https://github.com/screwdriver-cd/screwdriver/issues/1192