### PR TITLE
fix: merge build predefined meta

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -250,6 +250,9 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 	mergedMeta := map[string]interface{}{
 		"build": buildMeta,
 	}
+	if build.Meta != nil {
+		mergedMeta = deepMergeJSON(build.Meta, mergedMeta)
+	}
 
 	if len(parentBuildIDs) > 1 { // If has multiple parent build IDs, merge their metadata
 		// Get meta from all parent builds

--- a/launch_test.go
+++ b/launch_test.go
@@ -927,6 +927,38 @@ func TestUserShellBin(t *testing.T) {
 	}
 }
 
+func TestFetchPredefinedMeta(t *testing.T) {
+	oldWriteFile := writeFile
+	defer func() { writeFile = oldWriteFile }()
+	var defaultMeta []byte
+	mockMeta := make(map[string]interface{})
+	mockMeta["foo"] = "bar"
+
+	api := mockAPI(t, TestBuildID, TestJobID, 0, "RUNNING")
+	api.buildFromID = func(buildID int) (screwdriver.Build, error) {
+		return screwdriver.Build(FakeBuild{ID: buildID, JobID: TestJobID, Meta: mockMeta}), nil
+	}
+	api.jobFromID = func(jobID int) (screwdriver.Job, error) {
+		return screwdriver.Job(FakeJob{ID: jobID, PipelineID: TestPipelineID, Name: "main"}), nil
+	}
+	api.pipelineFromID = func(pipelineID int) (screwdriver.Pipeline, error) {
+		return screwdriver.Pipeline(FakePipeline{ID: pipelineID, ScmURI: TestScmURI, ScmRepo: TestScmRepo}), nil
+	}
+	writeFile = func(path string, data []byte, perm os.FileMode) (err error) {
+		if path == "./data/meta/meta.json" {
+			defaultMeta = data
+		}
+		return nil
+	}
+
+	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUiURL, TestShellBin, TestBuildTimeout, TestBuildToken)
+	want := []byte("{\"build\":{\"buildId\":\"1234\",\"eventId\":\"0\",\"jobId\":\"2345\",\"jobName\":\"main\",\"pipelineId\":\"3456\",\"sha\":\"\"},\"foo\":\"bar\"}")
+
+	if err != nil || string(defaultMeta) != string(want) {
+		t.Errorf("Expected defaultMeta is %v, but: %v", string(want), string(defaultMeta))
+	}
+}
+
 func TestFetchDefaultMeta(t *testing.T) {
 	oldWriteFile := writeFile
 	defer func() { writeFile = oldWriteFile }()


### PR DESCRIPTION
now we pre-populate some build meta about commit in the model, when we create the meta for a build, we should merge those.

Related to https://github.com/screwdriver-cd/screwdriver/issues/1437