### PR TITLE
fix: validate token

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -595,17 +595,7 @@ func main() {
 
 		if len(token) == 0 {
 			log.Println("Error token is not passed.")
-			os.Exit(0)
-		}
-
-		if len(url) == 0 {
-			log.Println("Error API uri is not specified.")
-			os.Exit(0)
-		}
-
-		if len(storeURL) == 0 {
-			log.Println("Error store uri is not specified.")
-			os.Exit(0)
+			cleanExit()
 		}
 
 		if fetchFlag {

--- a/launch.go
+++ b/launch.go
@@ -593,6 +593,21 @@ func main() {
 			return cli.ShowAppHelp(c)
 		}
 
+		if len(token) == 0 {
+			log.Println("Error token is not passed.")
+			os.Exit(0)
+		}
+
+		if len(url) == 0 {
+			log.Println("Error API uri is not specified.")
+			os.Exit(0)
+		}
+
+		if len(storeURL) == 0 {
+			log.Println("Error store uri is not specified.")
+			os.Exit(0)
+		}
+
 		if fetchFlag {
 			temporalApi, err := screwdriver.New(url, token)
 			if err != nil {

--- a/launch.go
+++ b/launch.go
@@ -594,7 +594,7 @@ func main() {
 		}
 
 		if len(token) == 0 {
-			log.Println("Error token is not passed.")
+			log.Println("Error: token is not passed.")
 			cleanExit()
 		}
 

--- a/launch_test.go
+++ b/launch_test.go
@@ -245,9 +245,6 @@ func setupTempDirectoryAndSocket(t *testing.T) (dir string, cleanup func()) {
 }
 
 func TestMain(m *testing.M) {
-	oldArgs := os.Args
-	defer func() { os.Args = oldArgs }()
-
 	mkdirAll = func(path string, perm os.FileMode) (err error) { return nil }
 	stat = func(path string) (info os.FileInfo, err error) { return nil, os.ErrExist }
 	open = func(f string) (*os.File, error) {
@@ -1236,21 +1233,5 @@ func TestFetchEventMetaMarshalError(t *testing.T) {
 
 	if err.Error() != expected {
 		t.Errorf("Error is wrong, got '%v', expected '%v'", err, expected)
-	}
-}
-
-func TestValidateOptions(t *testing.T) {
-	os.Args = []string{"launch", "--api-uri=http://api.screwdriver/v4", "1234"}
-	exitCalled := false
-	cleanExit = func() {
-		exitCalled = true
-	}
-
-	os.Setenv("SD_TOKEN", "")
-
-	main()
-
-	if !exitCalled {
-		t.Errorf("Explicit exit not called")
 	}
 }

--- a/launch_test.go
+++ b/launch_test.go
@@ -245,6 +245,9 @@ func setupTempDirectoryAndSocket(t *testing.T) (dir string, cleanup func()) {
 }
 
 func TestMain(m *testing.M) {
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+
 	mkdirAll = func(path string, perm os.FileMode) (err error) { return nil }
 	stat = func(path string) (info os.FileInfo, err error) { return nil, os.ErrExist }
 	open = func(f string) (*os.File, error) {
@@ -1233,5 +1236,21 @@ func TestFetchEventMetaMarshalError(t *testing.T) {
 
 	if err.Error() != expected {
 		t.Errorf("Error is wrong, got '%v', expected '%v'", err, expected)
+	}
+}
+
+func TestValidateOptions(t *testing.T) {
+	os.Args = []string{"launch", "--api-uri=http://api.screwdriver/v4", "1234"}
+	exitCalled := false
+	cleanExit = func() {
+		exitCalled = true
+	}
+
+	os.Setenv("SD_TOKEN", "")
+
+	main()
+
+	if !exitCalled {
+		t.Errorf("Explicit exit not called")
 	}
 }


### PR DESCRIPTION
## Context
Some build pods is running forever although it's build token is invalid and builds is not executed.
```
$ kubectl get pod 
NAME                                READY     STATUS    RESTARTS   AGE
36934-7prwc                         1/1       Running   0          1d
```
The build pod's log is below.
```
[WARN  tini (10)] Tini is not running as PID 1 and isn't registered as a child subreaper.
Zombie processes will not be re-parented to Tini, so zombie reaping won't work.
To fix the problem, use the -s option or set the environment variable TINI_SUBREAPER to register Tini as a child subreaper, or run Tini as PID 1.
2018/11/13 11:01:23 Error getting Build Token 36934: Posting to Build Token: 404 Not Found: Build does not exist
2018/11/13 11:01:23 Starting Build 36934
2018/11/13 11:01:23 No JWT specified. Cannot upload.
Usage of /opt/sd/logservice:
  -api-uri string
    	Base URI for the Screwdriver API ($SD_API_URL)
  -build string
    	ID of the build that is emitting logs ($SD_BUILDID)
  -emitter string
    	Path to the log emitter file (default "/var/run/sd/emitter")
  -lines-per-file int
    	Max number of lines per file when uploading ($SD_LINESPERFILE) (default 1000)
  -store-uri string
    	Base URI for the Screwdriver Store API ($SD_STORE_URL)
  -token string
    	JWT for authenticating with the Store API ($SD_TOKEN)
```
If build token is invalid, the JWT is not issued, so logservice is exit with error log,
but launcher is running without error.

## Objective
This PR add some validation for launcher, and launcher exit safely, like as logservice.