### PR TITLE
fix: update alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.8
 MAINTAINER The Screwdrivers <screwdriver.cd>
 
 WORKDIR /opt/sd


### PR DESCRIPTION
our alpine version is a lot behind and using a pretty old version of busybox with limited cmds. Upgrade it to 3.8. Latest is on 3.9 and actively being worked on.