### PR TITLE
fix(1830): fix redeclaration error for event-cache-dir

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -641,10 +641,6 @@ func main() {
 			Name:   "event-cache-dir",
 			Usage:  "Event cache directory",
 		},
-		cli.StringFlag{
-			Name:   "event-cache-dir",
-			Usage:  "Event cache directory",
-		},
 		cli.BoolFlag{
 			Name:   "cache-compress",
 			Usage:  "To compress and store cache",


### PR DESCRIPTION
## Context

event-cache-dir declared twice 

## Objective

remove event-cache-dir redeclaration 

## References

[1830]

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
