### PR TITLE
exec tini instead of subshell tini

### DIFF
--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -20,4 +20,4 @@ smart_run mkdir -p /sd
 smart_run mkfifo -m 666 /sd/emitter
 
 # Entrypoint
-/opt/sd/tini -- /bin/sh -c "$@"
+exec /opt/sd/tini -- /bin/sh -c "$@"

--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 
 # wrapper script for run build in multiple executors.
-SD_TOKEN=`/opt/sd/launch --only-fetch-token --token "$1" --api-uri "$2" --store-uri "$3" --emitter /sd/emitter --build-timeout "$4" "$5"` && (/opt/sd/launch --token "$SD_TOKEN" --api-uri "$2" --store-uri "$3" --emitter /sd/emitter --build-timeout "$4" "$5" & /opt/sd/logservice --token "$SD_TOKEN" --emitter /sd/emitter --api-uri "$2" --store-uri "$3" --build "$5" & wait $(jobs -p))
+SD_TOKEN=`/opt/sd/launch --only-fetch-token --token "$1" --api-uri "$2" --store-uri "$3" --emitter /sd/emitter --build-timeout "$4" "$5"`
+/opt/sd/launch --token "$SD_TOKEN" --api-uri "$2" --store-uri "$3" --emitter /sd/emitter --build-timeout "$4" "$5" &
+/opt/sd/logservice --token "$SD_TOKEN" --emitter /sd/emitter --api-uri "$2" --store-uri "$3" --build "$5" &
+wait $(jobs -p)

--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
 # wrapper script for run build in multiple executors.
-SD_TOKEN=`/opt/sd/launch --only-fetch-token --token "$1" --api-uri "$2" --store-uri "$3" --emitter /sd/emitter --build-timeout "$4" "$5"`
-/opt/sd/launch --token "$SD_TOKEN" --api-uri "$2" --store-uri "$3" --emitter /sd/emitter --build-timeout "$4" "$5" &
-/opt/sd/logservice --token "$SD_TOKEN" --emitter /sd/emitter --api-uri "$2" --store-uri "$3" --build "$5" &
-wait $(jobs -p)
+SD_TOKEN=`/opt/sd/launch --only-fetch-token --token "$1" --api-uri "$2" --store-uri "$3" --emitter /sd/emitter --build-timeout "$4" "$5"` && (/opt/sd/launch --token "$SD_TOKEN" --api-uri "$2" --store-uri "$3" --emitter /sd/emitter --build-timeout "$4" "$5" & /opt/sd/logservice --token "$SD_TOKEN" --emitter /sd/emitter --api-uri "$2" --store-uri "$3" --build "$5" & wait $(jobs -p))
+

--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -2,4 +2,3 @@
 
 # wrapper script for run build in multiple executors.
 SD_TOKEN=`/opt/sd/launch --only-fetch-token --token "$1" --api-uri "$2" --store-uri "$3" --emitter /sd/emitter --build-timeout "$4" "$5"` && (/opt/sd/launch --token "$SD_TOKEN" --api-uri "$2" --store-uri "$3" --emitter /sd/emitter --build-timeout "$4" "$5" & /opt/sd/logservice --token "$SD_TOKEN" --emitter /sd/emitter --api-uri "$2" --store-uri "$3" --build "$5" & wait $(jobs -p))
-


### PR DESCRIPTION
I think an _exec_ for tini would be better here.  It used to be that tini was the entrypoint, and thus it was PID 1.  Now it is being run as a subshell from the new entrypoint launcher_entrypoint.sh.  This change causes tini to replace launcher_entrypoint as PID 1. I have tested in my environment and it seems to work properly.  This would only be an issue in long running docker jobs that have many steps, eventually you might run out of file descriptors or something.