### PR TITLE
fix(1928): store-cli - runtime error 10000 thread limit

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -654,7 +654,7 @@ func main() {
 		cli.StringFlag{
 			Name:  "cache-max-size-mb",
 			Usage: "Cache allowed max size in mb",
-			Value:  "0",
+			Value: "0",
 		},
 		cli.BoolFlag{
 			Name:  "local-mode",

--- a/launch.go
+++ b/launch.go
@@ -651,9 +651,10 @@ func main() {
 			Name:  "cache-md5check",
 			Usage: "Do md5 check",
 		},
-		cli.Int64Flag{
+		cli.StringFlag{
 			Name:  "cache-max-size-mb",
 			Usage: "Cache allowed max size in mb",
+			Value:  "0",
 		},
 		cli.BoolFlag{
 			Name:  "local-mode",


### PR DESCRIPTION
## Context

If files to be cached are more than 15000, store-cli throws runtime error 10000-thread limit and the cache-max-size-mb argument to be read as a string instead of Int64 

## Objective

This PR 1. gets the latest store-cli which has changes related to reduce md5check concurrency process limit to 3000 from 10000 and 2. update cache-max-size-mb argument to be read as a string instead of Int64 to handle docker error when sd is run locally.

## References

[1928](https://github.com/screwdriver-cd/screwdriver/issues/1928)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
