### PR TITLE
fix(979): change the emitter path

### DIFF
--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -16,7 +16,7 @@ smart_run () {
 
 # Create FIFO for emitter
 # https://github.com/screwdriver-cd/screwdriver/issues/979
-smart_run mkfifo -m 666 /opt/sd/emitter
+smart_run mkfifo -m 666 /sd/emitter
 
 # Entrypoint
 /opt/sd/tini -- /bin/sh -c "$@"

--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -16,6 +16,7 @@ smart_run () {
 
 # Create FIFO for emitter
 # https://github.com/screwdriver-cd/screwdriver/issues/979
+smart_run mkdir -p /sd
 smart_run mkfifo -m 666 /sd/emitter
 
 # Entrypoint

--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 # wrapper script for run build in multiple executors.
-SD_TOKEN=`/opt/sd/launch --only-fetch-token --token "$1" --api-uri "$2" --store-uri "$3" --emitter /opt/sd/emitter --build-timeout "$4" "$5"` && (/opt/sd/launch --token "$SD_TOKEN" --api-uri "$2" --store-uri "$3" --emitter /opt/sd/emitter --build-timeout "$4" "$5" & /opt/sd/logservice --token "$SD_TOKEN" --emitter /opt/sd/emitter --api-uri "$2" --store-uri "$3" --build "$5" & wait $(jobs -p))
+SD_TOKEN=`/opt/sd/launch --only-fetch-token --token "$1" --api-uri "$2" --store-uri "$3" --emitter /sd/emitter --build-timeout "$4" "$5"` && (/opt/sd/launch --token "$SD_TOKEN" --api-uri "$2" --store-uri "$3" --emitter /opt/sd/emitter --build-timeout "$4" "$5" & /opt/sd/logservice --token "$SD_TOKEN" --emitter /sd/emitter --api-uri "$2" --store-uri "$3" --build "$5" & wait $(jobs -p))


### PR DESCRIPTION
cannot mkfifo `/opt/sd/emitter` for k8s-vm since the share mount /opt/sd is `read-only`

https://git.ouroath.com/cocktails-screwdriver/hyperctl-docker/blob/master/scripts/hyper-pod-template.json#L23