### PR TITLE
fix: run test recursively and refactor steps

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -9,11 +9,11 @@ jobs:
         environment:
             SD_SONAR_OPTS: "-Dsonar.sources=./  -Dsonar.exclusions=**/*_test.go,**/sonar-scanner*/** -Dsonar.go.coverage.reportPaths=/sd/workspace/artifacts/coverage.out"
         steps:
+            - gover: go version
             - install: go mod download
             - vet: go vet ./...
-            - gofmt: ret=$(find . -name '*.go' | xargs gofmt -d) && echo "$ret" && test -z "$ret"
-            - gover: go version
-            - test: go test -coverprofile=${SD_ARTIFACTS_DIR}/coverage.out -coverpkg=./...
+            - gofmt: (! gofmt -d . | grep '^')
+            - test: go test ./... -coverprofile=${SD_ARTIFACTS_DIR}/coverage.out -coverpkg=./...
             # Ensure we can compile
             - build: go build -a -o /dev/null
             # Test cross-compiling as well


### PR DESCRIPTION
## Context

Tests do not run recursively. It tests only `launch`. 
https://cd.screwdriver.cd/pipelines/21/builds/169248/steps/test

## Objective
- Run test recursively.
- Refactor some steps.


## References
https://github.com/screwdriver-cd/meta-cli/blob/master/screwdriver.yaml


## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
