### PR TITLE
fix: remove volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,8 +94,5 @@ COPY Docker/launcher_entrypoint.sh /opt/sd/launcher_entrypoint.sh
 # Copy wrapper script to the image
 COPY Docker/run.sh /opt/sd/run.sh
 
-VOLUME /opt/sd
-VOLUME /hab
-
 # Set Entrypoint
 ENTRYPOINT ["/opt/sd/launcher_entrypoint.sh"]


### PR DESCRIPTION
## Context
We want to use a custom launcher image which is based from sd launcer image in our SD cluster, and we want to add some utitility into `/opt/sd` in launcher or we may want to add some habitat pkg into `/hab` like below.
```
$ cat Dockerfile
FROM screwdrivercd/launcher:v5.0.30
RUN touch /opt/sd/foo
$ docker build . -t launcher:local --no-cache
Sending build context to Docker daemon  641.5kB
Step 1/2 : FROM screwdrivercd/launcher:v5.0.30
 ---> 8e8e504ca633
Step 2/2 : RUN touch /opt/sd/foo
 ---> Running in da9424bae60a
Removing intermediate container da9424bae60a
 ---> 920cd72b563c
Successfully built 920cd72b563c
Successfully tagged launcher:local
```

But, the new image doesn't include any added files.Because base image specifies `/opt/sd` and `/hab` as docker volume.
```
$ docker run -it --rm --entrypoint=/bin/sh launcher:local -c 'ls /opt/sd'
bin                     meta                    store-cli
launch                  run.sh                  tini
launcher_entrypoint.sh  sd-cmd
logservice              sd-step
```

## Objective
If there is no problem, we want to remove volume specific.
If it is necessary, please close this PR.