### PR TITLE
fix: Revert "fix: add default cluster env"

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -411,24 +411,6 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		"SD_TOKEN":               buildToken,
 	}
 
-	clusterEnv := map[string]string{
-		"SD_ZIP_ARTIFACTS": "true",
-		"SD_PROJECT":       "$SD_PIPELINE_ID",
-		"JOB":              "$SD_JOB_NAME",
-		"SD_JOB":           "$SD_JOB_NAME",
-		"SD_BUILD":         "$SD_BUILD_ID",
-		"ARTIFACTS_DIR":    "$SD_ARTIFACTS_DIR",
-		"TEST_DIR":         "$SD_ARTIFACTS_DIR/test",
-		"COVERAGE_DIR":     "$SD_ARTIFACTS_DIR/coverage",
-		"DOCS_DIR":         "$SD_ARTIFACTS_DIR/docs",
-		"PUBLISH_DIR":      "$SD_ARTIFACTS_DIR/publish",
-		"CACHE_DIR":        "/cache",
-		"TEMP_DIR":         "/tmp",
-		"BUILD_URL":        "$SD_BUILD_URL",
-		"SD_VERSION":       "4",
-		"GIT_COMMIT":       "$SD_BUILD_SHA",
-	}
-
 	// Add coverage env vars
 	coverageInfo, err := api.GetCoverageInfo()
 	if err != nil {
@@ -445,7 +427,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		return fmt.Errorf("Fetching secrets for build %v", build.ID)
 	}
 
-	env, userShellBin := createEnvironment(defaultEnv, clusterEnv, secrets, build)
+	env, userShellBin := createEnvironment(defaultEnv, secrets, build)
 	if userShellBin != "" {
 		shellBin = userShellBin
 	}
@@ -453,17 +435,13 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 	return executorRun(w.Src, env, emitter, build, api, buildID, shellBin, buildTimeout, envFilepath)
 }
 
-func createEnvironment(base, cluster map[string]string, secrets screwdriver.Secrets, build screwdriver.Build) ([]string, string) {
+func createEnvironment(base map[string]string, secrets screwdriver.Secrets, build screwdriver.Build) ([]string, string) {
 	var userShellBin string
 	buildEnvMap := map[string]string{}
 
 	// Add the default environment values
 	for k, v := range base {
-		os.Setenv(k, os.ExpandEnv(v))
-	}
-
-	for k, v := range cluster {
-		os.Setenv(k, os.ExpandEnv(v))
+		os.Setenv(k, v)
 	}
 
 	for k, v := range build.Environment {

--- a/launch_test.go
+++ b/launch_test.go
@@ -869,10 +869,6 @@ func TestCreateEnvironment(t *testing.T) {
 		"FOO":             "bar",
 		"THINGWITHEQUALS": "abc=def",
 		"GETSOVERRIDDEN":  "goesaway",
-		"SD_PIPELINE_ID":  "888",
-	}
-	cluster := map[string]string{
-		"SD_PROJECT":        "$SD_PIPELINE_ID",
 	}
 
 	secrets := screwdriver.Secrets{
@@ -889,7 +885,7 @@ func TestCreateEnvironment(t *testing.T) {
 		ID:          12345,
 		Environment: buildEnv,
 	}
-	env, userShellBin := createEnvironment(base, cluster, secrets, testBuild)
+	env, userShellBin := createEnvironment(base, secrets, testBuild)
 
 	if userShellBin != "" {
 		t.Errorf("Default userShellBin should be empty string")
@@ -909,7 +905,6 @@ func TestCreateEnvironment(t *testing.T) {
 		"OSENVWITHEQUALS=foo=bar=",
 		"GOPATH=/go/path",
 		"EXPAND=/go/path/expand",
-		"SD_PROJECT=888",
 	} {
 		if !foundEnv[want] {
 			t.Errorf("Did not receive expected environment setting %q", want)
@@ -923,7 +918,6 @@ func TestCreateEnvironment(t *testing.T) {
 
 func TestUserShellBin(t *testing.T) {
 	base := map[string]string{}
-	cluster := map[string]string{}
 	secrets := screwdriver.Secrets{}
 	buildEnv := map[string]string{
 		"USER_SHELL_BIN": "/bin/bash",
@@ -933,7 +927,7 @@ func TestUserShellBin(t *testing.T) {
 		ID:          12345,
 		Environment: buildEnv,
 	}
-	_, userShellBin := createEnvironment(base, cluster, secrets, testBuild)
+	_, userShellBin := createEnvironment(base, secrets, testBuild)
 
 	if userShellBin != "/bin/bash" {
 		t.Errorf("userShellBin %v, expect %v", userShellBin, "/bin/bash")


### PR DESCRIPTION
Will fix by passing the cluster env as API config, and inject into build.Environment