### PR TITLE
fix: write nops1 to a different file

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -247,6 +247,20 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 		"trap finish EXIT;\n",
 	}
 
+	 // The above script does the following
+	 // export PATH=$PATH:/opt/sd &&
+	 // finish() {
+	 //   EXITCODE=$?;
+	 //   prefix='export '; file=/tmp/env; nops1=/tmp/env_nops1; newfile=/tmp/env_export; env > $file &&
+	 //   sed '/^PS1=.* /d' $file > $nops1 &&
+	 //   while read -r line; do
+	 //   escapeQuote=`echo $line | sed 's/"/\\\"/g'` &&
+	 //   newline=`echo $escapeQuote | sed 's/\([A-Za-z_][A-Za-z0-9_]*\)=\(.*\)/\1="\2"/'` &&
+	 //   echo ${prefix}$newline;
+	 //   done < $nops1 > $newfile;
+	 //   echo $SD_STEP_ID $EXITCODE;
+	 // }  && trap finish EXIT;
+
 	shargs := strings.Join(setupCommands, " && ")
 
 	f.Write([]byte(shargs))

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -252,13 +252,13 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 	 // export PATH=$PATH:/opt/sd &&
 	 // finish() {
 	 //   EXITCODE=$?;
-	 //   prefix='export '; file=/tmp/env; nops1=/tmp/env_nops1; newfile=/tmp/env_export; env > $file &&
-	 //   sed '/^PS1=.* /d' $file > $nops1 &&
+	 //   prefix='export '; file=/tmp/env; tmpfile=/tmp/env_tmp; newfile=/tmp/env_export; env | grep -vi PS1 > $file &&
 	 //   while read -r line; do
 	 //   escapeQuote=`echo $line | sed 's/"/\\\"/g'` &&
 	 //   newline=`echo $escapeQuote | sed 's/\([A-Za-z_][A-Za-z0-9_]*\)=\(.*\)/\1="\2"/'` &&
 	 //   echo ${prefix}$newline;
-	 //   done < $nops1 > $newfile;
+	 //   done < $file > $tmpfile;
+	 //   mv $tmpfile $newfile;
 	 //   echo $SD_STEP_ID $EXITCODE;
 	 // }  && trap finish EXIT;
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -119,12 +119,11 @@ func doRunTeardownCommand(cmd screwdriver.CommandDef, emitter screwdriver.Emitte
 	shargs := []string{"-e", "-c"}
 	cmdStr := "export PATH=$PATH:/opt/sd && " +
 		"while ! [ -f  "+ exportFile + " ]; do sleep 1; done && " + // wait for the file to be available
-		"(. " + exportFile + " || echo 'Failed to export environment variables' ) && " +
+		". " + exportFile + " && " +
 		cmd.Cmd
 
 	shargs = append(shargs, cmdStr)
 
-	fmt.Print(shargs)
 	c := exec.Command(shellBin, shargs...)
 	emitter.StartCmd(cmd)
 	fmt.Fprintf(emitter, "$ %s\n", cmd.Cmd)

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"strconv"
 	"testing"
 	"time"
 
@@ -158,7 +159,6 @@ func ReadCommand(file string) []string {
 }
 
 func TestUnmocked(t *testing.T) {
-	envFilepath := "/tmp/testUnmocked"
 	var tests = []struct {
 		command string
 		err     error
@@ -175,7 +175,8 @@ func TestUnmocked(t *testing.T) {
 		{"ls", nil, "/bin/bash"},
 	}
 
-	for _, test := range tests {
+	for index, test := range tests {
+		envFilepath := "/tmp/testUnmocked" + strconv.Itoa(index)
 		setupTestCase(t, envFilepath)
 		cmd := screwdriver.CommandDef{
 			Cmd:  test.command,

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -140,7 +140,7 @@ func cleanup(filename string) {
 func setupTestCase(t *testing.T, filename string) {
 	t.Log("setup test case")
 	cleanup(filename)
-	cleanup(filename + "_nops1")
+	cleanup(filename + "_tmp")
 	cleanup(filename + "_export")
 }
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -139,6 +139,7 @@ func cleanup(filename string) {
 func setupTestCase(t *testing.T, filename string) {
 	t.Log("setup test case")
 	cleanup(filename)
+	cleanup(filename + "_nops1")
 	cleanup(filename + "_export")
 }
 

--- a/launch.go
+++ b/launch.go
@@ -194,7 +194,7 @@ func convertToArray(i interface{}) (array []int) {
 
 func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, storeURL, shellBin string, buildTimeout int, buildToken string) error {
 	emitter, err := newEmitter(emitterPath)
-	envFilepath := "/tmp/exportEnv"
+	envFilepath := "/tmp/env"
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
It's possible that during this part, `$newfile` exists and the check for it in `doRunTeardown` passes and tries to source the env file. 

```
sed '/^PS1=.*/d' $file > $newfile &&
mv $newfile $file
```

This PR uses a different filename and make $newfile only available at the end