### PR TITLE
fix: skip init step [1]

### DIFF
--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -335,6 +335,12 @@ func (a api) BuildFromID(buildID int) (build Build, err error) {
 	if err != nil {
 		return build, fmt.Errorf("Parsing JSON response %q: %v", body, err)
 	}
+
+	initCmd := build.Commands[0]
+	if initCmd.Name == "sd-setup-init" {
+		build.Commands = build.Commands[1:]
+	}
+
 	return build, nil
 }
 

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -92,6 +92,9 @@ func TestBuildFromID(t *testing.T) {
 	}
 
 	testCmds := []CommandDef{}
+	testCmds = append(testCmds, CommandDef{
+		Name: "sd-setup-init",
+	})
 	for _, test := range commands {
 		testCmds = append(testCmds, CommandDef{
 			Name: "test",
@@ -155,6 +158,10 @@ func TestBuildFromID(t *testing.T) {
 
 		if !reflect.DeepEqual(err, test.err) {
 			t.Errorf("Unexpected error from BuildFromID: \n%v\n want \n%v", err.Error(), test.err.Error())
+		}
+
+		if len(test.build.Commands) != 0 {
+			test.build.Commands = test.build.Commands[1:]
 		}
 
 		if !reflect.DeepEqual(build, test.build) {


### PR DESCRIPTION
- init step has no actual cmd to be executed, it's just a placeholder for build stats.

Related to: https://github.com/screwdriver-cd/screwdriver/issues/1270