### PR TITLE
fix: cmdPath when running with sourceDir

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -452,7 +452,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		shellBin = userShellBin
 	}
 
-	return executorRun(w.Src, env, emitter, build, api, buildID, shellBin, buildTimeout, envFilepath)
+	return executorRun(sourceDir, env, emitter, build, api, buildID, shellBin, buildTimeout, envFilepath)
 }
 
 func createEnvironment(base map[string]string, secrets screwdriver.Secrets, build screwdriver.Build) ([]string, string) {


### PR DESCRIPTION
when using with subDir, the working directory should be `subDir`, not `w.Src`.

Related: https://github.com/screwdriver-cd/screwdriver/issues/1455