### PR TITLE
fix(979): fix entrypoint mkfifo cmd with proper user

### DIFF
--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+I_AM_ROOT=false
+
+if [ `whoami` = "root" ]; then
+    I_AM_ROOT=true
+fi
+
 smart_run () {
     if ! $I_AM_ROOT; then
         sudo $@

--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -1,8 +1,16 @@
 #!/bin/sh
 
+smart_run () {
+    if ! $I_AM_ROOT; then
+        sudo $@
+    else
+        $@
+    fi
+}
+
 # Create FIFO for emitter
 # https://github.com/screwdriver-cd/screwdriver/issues/979
-mkfifo -m 666 /opt/sd/emitter
+smart_run mkfifo -m 666 /opt/sd/emitter
 
 # Entrypoint
 /opt/sd/tini -- /bin/sh -c "$@"


### PR DESCRIPTION
if the user of the image is not root, we need to do `sudo mkfifo -m 666 /opt/sd/emitter` to create it