### PR TITLE
fix: cache hab docker pkg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN set -x \
    # @TODO Remove this, I don't think it belongs here.  We should use /hab/bin/hab instead.
    && cp /hab/bin/hab /opt/sd/bin/hab \
    # Install Habitat packages
-   && /hab/bin/hab pkg install core/bash core/git core/zip \
+   && /hab/bin/hab pkg install core/bash core/git core/zip core/kmod core/iptables core/docker \
    # Cleanup Habitat Files
    && rm -rf /hab/cache /opt/sd/hab.tar.gz /opt/sd/hab-* \
    # Cleanup docs and man pages (how could this go wrong)


### PR DESCRIPTION
cache hab docker pkg and dependencies so that inside the build we don't rely on habitat to fetch pkgs