### PR TITLE
feat(1167): [4][small] Add fetch flag

### DIFF
--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 # wrapper script for run build in multiple executors.
-SD_TOKEN=`/opt/sd/launch --only-fetch-token --token "$1" --api-uri $2 --store-uri $3 --emitter /sd/emitter --build-timeout $4 $5` && (/opt/sd/launch --api-uri $2 --store-uri $3 --emitter /sd/emitter --build-timeout $4 $5 & /opt/sd/logservice --emitter /sd/emitter --api-uri $2 --store-uri $3 --build $5 & wait $(jobs -p))
+SD_TOKEN=`/opt/sd/launch --only-fetch-token --token "$1" --api-uri "$2" --store-uri "$3" --emitter /sd/emitter --build-timeout "$4" "$5"` && (/opt/sd/launch --api-uri "$2" --store-uri "$3" --emitter /sd/emitter --build-timeout "$4" "$5" & /opt/sd/logservice --emitter /sd/emitter --api-uri "$2" --store-uri "$3" --build "$5" & wait $(jobs -p))

--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# wrapper script for run build in multiple executors.
+SD_TOKEN=`/opt/sd/launch --only-fetch-token --token "$1" --api-uri $2 --store-uri $3 --emitter /sd/emitter --build-timeout $4 $5` && (/opt/sd/launch --api-uri $2 --store-uri $3 --emitter /sd/emitter --build-timeout $4 $5 & /opt/sd/logservice --emitter /sd/emitter --api-uri $2 --store-uri $3 --build $5 & wait $(jobs -p))

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,9 @@ RUN set -x \
 # Copy optional entrypoint script to the image
 COPY Docker/launcher_entrypoint.sh /opt/sd/launcher_entrypoint.sh
 
+# Copy wrapper script to the image
+COPY Docker/run.sh /opt/sd/run.sh
+
 VOLUME /opt/sd
 VOLUME /hab
 

--- a/launch.go
+++ b/launch.go
@@ -563,7 +563,7 @@ func main() {
 			EnvVar: "SD_BUILD_TIMEOUT",
 		},
 		cli.BoolFlag{
-			Name:  "fetch-flag",
+			Name:  "only-fetch-token",
 			Usage: "Only fetching build token",
 		},
 	}
@@ -578,7 +578,7 @@ func main() {
 		shellBin := c.String("shell-bin")
 		buildID, err := strconv.Atoi(c.Args().Get(0))
 		buildTimeoutSeconds := c.Int("build-timeout") * 60
-		fetchFlag := c.Bool("fetch-flag")
+		fetchFlag := c.Bool("only-fetch-token")
 
 		if err != nil {
 			return cli.ShowAppHelp(c)

--- a/launch.go
+++ b/launch.go
@@ -584,25 +584,25 @@ func main() {
 			return cli.ShowAppHelp(c)
 		}
 
-		temporalApi, err := screwdriver.New(url, token)
-		if err != nil {
-			log.Printf("Error creating temporal Screwdriver API %v: %v", buildID, err)
-			exit(screwdriver.Failure, buildID, nil, metaSpace)
-		}
-
-		buildToken, err := temporalApi.GetBuildToken(buildID, c.Int("build-timeout"))
-		if err != nil {
-			// If token is build scope token, GetBuildToken returns 403 error but need not exit
-			log.Printf("Error getting Build Token %v: %v", buildID, err)
-		}
-
 		if fetchFlag {
+			temporalApi, err := screwdriver.New(url, token)
+			if err != nil {
+				log.Printf("Error creating temporal Screwdriver API %v: %v", buildID, err)
+				exit(screwdriver.Failure, buildID, nil, metaSpace)
+			}
+
+			buildToken, err := temporalApi.GetBuildToken(buildID, c.Int("build-timeout"))
+			if err != nil {
+				log.Printf("Error getting Build Token %v: %v", buildID, err)
+				exit(screwdriver.Failure, buildID, nil, metaSpace)
+			}
+
 			log.Printf("Launcher process only fetch token.")
 			fmt.Printf("%s", buildToken)
 			cleanExit()
 		}
 
-		api, err := screwdriver.New(url, buildToken)
+		api, err := screwdriver.New(url, token)
 		if err != nil {
 			log.Printf("Error creating Screwdriver API %v: %v", buildID, err)
 			exit(screwdriver.Failure, buildID, nil, metaSpace)
@@ -610,7 +610,7 @@ func main() {
 
 		defer recoverPanic(buildID, api, metaSpace)
 
-		launchAction(api, buildID, workspace, emitterPath, metaSpace, storeURL, shellBin, buildTimeoutSeconds, buildToken)
+		launchAction(api, buildID, workspace, emitterPath, metaSpace, storeURL, shellBin, buildTimeoutSeconds, token)
 
 		// This should never happen...
 		log.Println("Unexpected return in launcher. Failing the build.")

--- a/launch.go
+++ b/launch.go
@@ -562,6 +562,10 @@ func main() {
 			Value:  DefaultTimeout,
 			EnvVar: "SD_BUILD_TIMEOUT",
 		},
+		cli.BoolFlag{
+			Name:  "fetch-flag",
+			Usage: "Only fetching build token",
+		},
 	}
 
 	app.Action = func(c *cli.Context) error {
@@ -574,6 +578,7 @@ func main() {
 		shellBin := c.String("shell-bin")
 		buildID, err := strconv.Atoi(c.Args().Get(0))
 		buildTimeoutSeconds := c.Int("build-timeout") * 60
+		fetchFlag := c.Bool("fetch-flag")
 
 		if err != nil {
 			return cli.ShowAppHelp(c)
@@ -587,7 +592,14 @@ func main() {
 
 		buildToken, err := temporalApi.GetBuildToken(buildID, c.Int("build-timeout"))
 		if err != nil {
+			// If token is build scope token, GetBuildToken returns 403 error but need not exit
 			log.Printf("Error getting Build Token %v: %v", buildID, err)
+		}
+
+		if fetchFlag {
+			log.Printf("Launcher process only fetch token.")
+			fmt.Printf("%s", buildToken)
+			cleanExit()
 		}
 
 		api, err := screwdriver.New(url, buildToken)


### PR DESCRIPTION
## Context
<!-- Why do we need this PR? What was the reason that led you to make this change? -->
To fetch build token in actual build execution, we fixed to exchange temporal token to build token in launcher process. 
However, also log-service uses token which is passed by `executor-*`.
To pass fetched build token to log-service and launcher, add the flag to launcher which only fetch token in launcher process, and use this flag to set fetched token before launcher and log-service processes start.
Detail: https://github.com/screwdriver-cd/screwdriver/issues/1167#issuecomment-409441739

## Objective
<!-- What does this PR fix? What intentional changes will this PR make? -->
Add flag to only fetch build token in launcher process.

Add wrapper script to run build in multiple executors.

## References
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
issue: https://github.com/screwdriver-cd/screwdriver/issues/1167
issue comment: https://github.com/screwdriver-cd/screwdriver/issues/1167#issuecomment-409441739

PR:
executor-k8s: https://github.com/screwdriver-cd/executor-k8s/pull/89
hyperctl-image: https://github.com/screwdriver-cd/hyperctl-image/pull/24
executor-docker: https://github.com/screwdriver-cd/executor-docker/pull/28
executor-jenkins: https://github.com/screwdriver-cd/executor-jenkins/pull/24