### PR TITLE
fix: set GIT_PAGER

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -407,6 +407,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		"PS1":                    "",
 		"SCREWDRIVER":            "true",
 		"CI":                     "true",
+		"GIT_PAGER":              "cat", // https://github.com/screwdriver-cd/screwdriver/issues/1583#issuecomment-539677403
 		"CONTINUOUS_INTEGRATION": "true",
 		"SD_JOB_NAME":            oldJobName,
 		"SD_PIPELINE_NAME":       pipeline.ScmRepo.Name,

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -11,7 +11,7 @@ jobs:
         steps:
             - install: go mod download
             - vet: go vet ./...
-            - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
+            - gofmt: "find . -name '*.go' | xargs gofmt -d"
             - gover: go version
             - test: go test -coverprofile=${SD_ARTIFACTS_DIR}/coverage.out -coverpkg=./...
             # The emitter file is changed by a test, but we want to ignore it


### PR DESCRIPTION
## Context

Screwdriver build shell is interactive. Setting GIT_PAGER until https://github.com/screwdriver-cd/screwdriver/issues/1583#issuecomment-539677403 is resolved.

## Objective

Set GIT_PAGER environment variable

## References
1. https://git-scm.com/docs/git#Documentation/git.txt-codeGITPAGERcode
1. https://stackoverflow.com/a/2183920/256400

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
