### PR TITLE
fix: change cacheMaxSizeInMB as StringFlag and parse as int64

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -651,7 +651,7 @@ func main() {
 			Name:  "cache-md5check",
 			Usage: "Do md5 check",
 		},
-		cli.Int64Flag{
+		cli.StringFlag{
 			Name:  "cache-max-size-mb",
 			Usage: "Cache allowed max size in mb",
 		},
@@ -688,7 +688,7 @@ func main() {
 		eventCacheDir := c.String("event-cache-dir")
 		cacheCompress, _ := strconv.ParseBool(c.String("cache-compress"))
 		cacheMd5Check, _ := strconv.ParseBool(c.String("cache-md5check"))
-		cacheMaxSizeInMB := c.Int64("cache-max-size-mb")
+		cacheMaxSizeInMB, _ := strconv.ParseInt(c.String("cache-max-size-mb"), 10, 64);
 		isLocal := c.Bool("local-mode")
 		localBuildJson := c.String("local-build-json")
 		localJobName := c.String("local-job-name")

--- a/launch.go
+++ b/launch.go
@@ -688,7 +688,7 @@ func main() {
 		eventCacheDir := c.String("event-cache-dir")
 		cacheCompress, _ := strconv.ParseBool(c.String("cache-compress"))
 		cacheMd5Check, _ := strconv.ParseBool(c.String("cache-md5check"))
-		cacheMaxSizeInMB, _ := strconv.ParseInt(c.String("cache-max-size-mb"), 10, 64);
+		cacheMaxSizeInMB, _ := strconv.ParseInt(c.String("cache-max-size-mb"), 10, 64)
 		isLocal := c.Bool("local-mode")
 		localBuildJson := c.String("local-build-json")
 		localJobName := c.String("local-job-name")


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Currently, if our `./Docker/run.sh` pass empty string `""` to `cacheMaxSizeInMB`, will cause `parse error`

![image](https://user-images.githubusercontent.com/15989893/73037346-93941180-3e03-11ea-9c1b-a59cab18596f.png)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR will relax and do a string to `int64` conversion for `cacheMaxSizeInMB` 

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
