### PR TITLE
fix: accept env as array. BREAKING CHANGE: build environment is now an array

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -187,7 +187,7 @@ func TestUnmocked(t *testing.T) {
 			Commands: []screwdriver.CommandDef{
 				cmd,
 			},
-			Environment: map[string]string{},
+			Environment: []map[string]string{},
 		}
 		testAPI := screwdriver.API(MockAPI{
 			updateStepStart: func(buildID int, stepName string) error {
@@ -237,7 +237,7 @@ func TestMulti(t *testing.T) {
 	testBuild := screwdriver.Build{
 		ID:          12345,
 		Commands:    commands,
-		Environment: map[string]string{},
+		Environment: []map[string]string{},
 	}
 	runTeardown := false
 	runUserTeardown := false
@@ -314,7 +314,7 @@ func TestTeardownEnv(t *testing.T) {
 	testBuild := screwdriver.Build{
 		ID:          12345,
 		Commands:    commands,
-		Environment: map[string]string{},
+		Environment: []map[string]string{},
 	}
 	runWrapUserTeardown := false
 	runUserTeardown := false
@@ -371,7 +371,7 @@ func TestTeardownfail(t *testing.T) {
 	testBuild := screwdriver.Build{
 		ID:          12345,
 		Commands:    commands,
-		Environment: map[string]string{},
+		Environment: []map[string]string{},
 	}
 	testAPI := screwdriver.API(MockAPI{
 		updateStepStart: func(buildID int, stepName string) error {
@@ -401,7 +401,7 @@ func TestTimeout(t *testing.T) {
 	testBuild := screwdriver.Build{
 		ID:          12345,
 		Commands:    commands,
-		Environment: map[string]string{},
+		Environment: []map[string]string{},
 	}
 	testAPI := screwdriver.API(MockAPI{
 		updateStepStart: func(buildID int, stepName string) error {
@@ -574,9 +574,10 @@ func TestUserShell(t *testing.T) {
 		{Cmd: "if [ $0 != /bin/bash ]; then exit 1; fi", Name: "teardown-user-step"},
 		{Cmd: "if [ $0 != /bin/bash ]; then exit 1; fi", Name: "sd-teardown-step"}, // source is not available in sh
 	}
-	env := map[string]string{
+	var env []map[string]string
+	env = append(env, map[string]string{
 		"USER_SHELL_BIN": "/bin/bash",
-	}
+	})
 	testBuild := screwdriver.Build{
 		ID:          12345,
 		Commands:    commands,

--- a/launch.go
+++ b/launch.go
@@ -74,10 +74,10 @@ func exit(status screwdriver.BuildStatus, buildID int, api screwdriver.API, meta
 }
 
 type scmPath struct {
-	Host   	string
-	Org    	string
-	Repo   	string
-	Branch 	string
+	Host    string
+	Org     string
+	Repo    string
+	Branch  string
 	RootDir string
 }
 
@@ -91,10 +91,10 @@ func parseScmURI(scmURI, scmName string) (scmPath, error) {
 	}
 
 	parsed := scmPath{
-		Host:   uri[0],
-		Org:    orgRepo[0],
-		Repo:   orgRepo[1],
-		Branch: uri[2],
+		Host:    uri[0],
+		Org:     orgRepo[0],
+		Repo:    orgRepo[1],
+		Branch:  uri[2],
 		RootDir: "",
 	}
 
@@ -455,7 +455,6 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 
 func createEnvironment(base, cluster map[string]string, secrets screwdriver.Secrets, build screwdriver.Build) ([]string, string) {
 	var userShellBin string
-	buildEnvMap := map[string]string{}
 
 	// Add the default environment values
 	for k, v := range base {
@@ -466,11 +465,13 @@ func createEnvironment(base, cluster map[string]string, secrets screwdriver.Secr
 		os.Setenv(k, os.ExpandEnv(v))
 	}
 
-	for k, v := range build.Environment {
-		os.Setenv(k, os.ExpandEnv(v))
+	for _, env := range build.Environment {
+		for k, v := range env {
+			os.Setenv(k, os.ExpandEnv(v))
 
-		if k == "USER_SHELL_BIN" {
-			userShellBin = v
+			if k == "USER_SHELL_BIN" {
+				userShellBin = v
+			}
 		}
 	}
 
@@ -479,13 +480,9 @@ func createEnvironment(base, cluster map[string]string, secrets screwdriver.Secr
 		os.Setenv(s.Name, os.ExpandEnv(s.Value))
 	}
 
-	for k, v := range buildEnvMap {
-		os.Setenv(k, os.ExpandEnv(v))
-	}
-
 	envMap := map[string]string{}
 
-	// Make an environment variables map
+	// Go through environment and make an environment variables map
 	for _, e := range os.Environ() {
 		pieces := strings.SplitAfterN(e, "=", 2)
 		if len(pieces) != 2 {

--- a/launch.go
+++ b/launch.go
@@ -411,24 +411,6 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		"SD_TOKEN":               buildToken,
 	}
 
-	clusterEnv := map[string]string{
-		"SD_ZIP_ARTIFACTS": "true",
-		"SD_PROJECT":       "$SD_PIPELINE_ID",
-		"JOB":              "$SD_JOB_NAME",
-		"SD_JOB":           "$SD_JOB_NAME",
-		"SD_BUILD":         "$SD_BUILD_ID",
-		"ARTIFACTS_DIR":    "$SD_ARTIFACTS_DIR",
-		"TEST_DIR":         "$SD_ARTIFACTS_DIR/test",
-		"COVERAGE_DIR":     "$SD_ARTIFACTS_DIR/coverage",
-		"DOCS_DIR":         "$SD_ARTIFACTS_DIR/docs",
-		"PUBLISH_DIR":      "$SD_ARTIFACTS_DIR/publish",
-		"CACHE_DIR":        "/cache",
-		"TEMP_DIR":         "/tmp",
-		"BUILD_URL":        "$SD_BUILD_URL",
-		"SD_VERSION":       "4",
-		"GIT_COMMIT":       "$SD_BUILD_SHA",
-	}
-
 	// Add coverage env vars
 	coverageInfo, err := api.GetCoverageInfo()
 	if err != nil {
@@ -445,7 +427,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		return fmt.Errorf("Fetching secrets for build %v", build.ID)
 	}
 
-	env, userShellBin := createEnvironment(defaultEnv, clusterEnv, secrets, build)
+	env, userShellBin := createEnvironment(defaultEnv, secrets, build)
 	if userShellBin != "" {
 		shellBin = userShellBin
 	}
@@ -453,7 +435,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 	return executorRun(w.Src, env, emitter, build, api, buildID, shellBin, buildTimeout, envFilepath)
 }
 
-func createEnvironment(base, cluster map[string]string, secrets screwdriver.Secrets, build screwdriver.Build) ([]string, string) {
+func createEnvironment(base map[string]string, secrets screwdriver.Secrets, build screwdriver.Build) ([]string, string) {
 	var userShellBin string
 
 	// Add the default environment values
@@ -461,8 +443,8 @@ func createEnvironment(base, cluster map[string]string, secrets screwdriver.Secr
 		os.Setenv(k, os.ExpandEnv(v))
 	}
 
-	for k, v := range cluster {
-		os.Setenv(k, os.ExpandEnv(v))
+	for _, s := range secrets {
+		os.Setenv(s.Name, os.ExpandEnv(s.Value))
 	}
 
 	for _, env := range build.Environment {
@@ -473,11 +455,6 @@ func createEnvironment(base, cluster map[string]string, secrets screwdriver.Secr
 				userShellBin = v
 			}
 		}
-	}
-
-	// Add secrets to the environment
-	for _, s := range secrets {
-		os.Setenv(s.Name, os.ExpandEnv(s.Value))
 	}
 
 	envMap := map[string]string{}

--- a/launch_test.go
+++ b/launch_test.go
@@ -872,7 +872,7 @@ func TestCreateEnvironment(t *testing.T) {
 		"SD_PIPELINE_ID":  "888",
 	}
 	cluster := map[string]string{
-		"SD_PROJECT":        "$SD_PIPELINE_ID",
+		"SD_PROJECT": "$SD_PIPELINE_ID",
 	}
 
 	secrets := screwdriver.Secrets{
@@ -880,10 +880,9 @@ func TestCreateEnvironment(t *testing.T) {
 		{Name: "GETSOVERRIDDEN", Value: "override"},
 	}
 
-	buildEnv := map[string]string{
-		"GOPATH": "/go/path",
-		"EXPAND": "${GOPATH}/expand",
-	}
+	var buildEnv []map[string]string
+	buildEnv = append(buildEnv, map[string]string{"GOPATH": "/go/path"})
+	buildEnv = append(buildEnv, map[string]string{"EXPAND": "${GOPATH}/expand"})
 
 	testBuild := screwdriver.Build{
 		ID:          12345,
@@ -925,9 +924,8 @@ func TestUserShellBin(t *testing.T) {
 	base := map[string]string{}
 	cluster := map[string]string{}
 	secrets := screwdriver.Secrets{}
-	buildEnv := map[string]string{
-		"USER_SHELL_BIN": "/bin/bash",
-	}
+	var buildEnv []map[string]string
+	buildEnv = append(buildEnv, map[string]string{"USER_SHELL_BIN": "/bin/bash"})
 
 	testBuild := screwdriver.Build{
 		ID:          12345,

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -133,7 +133,7 @@ type Build struct {
 	JobID         int                    `json:"jobId"`
 	SHA           string                 `json:"sha"`
 	Commands      []CommandDef           `json:"steps"`
-	Environment   map[string]string      `json:"environment"`
+	Environment   []map[string]string    `json:"environment"`
 	ParentBuildID IntOrArray             `json:"parentBuildId"`
 	Meta          map[string]interface{} `json:"meta"`
 	EventID       int                    `json:"eventId"`

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -86,10 +86,9 @@ func TestBuildFromID(t *testing.T) {
 		{"neverexecuted", nil},
 	}
 
-	testEnv := map[string]string{
-		"foo": "bar",
-		"baz": "bah",
-	}
+	var testEnv []map[string]string
+	testEnv = append(testEnv, map[string]string{"foo": "bar"})
+	testEnv = append(testEnv, map[string]string{"baz": "bah"})
 
 	testCmds := []CommandDef{}
 	testCmds = append(testCmds, CommandDef{


### PR DESCRIPTION
We can merge this, but it needs to deploy at the same time as our API (https://github.com/screwdriver-cd/screwdriver/pull/1600)
Otherwise, it will break. 
- If API gets deployed first, API returns array but launcher expects object.
- If launcher gets deployed first, API still returns object and launcher expects an array. 

We might need some downtime to deploy this change. 

Related: https://github.com/screwdriver-cd/screwdriver/issues/1070