### PR TITLE
fix(1555): Switch order of run.sh flags

### DIFF
--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 # wrapper script for run build in multiple executors.
-SD_TOKEN=`/opt/sd/launch --only-fetch-token --token "$1" --api-uri "$2" --store-uri "$3" --emitter /sd/emitter --build-timeout "$4" "$5" --ui-uri "$6"` && (/opt/sd/launch --token "$SD_TOKEN" --api-uri "$2" --store-uri "$3" --emitter /sd/emitter --build-timeout "$4" "$5"  --ui-uri "$6" & /opt/sd/logservice --token "$SD_TOKEN" --emitter /sd/emitter --api-uri "$2" --store-uri "$3" --build "$5" & wait $(jobs -p))
+SD_TOKEN=`/opt/sd/launch --only-fetch-token --token "$1" --api-uri "$2" --store-uri "$3" --ui-uri "$6" --emitter /sd/emitter --build-timeout "$4" "$5"` && (/opt/sd/launch --token "$SD_TOKEN" --api-uri "$2" --store-uri "$3" --ui-uri "$6" --emitter /sd/emitter --build-timeout "$4" "$5" & /opt/sd/logservice --token "$SD_TOKEN" --emitter /sd/emitter --api-uri "$2" --store-uri "$3" --build "$5" & wait $(jobs -p))


### PR DESCRIPTION
The flag is not getting read when it is at the end of the command. Moving it to the middle.

Related to https://github.com/screwdriver-cd/screwdriver/issues/1555