### PR TITLE
[DNM][WIP] feat(1010): use prNum of Job to set SD_PULL_REQUEST

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,7 @@ builds:
       - amd64
     # Include the default settings from https://goreleaser.com/#builds
     # Also include static compilation
-    ldflags: -d -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -extldflags "-static"
+    ldflags: -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -extldflags "-static"
     # Ensure the binary is static
     env:
       - CGO_ENABLED=0

--- a/data/emitter
+++ b/data/emitter
@@ -1,3 +1,8 @@
-{"t":1482188362433,"m":"Workspace created in /var/folders/d6/rwx8bw4s4773s5v75z185j4r001ttj/T/ArtifactDir701279641","s":"sd-setup-launcher"}
-{"t":1482188362433,"m":"Source Dir: /var/folders/d6/rwx8bw4s4773s5v75z185j4r001ttj/T/ArtifactDir701279641/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
-{"t":1482188362433,"m":"Artifacts Dir: /var/folders/d6/rwx8bw4s4773s5v75z185j4r001ttj/T/ArtifactDir701279641/artifacts","s":"sd-setup-launcher"}
+{"t":1542876536366,"m":"Screwdriver Launcher information","s":"sd-setup-launcher"}
+{"t":1542876536367,"m":"Version:        vdev","s":"sd-setup-launcher"}
+{"t":1542876536368,"m":"Pipeline:       #3","s":"sd-setup-launcher"}
+{"t":1542876536369,"m":"Job:            main","s":"sd-setup-launcher"}
+{"t":1542876536370,"m":"Build:          #1","s":"sd-setup-launcher"}
+{"t":1542876536370,"m":"Workspace Dir:  /tmp/ArtifactDir990702653","s":"sd-setup-launcher"}
+{"t":1542876536371,"m":"Source Dir:     /tmp/ArtifactDir990702653/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
+{"t":1542876536372,"m":"Artifacts Dir:  /tmp/ArtifactDir990702653/artifacts","s":"sd-setup-launcher"}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -226,8 +226,8 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 
 	// Command to Export Env. Use tmpfile just in case export -p takes some time
 	exportEnvCmd :=
-	"tmpfile=" + tmpFile + "; exportfile=" + exportFile + "; " +
-	"export -p | grep -vi \"PS1=\" > $tmpfile && mv $tmpfile $exportfile; "
+		"tmpfile=" + tmpFile + "; exportfile=" + exportFile + "; " +
+			"export -p | grep -vi \"PS1=\" > $tmpfile && mv $tmpfile $exportfile; "
 
 	// Run setup commands
 	setupCommands := []string{
@@ -235,9 +235,9 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 		"export PATH=$PATH:/opt/sd",
 		// trap EXIT, echo the last step ID and write ENV to /tmp/buildEnv
 		"finish() { " +
-		"EXITCODE=$?; " +
-		exportEnvCmd +
-		"echo $SD_STEP_ID $EXITCODE; }",    //mv newfile to file
+			"EXITCODE=$?; " +
+			exportEnvCmd +
+			"echo $SD_STEP_ID $EXITCODE; }", //mv newfile to file
 		"trap finish EXIT;\n",
 	}
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -7,8 +7,8 @@ import (
 	"io/ioutil"
 	"os"
 	"reflect"
-	"strings"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -329,7 +329,7 @@ func TestTeardownEnv(t *testing.T) {
 			if stepName == "sd-teardown-doublequote" {
 				runSdTeardown = true
 			}
-			if (code != 0 && stepName != "doesnotexit") {	// all steps should pass except for this step
+			if code != 0 && stepName != "doesnotexit" { // all steps should pass except for this step
 				t.Errorf("step %v failed with exit code %v", stepName, code)
 			}
 			return nil
@@ -561,7 +561,7 @@ func TestUserShell(t *testing.T) {
 		{Cmd: "if [ $0 != /bin/bash ]; then exit 1; fi", Name: "sd-setup-step"},
 		{Cmd: "if [ $0 != /bin/bash ]; then exit 1; fi", Name: "user-step"},
 		{Cmd: "if [ $0 != /bin/bash ]; then exit 1; fi", Name: "teardown-user-step"},
-		{Cmd: "if [ $0 != /bin/bash ]; then exit 1; fi", Name: "sd-teardown-step"},	// source is not available in sh
+		{Cmd: "if [ $0 != /bin/bash ]; then exit 1; fi", Name: "sd-teardown-step"}, // source is not available in sh
 	}
 	env := map[string]string{
 		"USER_SHELL_BIN": "/bin/bash",

--- a/launch.go
+++ b/launch.go
@@ -163,6 +163,17 @@ func writeArtifact(aDir string, fName string, artifact interface{}) error {
 	return nil
 }
 
+// prNumber checks to see if the job name is a pull request and returns its number
+func prNumber(jobName string) string {
+	matched := r.FindStringSubmatch(jobName)
+	if matched == nil || len(matched) != 2 {
+		log.Println("This build is not a PR build")
+		return ""
+	}
+	log.Printf("Build is a PR: %v\n", matched[1])
+	return matched[1]
+}
+
 // convertToArray will convert the interface to an array of ints
 func convertToArray(i interface{}) (array []int) {
 	switch v := i.(type) {
@@ -180,17 +191,6 @@ func convertToArray(i interface{}) (array []int) {
 		var arr = make([]int, 0)
 		return arr
 	}
-}
-
-// prNumber checks to see if the job name is a pull request and returns its number
-func prNumber(jobName string) string {
-	matched := r.FindStringSubmatch(jobName)
-	if matched == nil || len(matched) != 2 {
-		log.Println("This build is not a PR build")
-		return ""
-	}
-	log.Printf("Build is a PR: %v\n", matched[1])
-	return matched[1]
 }
 
 func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, storeURL, shellBin string, buildTimeout int, buildToken string) error {
@@ -601,13 +601,13 @@ func main() {
 		}
 
 		if fetchFlag {
-			temporalApi, err := screwdriver.New(url, token)
+			temporalAPI, err := screwdriver.New(url, token)
 			if err != nil {
 				log.Printf("Error creating temporal Screwdriver API %v: %v", buildID, err)
 				exit(screwdriver.Failure, buildID, nil, metaSpace)
 			}
 
-			buildToken, err := temporalApi.GetBuildToken(buildID, c.Int("build-timeout"))
+			buildToken, err := temporalAPI.GetBuildToken(buildID, c.Int("build-timeout"))
 			if err != nil {
 				log.Printf("Error getting Build Token %v: %v", buildID, err)
 				exit(screwdriver.Failure, buildID, nil, metaSpace)

--- a/launch_test.go
+++ b/launch_test.go
@@ -876,7 +876,7 @@ func TestCreateEnvironment(t *testing.T) {
 	}
 	env, userShellBin := createEnvironment(base, secrets, testBuild)
 
-	if (userShellBin != "") {
+	if userShellBin != "" {
 		t.Errorf("Default userShellBin should be empty string")
 	}
 
@@ -917,7 +917,7 @@ func TestUserShellBin(t *testing.T) {
 	}
 	_, userShellBin := createEnvironment(base, secrets, testBuild)
 
-	if (userShellBin != "/bin/bash") {
+	if userShellBin != "/bin/bash" {
 		t.Errorf("userShellBin %v, expect %v", userShellBin, "/bin/bash")
 	}
 }

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: golang:1.10
+    image: golang:1.11
     environment:
         GOPATH: /sd/workspace
 

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -7,14 +7,14 @@ jobs:
     main:
         requires: [~pr, ~commit]
         steps:
+            - gover: go version
+            - gofmt: "(! gofmt -s -d . | grep '^')"
             - glide: |
                 export PATH=$PATH:$GOPATH/bin
                 go get -v github.com/Masterminds/glide
             - install: glide install
             - vet: go vet ./...
-            - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
-            - gover: go version
-            - test: GOCACHE=off go test ./...
+            - test: GOCACHE=off go test ./... -v
             # The emitter file is changed by a test, but we want to ignore it
             - ignore-git: git update-index --assume-unchanged data/emitter
             # Ensure we can compile

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -124,7 +124,7 @@ type CommandDef struct {
 	Cmd  string `json:"command"`
 }
 
-// Need a generic interface to take in an int or array of ints
+// IntOrArray is a generic interface to take in an int or array of ints
 type IntOrArray interface{}
 
 // Build is a Screwdriver Build

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -115,6 +115,7 @@ type Job struct {
 	ID         int    `json:"id"`
 	PipelineID int    `json:"pipelineId"`
 	Name       string `json:"name"`
+	PRNum      int    `json:"prNum"`
 }
 
 // CommandDef is the definition of a single executable command.


### PR DESCRIPTION
## Context
We want to implement `prChain` feature. If `prChain` is true, a job name does not have `PR-` prefix. So we will add `prNum` to Job schema.

## Objective
Use `prNum` instead of a job name.
This PR has backward compatibility so we can also use `PR-` prefix.
This PR also provides some refactoring.

## Misc.
Related Issue: https://github.com/screwdriver-cd/screwdriver/issues/1010
Related PRs:
- https://github.com/screwdriver-cd/data-schema/pull/296
- https://github.com/screwdriver-cd/config-parser/pull/81