### PR TITLE
fix: Add another key server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ RUN set -x \
       gpg --no-tty --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 || \
       gpg --no-tty --keyserver pgp.mit.edu --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 || \
       gpg --no-tty --keyserver keyserver.pgp.com --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 || \
+      gpg --no-tty --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 || \
       gpg --no-tty --keyserver ha.pool.sks-keyservers.net --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
       ) \
    && found=yes && break; \


### PR DESCRIPTION
Adding another key server based on another example found here: https://github.com/nodejs/docker-node/blob/9e126c900676db68a1bb8c993565d1459280bf23/11/alpine/Dockerfile#L33-L35

Related to https://github.com/screwdriver-cd/launcher/pull/128, https://cloud.docker.com/u/screwdrivercd/repository/registry-1.docker.io/screwdrivercd/launcher/timeline