### PR TITLE
feat(979): [small] update docker entry point and remove mkfifo from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,8 +76,6 @@ RUN set -x \
    && find /hab -name docs -exec rm -r {} + \
    && find /hab -name man -exec rm -r {} + \
 
-   # Create FIFO
-   && mkfifo -m 666 emitter \
    # Cleanup packages
    && apk del --purge .build-dependencies
 
@@ -91,4 +89,4 @@ VOLUME /opt/sd
 VOLUME /hab
 
 # Set Entrypoint
-ENTRYPOINT ["/opt/sd/tini", "--", "/opt/sd/launch"]
+ENTRYPOINT ["/opt/sd/launcher_entrypoint.sh"]

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: golang
+    image: golang:1.10
     environment:
         GOPATH: /sd/workspace
 


### PR DESCRIPTION
This may fix a bug of missing files with Docker 18.03.0-ce.

These executors were already updated.
- https://github.com/screwdriver-cd/executor-docker/blob/b511eedee2e01c22d7d401f186c00fbdae3aca15/index.js#L175
- https://github.com/screwdriver-cd/executor-k8s/blob/91bcd9999b0693327dda03a652677d48665e82c7/config/pod.yaml.tim#L22

blocked by: https://github.com/screwdriver-cd/hyperctl-image/pull/25 -> merged

Related issue: https://github.com/screwdriver-cd/screwdriver/issues/979
