### PR TITLE
fix(1906): pull latest store cli

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,9 +12,9 @@ builds:
     # Ensure the binary is static
     env:
       - CGO_ENABLED=0
-archive:
-  format: binary
-  name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+archives:
+  - format: binary
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
 
 # Put the packages in the artifacts dir (but it won't eval environment variables)
 dist: /sd/workspace/artifacts/dist


### PR DESCRIPTION
## Context

Not able to cherry-pick the folder or file in a directory and store or retrieve the cache.

## Objective

Pull the latest store-cli package which has the fix for build-cache disk-based strategy to cherry-pick the folder or file.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1906

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
