### PR TITLE
fix: Add timeout for wait

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -120,7 +120,7 @@ func doRunCommand(guid, path string, emitter screwdriver.Emitter, f *os.File, fR
 func doRunTeardownCommand(cmd screwdriver.CommandDef, emitter screwdriver.Emitter, env []string, path, shellBin string, exportFile string) (int, error) {
 	shargs := []string{"-e", "-c"}
 	cmdStr := "export PATH=$PATH:/opt/sd && " +
-		"START_TIME=$SECONDS; while ! [ -f " + exportFile + " ] && [ $(($SECONDS - $START_TIME)) -lt " + strconv.Itoa(WaitTimeout) + " ]; do sleep 1; done; " +
+		"START=$(date +'%s'); while ! [ -f " + exportFile + " ] && [ $(($(date +'%s')-$START)) -lt " + strconv.Itoa(WaitTimeout) + " ]; do sleep 1; done; " +
 		". " + exportFile + "; " +
 		cmd.Cmd
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/screwdriver-cd/launcher/screwdriver"
 )
 
-const TestBuildTimeout = 60
+const TestBuildTimeout = 60*6
 
 var stepFilePath = "/tmp/step.sh"
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/screwdriver-cd/launcher/screwdriver"
 )
 
-const TestBuildTimeout = 60*6
+const TestBuildTimeout = 60
 
 var stepFilePath = "/tmp/step.sh"
 


### PR DESCRIPTION
Currently, if the `env_export` file is not available then it will wait forever. 
Adding this to timeout after 5 seconds. 