### PR TITLE
fix: SD_META_PATH points to correct path

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -386,7 +386,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		"SD_SOURCE_DIR":          w.Src,
 		"SD_ROOT_DIR":            w.Root,
 		"SD_ARTIFACTS_DIR":       w.Artifacts,
-		"SD_META_PATH":           metaSpace + "/" + metaFile,
+		"SD_META_PATH":           metaSpace + "/meta.json",
 		"SD_BUILD_SHA":           build.SHA,
 		"SD_PULL_REQUEST":        pr,
 		"SD_API_URL":             apiURL,


### PR DESCRIPTION
`metaFile` is overwritten when there is an external triggered job.
`SD_META_PATH` should always point to the path of the current job meta, which is `{metaSpace}/meta.json`