### PR TITLE
fix: increase http request timeout

### DIFF
--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -71,7 +71,7 @@ func New(url, token string) (API, error) {
 	newapi := api{
 		url,
 		token,
-		&http.Client{Timeout: 10 * time.Second},
+		&http.Client{Timeout: 20 * time.Second},
 	}
 	return API(newapi), nil
 }


### PR DESCRIPTION
we're seeing some network delay and cause some timeout err,  increase http request timeout from 10s to 20s

Related to: https://github.com/screwdriver-cd/screwdriver/issues/1443