### PR TITLE
fix: add another pgp server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN set -x \
       | wget --base=http://github.com/ -i - -O tini-static.asc \
    && found=''; \
       ( \
+      gpg --no-tty --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 || \
       gpg --no-tty --keyserver pgp.mit.edu --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 || \
       gpg --no-tty --keyserver keyserver.pgp.com --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 || \
       gpg --no-tty --keyserver ha.pool.sks-keyservers.net --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \


### PR DESCRIPTION
docker hub is having problem retrieving keys from the 3 key servers we have now. Add another one to see if it helps. It can build without any problem locally.

https://github.com/krallin/tini/blob/master/README.md