### PR TITLE
fix(1670): fix not to expand Secrets

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -464,7 +464,7 @@ func createEnvironment(base map[string]string, secrets screwdriver.Secrets, buil
 	}
 
 	for _, s := range secrets {
-		os.Setenv(s.Name, os.ExpandEnv(s.Value))
+		os.Setenv(s.Name, s.Value)
 	}
 
 	for _, env := range build.Environment {

--- a/launch_test.go
+++ b/launch_test.go
@@ -874,6 +874,7 @@ func TestCreateEnvironment(t *testing.T) {
 		{Name: "secret1", Value: "secret1value"},
 		{Name: "GETSOVERRIDDEN", Value: "override"},
 		{Name: "MYSECRETPATH", Value: "secretpath"},
+		{Name: "WITHDOLLAR", Value: "$FOO"},
 	}
 
 	var buildEnv []map[string]string
@@ -906,6 +907,7 @@ func TestCreateEnvironment(t *testing.T) {
 		"GOPATH=/go/path",
 		"EXPANDENV=/go/path/expand",
 		"EXPANDSECRET=secretpath/home",
+		"WITHDOLLAR=$FOO",
 	} {
 		if !foundEnv[want] {
 			t.Errorf("Did not receive expected environment setting %q", want)


### PR DESCRIPTION
## Context
SD Secrets are often used for passing some passwords like XaaS. 
Those passwords sometimes include `$` or any other expandable char.

## Objective
This PR fixed not to expand Secrets.

## References
Related Issues:
- https://github.com/screwdriver-cd/screwdriver/issues/1670
- https://github.com/screwdriver-cd/screwdriver/issues/1070

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
