### PR TITLE
fix(1403): Fix to correctly inherit pid of process

### DIFF
--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -20,4 +20,4 @@ smart_run mkdir -p /sd
 smart_run mkfifo -m 666 /sd/emitter
 
 # Entrypoint
-/opt/sd/tini -- /bin/sh -c "$@"
+exec /opt/sd/tini -- /bin/sh -c "$@"


### PR DESCRIPTION
Fix for give pid1 over subsequent process from `launher_entrypoint.sh`. As a result, tini has pid1, and SIGTERM processing is done correctly.

References:
- https://github.com/screwdriver-cd/screwdriver/issues/1403