### PR TITLE
fix(1455): set SD_SOURCE_DIR properly when pipeline has rootDir (2)

### DIFF
--- a/launch_test.go
+++ b/launch_test.go
@@ -796,6 +796,23 @@ func TestSetEnv(t *testing.T) {
 			t.Fatalf("foundEnv[%s] = %s, want %s", k, foundEnv[k], v)
 		}
 	}
+
+	// set SD_SOURCE_DIR correctly with scm.RootDir
+	api.pipelineFromID = func(pipelineID int) (screwdriver.Pipeline, error) {
+		return screwdriver.Pipeline(FakePipeline{ID: pipelineID, ScmURI: TestScmURI + ":lib", ScmRepo: TestScmRepo}), nil
+	}
+	tests["SD_SOURCE_DIR"] = tests["SD_SOURCE_DIR"] + "/lib"
+	TestEnvVars = map[string]string{}
+	foundEnv = map[string]string{}
+	err = launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUiURL, TestShellBin, TestBuildTimeout, TestBuildToken)
+	if err != nil {
+		t.Fatalf("Unexpected error from launch: %v", err)
+	}
+	for k, v := range tests {
+		if foundEnv[k] != v {
+			t.Fatalf("foundEnv[%s] = %s, want %s", k, foundEnv[k], v)
+		}
+	}
 }
 
 func TestEnvSecrets(t *testing.T) {


### PR DESCRIPTION
set SD_SOURCE_DIR properly when pipeline has rootDir

Related to: https://github.com/screwdriver-cd/screwdriver/issues/1455