### PR TITLE
fix: SD_PARENT_BUILD_ID is overflow 

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -154,6 +154,7 @@ func writeArtifact(aDir string, fName string, artifact interface{}) error {
 	}
 
 	pathToCreate := path.Join(aDir, fName)
+
 	err = writeFile(pathToCreate, data, 0644)
 	if err != nil {
 		return fmt.Errorf("Creating file %q : %v", pathToCreate, err)
@@ -251,6 +252,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		"build": buildMeta,
 	}
 
+	fmt.Printf("=================parentbuildIds %v\n", parentBuildIDs)
 	if len(parentBuildIDs) > 1 { // If has multiple parent build IDs, merge their metadata
 		// Get meta from all parent builds
 		for _, pbID := range parentBuildIDs {
@@ -265,6 +267,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 
 		metaLog = fmt.Sprintf(`Builds(%v)`, parentBuildIDs)
 	} else if len(parentBuildIDs) == 1 { // If has parent build, fetch from parent build
+		fmt.Printf("*****************%v\n",parentBuildIDs[0])
 		log.Printf("Fetching Parent Build %d", parentBuildIDs[0])
 		parentBuild, err := api.BuildFromID(parentBuildIDs[0])
 		if err != nil {
@@ -293,6 +296,8 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		}
 
 		metaLog = fmt.Sprintf(`Build(%v)`, parentBuild.ID)
+		fmt.Println("=======================1")
+		fmt.Println(metaLog)
 	} else if event.ParentEventID != 0 { // If has parent event, fetch meta from parent event
 		log.Printf("Fetching Parent Event %d", event.ParentEventID)
 		parentEvent, err := api.EventFromID(event.ParentEventID)
@@ -368,6 +373,9 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 
 	apiURL, _ := api.GetAPIURL()
 
+	fmt.Println("====================")
+	fmt.Print(parentBuildIDs)
+
 	defaultEnv := map[string]string{
 		"PS1":         "",
 		"SCREWDRIVER": "true",
@@ -381,7 +389,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		"SD_PIPELINE_NAME":       pipeline.ScmRepo.Name,
 		"SD_PULL_REQUEST":        pr,
 		"SD_PR_PARENT_JOB_ID":    strconv.Itoa(job.PrParentJobID),
-		"SD_PARENT_BUILD_ID":     fmt.Sprintf("%v", build.ParentBuildID),
+		"SD_PARENT_BUILD_ID":     fmt.Sprintf("%v", parentBuildIDs),
 		"SD_PARENT_EVENT_ID":     strconv.Itoa(event.ParentEventID),
 		"SD_SOURCE_DIR":          w.Src,
 		"SD_ROOT_DIR":            w.Root,

--- a/launch.go
+++ b/launch.go
@@ -154,7 +154,6 @@ func writeArtifact(aDir string, fName string, artifact interface{}) error {
 	}
 
 	pathToCreate := path.Join(aDir, fName)
-
 	err = writeFile(pathToCreate, data, 0644)
 	if err != nil {
 		return fmt.Errorf("Creating file %q : %v", pathToCreate, err)
@@ -252,7 +251,6 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		"build": buildMeta,
 	}
 
-	fmt.Printf("=================parentbuildIds %v\n", parentBuildIDs)
 	if len(parentBuildIDs) > 1 { // If has multiple parent build IDs, merge their metadata
 		// Get meta from all parent builds
 		for _, pbID := range parentBuildIDs {
@@ -267,7 +265,6 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 
 		metaLog = fmt.Sprintf(`Builds(%v)`, parentBuildIDs)
 	} else if len(parentBuildIDs) == 1 { // If has parent build, fetch from parent build
-		fmt.Printf("*****************%v\n",parentBuildIDs[0])
 		log.Printf("Fetching Parent Build %d", parentBuildIDs[0])
 		parentBuild, err := api.BuildFromID(parentBuildIDs[0])
 		if err != nil {
@@ -296,14 +293,13 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		}
 
 		metaLog = fmt.Sprintf(`Build(%v)`, parentBuild.ID)
-		fmt.Println("=======================1")
-		fmt.Println(metaLog)
 	} else if event.ParentEventID != 0 { // If has parent event, fetch meta from parent event
 		log.Printf("Fetching Parent Event %d", event.ParentEventID)
 		parentEvent, err := api.EventFromID(event.ParentEventID)
 		if err != nil {
 			return fmt.Errorf("Fetching Parent Event ID %d: %v", event.ParentEventID, err)
 		}
+
 		if parentEvent.Meta != nil {
 			mergedMeta = deepMergeJSON(parentEvent.Meta, mergedMeta)
 		}
@@ -372,9 +368,6 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 	}
 
 	apiURL, _ := api.GetAPIURL()
-
-	fmt.Println("====================")
-	fmt.Print(parentBuildIDs)
 
 	defaultEnv := map[string]string{
 		"PS1":         "",

--- a/launch_test.go
+++ b/launch_test.go
@@ -1225,6 +1225,9 @@ func TestFetchEventMeta(t *testing.T) {
 	var eventMeta []byte
 
 	api := mockAPI(t, TestBuildID, TestJobID, 0, "RUNNING")
+	api.buildFromID = func(buildID int) (screwdriver.Build, error) {
+		return screwdriver.Build(FakeBuild{ID: TestBuildID, EventID: TestEventID, JobID: TestJobID, SHA: TestSHA, }), nil
+	}
 	api.eventFromID = func(eventID int) (screwdriver.Event, error) {
 		if eventID == TestEventID {
 			return screwdriver.Event(FakeEvent{ID: TestEventID, Meta: mockMeta}), nil

--- a/launch_test.go
+++ b/launch_test.go
@@ -57,7 +57,7 @@ type FakeScmRepo screwdriver.ScmRepo
 func mockAPI(t *testing.T, testBuildID, testJobID, testPipelineID int, testStatus screwdriver.BuildStatus) MockAPI {
 	return MockAPI{
 		buildFromID: func(buildID int) (screwdriver.Build, error) {
-			return screwdriver.Build(FakeBuild{ID: testBuildID, EventID: TestEventID, JobID: testJobID, SHA: TestSHA, ParentBuildID: 1234}), nil
+			return screwdriver.Build(FakeBuild{ID: testBuildID, EventID: TestEventID, JobID: testJobID, SHA: TestSHA, ParentBuildID: float64(1234)}), nil
 		},
 		eventFromID: func(eventID int) (screwdriver.Event, error) {
 			return screwdriver.Event(FakeEvent{ID: TestEventID, ParentEventID: TestParentEventID}), nil
@@ -738,7 +738,7 @@ func TestSetEnv(t *testing.T) {
 		"SD_SONAR_AUTH_URL":      "https://api.screwdriver.cd/v4/coverage/token",
 		"SD_SONAR_HOST":          "https://sonar.screwdriver.cd",
 		"SD_TOKEN":               "foobar",
-		"SD_PARENT_BUILD_ID":     "1234",
+		"SD_PARENT_BUILD_ID":     "[1234]",
 		"SD_PARENT_EVENT_ID":     "3345",
 	}
 
@@ -1180,6 +1180,9 @@ func TestFetchParentEventMetaWriteError(t *testing.T) {
 	defer func() { marshal = oldMarshal }()
 
 	api := mockAPI(t, TestEventID, TestJobID, 0, "RUNNING")
+	api.buildFromID = func(buildID int) (screwdriver.Build, error) {
+		return screwdriver.Build(FakeBuild{ID: TestBuildID, EventID: TestEventID, JobID: TestJobID, SHA: TestSHA, }), nil
+	}
 	api.eventFromID = func(eventID int) (screwdriver.Event, error) {
 		if eventID == TestParentEventID {
 			return screwdriver.Event(FakeEvent{ID: TestParentEventID}), nil


### PR DESCRIPTION
Use `parentBuildID` instead of `build.ParentBuildID`, since that will through the [convertToArray logic](https://github.com/screwdriver-cd/launcher/blob/70fae824437541eee50167f96aa7ac804403fbe4/launch.go#L183-L188). This will solve the overflow problem. However, it will create a side effect that if single parent build ID, it'll still be an array (eg: `[1234]` instead of `1234`)


Related: https://github.com/screwdriver-cd/screwdriver/issues/1515