### PR TITLE
 fix(1455): add SD_CHECKOUT_DIR

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -78,6 +78,7 @@ type scmPath struct {
 	Org     string
 	Repo    string
 	Branch  string
+	RootDir string
 }
 
 // e.g. scmUri: "github:123456:master", scmName: "screwdriver-cd/launcher"
@@ -89,12 +90,19 @@ func parseScmURI(scmURI, scmName string) (scmPath, error) {
 		return scmPath{}, fmt.Errorf("Unable to parse scmUri %v and scmName %v", scmURI, scmName)
 	}
 
-	return scmPath{
+	parsed := scmPath{
 		Host:    uri[0],
 		Org:     orgRepo[0],
 		Repo:    orgRepo[1],
 		Branch:  uri[2],
-	}, nil
+		RootDir: "",
+	}
+
+	if len(uri) > 3 {
+		parsed.RootDir = uri[3]
+	}
+
+	return parsed, nil
 }
 
 // A Workspace is a description of the paths available to a Screwdriver build
@@ -362,6 +370,10 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 	if err != nil {
 		return err
 	}
+	sourceDir := w.Src
+	if scm.RootDir != "" {
+		sourceDir = sourceDir + "/" + scm.RootDir
+	}
 
 	cyanFprintf(emitter, "Screwdriver Launcher information\n")
 	fmt.Fprintf(emitter, "%s%s\n", blackSprint("Version:        v"), version)
@@ -369,7 +381,8 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 	fmt.Fprintf(emitter, "%s%s\n", blackSprint("Job:            "), job.Name)
 	fmt.Fprintf(emitter, "%s%d\n", blackSprint("Build:          #"), buildID)
 	fmt.Fprintf(emitter, "%s%s\n", blackSprint("Workspace Dir:  "), w.Root)
-	fmt.Fprintf(emitter, "%s%s\n", blackSprint("Source Dir:     "), w.Src)
+	fmt.Fprintf(emitter, "%s%s\n", blackSprint("Checkout Dir:     "), w.Src)
+	fmt.Fprintf(emitter, "%s%s\n", blackSprint("Source Dir:     "), sourceDir)
 	fmt.Fprintf(emitter, "%s%s\n", blackSprint("Artifacts Dir:  "), w.Artifacts)
 
 	oldJobName := job.Name
@@ -404,7 +417,8 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		"SD_PARENT_BUILD_ID":     fmt.Sprintf("%v", parentBuildIDs),
 		"SD_PR_PARENT_JOB_ID":    strconv.Itoa(job.PrParentJobID),
 		"SD_PARENT_EVENT_ID":     strconv.Itoa(event.ParentEventID),
-		"SD_SOURCE_DIR":          w.Src,
+		"SD_SOURCE_DIR":          sourceDir,
+		"SD_CHECKOUT_DIR":        w.Src,
 		"SD_ROOT_DIR":            w.Root,
 		"SD_ARTIFACTS_DIR":       w.Artifacts,
 		"SD_META_PATH":           metaSpace + "/meta.json",

--- a/launch_test.go
+++ b/launch_test.go
@@ -794,23 +794,6 @@ func TestSetEnv(t *testing.T) {
 			t.Fatalf("foundEnv[%s] = %s, want %s", k, foundEnv[k], v)
 		}
 	}
-
-	// set SD_SOURCE_DIR correctly with scm.RootDir
-	api.pipelineFromID = func(pipelineID int) (screwdriver.Pipeline, error) {
-		return screwdriver.Pipeline(FakePipeline{ID: pipelineID, ScmURI: TestScmURI + ":lib", ScmRepo: TestScmRepo}), nil
-	}
-	tests["SD_SOURCE_DIR"] = tests["SD_SOURCE_DIR"] + "/lib"
-	TestEnvVars = map[string]string{}
-	foundEnv = map[string]string{}
-	err = launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUiURL, TestShellBin, TestBuildTimeout, TestBuildToken)
-	if err != nil {
-		t.Fatalf("Unexpected error from launch: %v", err)
-	}
-	for k, v := range tests {
-		if foundEnv[k] != v {
-			t.Fatalf("foundEnv[%s] = %s, want %s", k, foundEnv[k], v)
-		}
-	}
 }
 
 func TestEnvSecrets(t *testing.T) {


### PR DESCRIPTION
Add an new env `SD_CHECKOUT_DIR`. Later on, inside the scm-github, we will checkout at this checkoutDir. If you don't have custom `rootDir`, this will be the same as the SD_SOURCE_DIR. Otherwise `SD_CHECKOUT_DIR` will still be the path to the repo root dir, but `SD_SOURCE_DIR` will be `SD_CHECKOUT_DIR/rootDir`.

We need to separate this out so that when we clone, it will always clone to the root. And then we can cd to the proper source dir.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1455