### PR TITLE
fix: pin hab version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN set -x \
    # Install Habitat
    && mkdir -p /hab/bin /opt/sd/bin \
    # Download Habitat Binary
-   && wget -O hab.tar.gz 'https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-$latest-x86_64-linux.tar.gz?bt_package=hab-x86_64-linux' \
+   && wget -O hab.tar.gz 'https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-0.79.1-20190410220617-x86_64-linux.tar.gz?bt_package=hab-x86_64-linux' \
    && tar -C . -ozxvf hab.tar.gz \
    && mv hab-*/hab /hab/bin/hab \
    && chmod +x /hab/bin/hab \


### PR DESCRIPTION
pin hab version since the latest one requires us to accept a chef license. Our docker builds are failing becausue of this.

ref: https://forums.habitat.sh/t/habitat-0-81-0-released/1095