### PR TITLE
fix(1167): fix run script

### DIFF
--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 # wrapper script for run build in multiple executors.
-SD_TOKEN=`/opt/sd/launch --only-fetch-token --token "$1" --api-uri "$2" --store-uri "$3" --emitter /sd/emitter --build-timeout "$4" "$5"` && (/opt/sd/launch --api-uri "$2" --store-uri "$3" --emitter /sd/emitter --build-timeout "$4" "$5" & /opt/sd/logservice --emitter /sd/emitter --api-uri "$2" --store-uri "$3" --build "$5" & wait $(jobs -p))
+SD_TOKEN=`/opt/sd/launch --only-fetch-token --token "$1" --api-uri "$2" --store-uri "$3" --emitter /opt/sd/emitter --build-timeout "$4" "$5"` && (/opt/sd/launch --token "$SD_TOKEN" --api-uri "$2" --store-uri "$3" --emitter /opt/sd/emitter --build-timeout "$4" "$5" & /opt/sd/logservice --token "$SD_TOKEN" --emitter /opt/sd/emitter --api-uri "$2" --store-uri "$3" --build "$5" & wait $(jobs -p))


### PR DESCRIPTION
## Context
In the run.sh, `SD_TOKEN` is temporally defined, therefore it cannot be used from environment variables in the process. 
```
mkfifo: cannot create fifo '/opt/sd/emitter': File exists
[WARN  tini (8)] Tini is not running as PID 1 and isn't registered as a child subreaper.
Zombie processes will not be re-parented to Tini, so zombie reaping won't work.
To fix the problem, use the -s option or set the environment variable TINI_SUBREAPER to register Tini as a child subreaper, or run Tini as PID 1.
2018/08/06 22:07:43 Launcher process only fetch token.
2018/08/06 22:07:43 No JWT specified. Cannot upload.
Usage of /opt/sd/logservice:
  -api-uri string
    	Base URI for the Screwdriver API ($SD_API_URL)
  -build string
    	ID of the build that is emitting logs ($SD_BUILDID)
  -emitter string
    	Path to the log emitter file (default "/var/run/sd/emitter")
  -lines-per-file int
    	Max number of lines per file when uploading ($SD_LINESPERFILE) (default 1000)
  -store-uri string
    	Base URI for the Screwdriver Store API ($SD_STORE_URL)
  -token string
    	JWT for authenticating with the Store API ($SD_TOKEN)
2018/08/06 22:07:43 Starting Build 23009
2018/08/06 22:07:43 Error running launcher: Failed opening emitter path "/sd/emitter": open /sd/emitter: no such file or directory
2018/08/06 22:07:43 Loading meta from "/sd/meta"/meta.json
2018/08/06 22:07:43 Failed to load "/sd/meta"/meta.json: open /sd/meta/meta.json: no such file or directory
2018/08/06 22:07:43 Setting build status to FAILURE
2018/08/06 22:07:43 Failed updating the build status: Posting to Build Status: 401 Unauthorized: Missing authentication
```
I fixed to run.sh to pass fetched `SD_TOKEN` to the log-service using token option.
I also fixed emitter path in the run.sh.

## Objective
Fixed the run.sh to pass `SD_TOKEN` using token option.
Fixed emitter path in the run.sh.

## Reference
Related issue: https://github.com/screwdriver-cd/screwdriver/issues/1167
