### PR TITLE
fix: cache wget in launcher

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ RUN set -x \
    # @TODO Remove this, I don't think it belongs here.  We should use /hab/bin/hab instead.
    && cp /hab/bin/hab /opt/sd/bin/hab \
    # Install Habitat packages
-   && /hab/bin/hab pkg install core/bash core/git core/zip core/kmod core/iptables core/docker \
+   && /hab/bin/hab pkg install core/bash core/git core/zip core/kmod core/iptables core/docker core/wget \
    # Install curl 7.54.1 since we use that version in artifact-bookend
    # https://github.com/screwdriver-cd/artifact-bookend/blob/master/commands.txt
    && /hab/bin/hab pkg install core/curl/7.54.1 \


### PR DESCRIPTION
cache wget in launcher since the REPO feature will need that.