### PR TITLE
fix(1590): expandEnv

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -370,9 +370,9 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 	apiURL, _ := api.GetAPIURL()
 
 	defaultEnv := map[string]string{
-		"PS1":                    "",
-		"SCREWDRIVER":            "true",
-		"CI":                     "true",
+		"PS1":         "",
+		"SCREWDRIVER": "true",
+		"CI":          "true",
 		"CONTINUOUS_INTEGRATION": "true",
 		"SD_JOB_NAME":            oldJobName,
 		"SD_PIPELINE_NAME":       pipeline.ScmRepo.Name,
@@ -431,6 +431,7 @@ func createEnvironment(base map[string]string, secrets screwdriver.Secrets, buil
 
 	for k, v := range build.Environment {
 		os.Setenv(k, os.ExpandEnv(v))
+
 		if k == "USER_SHELL_BIN" {
 			userShellBin = v
 		}

--- a/launch.go
+++ b/launch.go
@@ -412,21 +412,42 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		return fmt.Errorf("Fetching secrets for build %v", build.ID)
 	}
 
-	osEnv, buildEnv , userShellBin := createEnvironment(defaultEnv, secrets, build)
+	env, userShellBin := createEnvironment(defaultEnv, secrets, build)
 	if userShellBin != "" {
 		shellBin = userShellBin
 	}
 
-	return executorRun(w.Src, osEnv, buildEnv, emitter, build, api, buildID, shellBin, buildTimeout, envFilepath)
+	return executorRun(w.Src, env, emitter, build, api, buildID, shellBin, buildTimeout, envFilepath)
 }
 
-func createEnvironment(base map[string]string, secrets screwdriver.Secrets, build screwdriver.Build) ([]string, string, string) {
+func createEnvironment(base map[string]string, secrets screwdriver.Secrets, build screwdriver.Build) ([]string, string) {
 	var userShellBin string
-
-	osEnvMap := map[string]string{}
 	buildEnvMap := map[string]string{}
 
-	// Start with the current environment
+	// Add the default environment values
+	for k, v := range base {
+		os.Setenv(k, v)
+	}
+
+	for k, v := range build.Environment {
+		os.Setenv(k, os.ExpandEnv(v))
+		if k == "USER_SHELL_BIN" {
+			userShellBin = v
+		}
+	}
+
+	// Add secrets to the environment
+	for _, s := range secrets {
+		os.Setenv(s.Name, os.ExpandEnv(s.Value))
+	}
+
+	for k, v := range buildEnvMap {
+		os.Setenv(k, os.ExpandEnv(v))
+	}
+
+	envMap := map[string]string{}
+
+	// Make an environment variables map
 	for _, e := range os.Environ() {
 		pieces := strings.SplitAfterN(e, "=", 2)
 		if len(pieces) != 2 {
@@ -437,38 +458,15 @@ func createEnvironment(base map[string]string, secrets screwdriver.Secrets, buil
 		k := pieces[0][:len(pieces[0])-1] // Drop the "=" off the end
 		v := pieces[1]
 
-		osEnvMap[k] = v
+		envMap[k] = v
 	}
 
-	osEnv := []string{}
-	for k, v := range osEnvMap {
-		osEnv = append(osEnv, strings.Join([]string{k, v}, "="))
+	env := []string{}
+	for k, v := range envMap {
+		env = append(env, strings.Join([]string{k, v}, "="))
 	}
 
-	// Add the default environment values
-	for k, v := range base {
-		buildEnvMap[k] = v
-	}
-
-	// Add secrets to the environment
-	for _, s := range secrets {
-		buildEnvMap[s.Name] = s.Value
-	}
-
-	// Create the final string slice
-	buildEnv := ""
-	for k, v := range buildEnvMap {
-		buildEnv += "export " + k + "=" + v + "\n"
-	}
-
-	for k, v := range build.Environment {
-		buildEnv += "export " + k + "=" + v + "\n"
-		if k == "USER_SHELL_BIN" {
-			userShellBin = v
-		}
-	}
-
-	return osEnv, buildEnv, userShellBin
+	return env, userShellBin
 }
 
 // Executes the command based on arguments from the CLI

--- a/launch_test.go
+++ b/launch_test.go
@@ -251,7 +251,7 @@ func TestMain(m *testing.M) {
 	open = func(f string) (*os.File, error) {
 		return os.Open("data/screwdriver.yaml")
 	}
-	executorRun = func(path string, osEnv []string, buildEnv string, emitter screwdriver.Emitter, build screwdriver.Build, api screwdriver.API, buildID int, shellBin string, timeout int, envFilepath string) error {
+	executorRun = func(path string, env []string, emitter screwdriver.Emitter, build screwdriver.Build, api screwdriver.API, buildID int, shellBin string, timeout int, envFilepath string) error {
 		return nil
 	}
 	cleanExit = func() {}
@@ -534,7 +534,7 @@ func TestUpdateBuildNonZeroFailure(t *testing.T) {
 
 	oldRun := executorRun
 	defer func() { executorRun = oldRun }()
-	executorRun = func(path string, osEnv []string, env string, out screwdriver.Emitter, build screwdriver.Build, a screwdriver.API, buildID int, shellBin string, timeout int, envFilepath string) error {
+	executorRun = func(path string, env []string, out screwdriver.Emitter, build screwdriver.Build, a screwdriver.API, buildID int, shellBin string, timeout int, envFilepath string) error {
 		return executor.ErrStatus{Status: 1}
 	}
 
@@ -722,32 +722,32 @@ func TestSetEnv(t *testing.T) {
 	defer func() { executorRun = oldExecutorRun }()
 
 	tests := map[string]string{
-		"export PS1":                    "",
-		"export SCREWDRIVER":            "true",
-		"export CI":                     "true",
-		"export CONTINUOUS_INTEGRATION": "true",
-		"export SD_JOB_NAME":            "PR-1",
-		"export SD_PIPELINE_NAME":       "screwdriver-cd/launcher",
-		"export SD_BUILD_ID":            "1234",
-		"export SD_JOB_ID":							"2345",
-		"export SD_EVENT_ID":            "2234",
-		"export SD_PIPELINE_ID":         "3456",
-		"export SD_PARENT_BUILD_ID":     "[1234]",
-		"export SD_PR_PARENT_JOB_ID":    "111",
-		"export SD_PARENT_EVENT_ID":     "3345",
-		"export SD_SOURCE_DIR":          "/sd/workspace/src/github.com/screwdriver-cd/launcher",
-		"export SD_ROOT_DIR":            "/sd/workspace",
-		"export SD_ARTIFACTS_DIR":       "/sd/workspace/artifacts",
-		"export SD_META_PATH":           "./data/meta/meta.json",
-		"export SD_BUILD_SHA":           "abc123",
-		"export SD_PULL_REQUEST":        "1",
-		"export SD_API_URL":             "https://api.screwdriver.cd/v4/",
-		"export SD_BUILD_URL":           "https://api.screwdriver.cd/v4/builds/1234",
-		"export SD_STORE_URL":           "https://store.screwdriver.cd/v1/",
-		"export SD_UI_URL":              "https://screwdriver.cd/",
-		"export SD_TOKEN":               "foobar",
-		"export SD_SONAR_AUTH_URL":      "https://api.screwdriver.cd/v4/coverage/token",
-		"export SD_SONAR_HOST":          "https://sonar.screwdriver.cd",
+		"PS1":                    "",
+		"SCREWDRIVER":            "true",
+		"CI":                     "true",
+		"CONTINUOUS_INTEGRATION": "true",
+		"SD_JOB_NAME":            "PR-1",
+		"SD_PIPELINE_NAME":       "screwdriver-cd/launcher",
+		"SD_BUILD_ID":            "1234",
+		"SD_JOB_ID":							"2345",
+		"SD_EVENT_ID":            "2234",
+		"SD_PIPELINE_ID":         "3456",
+		"SD_PARENT_BUILD_ID":     "[1234]",
+		"SD_PR_PARENT_JOB_ID":    "111",
+		"SD_PARENT_EVENT_ID":     "3345",
+		"SD_SOURCE_DIR":          "/sd/workspace/src/github.com/screwdriver-cd/launcher",
+		"SD_ROOT_DIR":            "/sd/workspace",
+		"SD_ARTIFACTS_DIR":       "/sd/workspace/artifacts",
+		"SD_META_PATH":           "./data/meta/meta.json",
+		"SD_BUILD_SHA":           "abc123",
+		"SD_PULL_REQUEST":        "1",
+		"SD_API_URL":             "https://api.screwdriver.cd/v4/",
+		"SD_BUILD_URL":           "https://api.screwdriver.cd/v4/builds/1234",
+		"SD_STORE_URL":           "https://store.screwdriver.cd/v1/",
+		"SD_UI_URL":              "https://screwdriver.cd/",
+		"SD_TOKEN":               "foobar",
+		"SD_SONAR_AUTH_URL":      "https://api.screwdriver.cd/v4/coverage/token",
+		"SD_SONAR_HOST":          "https://sonar.screwdriver.cd",
 	}
 
 	api := mockAPI(t, TestBuildID, TestJobID, TestPipelineID, "RUNNING")
@@ -756,20 +756,17 @@ func TestSetEnv(t *testing.T) {
 	}
 
 	foundEnv := map[string]string{}
-	executorRun = func(path string, osEnv []string, env string, emitter screwdriver.Emitter, build screwdriver.Build, api screwdriver.API, buildID int, shellBin string, timeout int, envFilepath string) error {
+	executorRun = func(path string, env []string, emitter screwdriver.Emitter, build screwdriver.Build, api screwdriver.API, buildID int, shellBin string, timeout int, envFilepath string) error {
 		if len(env) == 0 {
 			t.Fatalf("Unexpected empty environment passed to executorRun")
 		}
 
-		envArr := strings.Split(env, "\n")
-		for _, e := range envArr {
+		for _, e := range env {
 			split := strings.SplitN(e, "=", 2)
-			if e != "" {	// last line can be "", do not fail
-				if len(split) != 2 {
-					t.Fatalf("Bad environment value passed to executorRun: %s", e)
-				}
-				foundEnv[split[0]] = split[1]
+			if len(split) != 2 {
+				t.Fatalf("Bad environment value passed to executorRun: %s", e)
 			}
+			foundEnv[split[0]] = split[1]
 		}
 
 		return nil
@@ -786,8 +783,8 @@ func TestSetEnv(t *testing.T) {
 	}
 
 	// in case of no coverage plugins
-	delete(tests, "export SD_SONAR_AUTH_URL")
-	delete(tests, "export SD_SONAR_HOST")
+	delete(tests, "SD_SONAR_AUTH_URL")
+	delete(tests, "SD_SONAR_HOST")
 	TestEnvVars = map[string]string{}
 	foundEnv = map[string]string{}
 	err = launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUiURL, TestShellBin, TestBuildTimeout, TestBuildToken)
@@ -822,20 +819,17 @@ func TestEnvSecrets(t *testing.T) {
 	foundEnv := map[string]string{}
 	oldExecutorRun := executorRun
 	defer func() { executorRun = oldExecutorRun }()
-	executorRun = func(path string, osEnv []string, env string, emitter screwdriver.Emitter, build screwdriver.Build, api screwdriver.API, buildID int, shellBin string, timeout int, envFilepath string) error {
+	executorRun = func(path string, env []string, emitter screwdriver.Emitter, build screwdriver.Build, api screwdriver.API, buildID int, shellBin string, timeout int, envFilepath string) error {
 		if len(env) == 0 {
 			t.Fatalf("Unexpected empty environment passed to executorRun")
 		}
 
-		envArr := strings.Split(env, "\n")
-		for _, e := range envArr {
+		for _, e := range env {
 			split := strings.SplitN(e, "=", 2)
-			if e != "" {	// last line can be "", do not fail
-				if len(split) != 2 {
-					t.Fatalf("Bad environment value passed to executorRun: %s", e)
-				}
-				foundEnv[split[0]] = split[1]
+			if len(split) != 2 {
+				t.Fatalf("Bad environment value passed to executorRun: %s", e)
 			}
+			foundEnv[split[0]] = split[1]
 		}
 
 		return nil
@@ -846,7 +840,7 @@ func TestEnvSecrets(t *testing.T) {
 		t.Fatalf("Unexpected error from launch: %v", err)
 	}
 
-	if foundEnv["export FOONAME"] != "barvalue" {
+	if foundEnv["FOONAME"] != "barvalue" {
 		t.Errorf("secret not set in environment %v, want FOONAME=barvalue", foundEnv)
 	}
 }
@@ -873,31 +867,25 @@ func TestCreateEnvironment(t *testing.T) {
 		ID:          12345,
 		Environment: buildEnv,
 	}
-
-	osEnv, env, userShellBin := createEnvironment(base, secrets, testBuild)
-	envArr := strings.Split(env, "\n")
+	env, userShellBin := createEnvironment(base, secrets, testBuild)
 
 	if userShellBin != "" {
 		t.Errorf("Default userShellBin should be empty string")
 	}
 
 	foundEnv := map[string]bool{}
-	for _, i := range osEnv {
-		foundEnv[i] = true
-	}
-
-	for _, i := range envArr {
+	for _, i := range env {
 		foundEnv[i] = true
 	}
 
 	for _, want := range []string{
+		"SD_TOKEN=1234",
+		"FOO=bar",
+		"THINGWITHEQUALS=abc=def",
+		"secret1=secret1value",
+		"GETSOVERRIDDEN=override",
 		"OSENVWITHEQUALS=foo=bar=",
-		"export SD_TOKEN=1234",
-		"export FOO=bar",
-		"export THINGWITHEQUALS=abc=def",
-		"export secret1=secret1value",
-		"export GETSOVERRIDDEN=override",
-		"export GOPATH=/go/path",
+		"GOPATH=/go/path",
 	} {
 		if !foundEnv[want] {
 			t.Errorf("Did not receive expected environment setting %q", want)
@@ -920,7 +908,7 @@ func TestUserShellBin(t *testing.T) {
 		ID:          12345,
 		Environment: buildEnv,
 	}
-	_, _, userShellBin := createEnvironment(base, secrets, testBuild)
+	_, userShellBin := createEnvironment(base, secrets, testBuild)
 
 	if userShellBin != "/bin/bash" {
 		t.Errorf("userShellBin %v, expect %v", userShellBin, "/bin/bash")

--- a/launch_test.go
+++ b/launch_test.go
@@ -722,14 +722,14 @@ func TestSetEnv(t *testing.T) {
 	defer func() { executorRun = oldExecutorRun }()
 
 	tests := map[string]string{
-		"PS1":                    "",
-		"SCREWDRIVER":            "true",
-		"CI":                     "true",
+		"PS1":         "",
+		"SCREWDRIVER": "true",
+		"CI":          "true",
 		"CONTINUOUS_INTEGRATION": "true",
 		"SD_JOB_NAME":            "PR-1",
 		"SD_PIPELINE_NAME":       "screwdriver-cd/launcher",
 		"SD_BUILD_ID":            "1234",
-		"SD_JOB_ID":							"2345",
+		"SD_JOB_ID":              "2345",
 		"SD_EVENT_ID":            "2234",
 		"SD_PIPELINE_ID":         "3456",
 		"SD_PARENT_BUILD_ID":     "[1234]",
@@ -861,6 +861,7 @@ func TestCreateEnvironment(t *testing.T) {
 
 	buildEnv := map[string]string{
 		"GOPATH": "/go/path",
+		"EXPAND": "${GOPATH}/expand",
 	}
 
 	testBuild := screwdriver.Build{
@@ -886,6 +887,7 @@ func TestCreateEnvironment(t *testing.T) {
 		"GETSOVERRIDDEN=override",
 		"OSENVWITHEQUALS=foo=bar=",
 		"GOPATH=/go/path",
+		"EXPAND=/go/path/expand",
 	} {
 		if !foundEnv[want] {
 			t.Errorf("Did not receive expected environment setting %q", want)
@@ -1189,7 +1191,7 @@ func TestFetchParentEventMetaWriteError(t *testing.T) {
 
 	api := mockAPI(t, TestEventID, TestJobID, 0, "RUNNING")
 	api.buildFromID = func(buildID int) (screwdriver.Build, error) {
-		return screwdriver.Build(FakeBuild{ID: TestBuildID, EventID: TestEventID, JobID: TestJobID, SHA: TestSHA, }), nil
+		return screwdriver.Build(FakeBuild{ID: TestBuildID, EventID: TestEventID, JobID: TestJobID, SHA: TestSHA}), nil
 	}
 	api.eventFromID = func(eventID int) (screwdriver.Event, error) {
 		if eventID == TestParentEventID {
@@ -1234,7 +1236,7 @@ func TestFetchEventMeta(t *testing.T) {
 
 	api := mockAPI(t, TestBuildID, TestJobID, 0, "RUNNING")
 	api.buildFromID = func(buildID int) (screwdriver.Build, error) {
-		return screwdriver.Build(FakeBuild{ID: TestBuildID, EventID: TestEventID, JobID: TestJobID, SHA: TestSHA, }), nil
+		return screwdriver.Build(FakeBuild{ID: TestBuildID, EventID: TestEventID, JobID: TestJobID, SHA: TestSHA}), nil
 	}
 	api.eventFromID = func(eventID int) (screwdriver.Event, error) {
 		if eventID == TestEventID {


### PR DESCRIPTION
Related: https://github.com/screwdriver-cd/screwdriver/issues/1070

Doing expansion in `go` rather than doing it in the shell, since we get into different parsing issues. 
Thanks @jithin1987  for suggestions. 