### PR TITLE
fix: bring handleResponse under retry purview

### DIFF
--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -176,8 +176,6 @@ func tokenHeader(token string) string {
 }
 
 func handleResponse(res *http.Response) ([]byte, error) {
-	defer res.Body.Close()
-
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		return nil, fmt.Errorf("Reading response Body from Screwdriver: %v", err)
@@ -235,6 +233,8 @@ func (a api) get(url *url.URL) ([]byte, error) {
 			return nil, err
 		}
 
+		defer res.Body.Close()
+
 		if res.StatusCode/100 == 5 {
 			log.Printf("WARNING: received response %d from GET %s "+
 				"(attempt %d of %d)", res.StatusCode, url.String(), attemptNumber, maxAttempts)
@@ -274,6 +274,8 @@ func (a api) write(url *url.URL, requestType string, bodyType string, payload io
 				"(attempt %d of %d)", requestType, url.String(), err, attemptNumber, maxAttempts)
 			return nil, err
 		}
+
+		defer res.Body.Close()
 
 		if res.StatusCode/100 == 5 {
 			log.Printf("WARNING: received response %d from %s "+

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -176,6 +176,8 @@ func tokenHeader(token string) string {
 }
 
 func handleResponse(res *http.Response) ([]byte, error) {
+	defer res.Body.Close()
+
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		return nil, fmt.Errorf("Reading response Body from Screwdriver: %v", err)
@@ -185,18 +187,22 @@ func handleResponse(res *http.Response) ([]byte, error) {
 		var err SDError
 		parserr := json.Unmarshal(body, &err)
 		if parserr != nil {
-			return nil, fmt.Errorf("Unparseable error response from Screwdriver: %v", parserr)
+			return nil, SDError{Message: fmt.Sprintf("Unparseable error response from Screwdriver: %v", parserr)}
 		}
 		return nil, err
 	}
 	return body, nil
 }
 
-func retry(attempts int, callback func() error) (err error) {
+func retry(attempts int, callback func() ([]byte, error)) (data []byte, err error) {
 	for i := 0; ; i++ {
-		err = callback()
-		if err == nil {
-			return nil
+		data, err = callback()
+
+		switch err := err.(type) {
+		case nil:
+			return data, nil
+		case SDError:
+			return nil, err
 		}
 
 		if i >= (attempts - 1) {
@@ -207,7 +213,7 @@ func retry(attempts int, callback func() error) (err error) {
 		duration := time.Duration(math.Pow(2, float64(i+1)))
 		sleep(duration * time.Second)
 	}
-	return fmt.Errorf("After %d attempts, Last error: %s", attempts, err)
+	return nil, fmt.Errorf("After %d attempts, Last error: %v", attempts, err)
 }
 
 func (a api) get(url *url.URL) ([]byte, error) {
@@ -220,31 +226,24 @@ func (a api) get(url *url.URL) ([]byte, error) {
 	res := &http.Response{}
 	attemptNumber := 0
 
-	err = retry(maxAttempts, func() error {
+	return retry(maxAttempts, func() ([]byte, error) {
 		attemptNumber++
 		res, err = a.client.Do(req)
 		if err != nil {
 			log.Printf("WARNING: received error from GET(%s): %v "+
 				"(attempt %d of %d)", url.String(), err, attemptNumber, maxAttempts)
-			return err
+			return nil, err
 		}
 
 		if res.StatusCode/100 == 5 {
 			log.Printf("WARNING: received response %d from GET %s "+
 				"(attempt %d of %d)", res.StatusCode, url.String(), attemptNumber, maxAttempts)
-			return fmt.Errorf("GET retries exhausted: %d returned from GET %s",
+			return nil, fmt.Errorf("GET retries exhausted: %d returned from GET %s",
 				res.StatusCode, url.String())
 		}
-		return nil
+
+		return handleResponse(res)
 	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	defer res.Body.Close()
-
-	return handleResponse(res)
 }
 
 func (a api) write(url *url.URL, requestType string, bodyType string, payload io.Reader) ([]byte, error) {
@@ -256,14 +255,14 @@ func (a api) write(url *url.URL, requestType string, bodyType string, payload io
 	req := &http.Request{}
 	attemptNumber := 0
 
-	err := retry(maxAttempts, func() error {
+	return retry(maxAttempts, func() ([]byte, error) {
 		attemptNumber++
 		var err error
 		req, err = http.NewRequest(requestType, url.String(), strings.NewReader(p))
 		if err != nil {
 			log.Printf("WARNING: received error generating new request for %s(%s): %v "+
 				"(attempt %v of %v)", requestType, url.String(), err, attemptNumber, maxAttempts)
-			return err
+			return nil, err
 		}
 
 		req.Header.Set("Authorization", tokenHeader(a.token))
@@ -273,25 +272,17 @@ func (a api) write(url *url.URL, requestType string, bodyType string, payload io
 		if err != nil {
 			log.Printf("WARNING: received error from %s(%s): %v "+
 				"(attempt %d of %d)", requestType, url.String(), err, attemptNumber, maxAttempts)
-			return err
+			return nil, err
 		}
 
 		if res.StatusCode/100 == 5 {
 			log.Printf("WARNING: received response %d from %s "+
 				"(attempt %d of %d)", res.StatusCode, url.String(), attemptNumber, maxAttempts)
-			return fmt.Errorf("retries exhausted: %d returned from %s",
+			return nil, fmt.Errorf("retries exhausted: %d returned from %s",
 				res.StatusCode, url.String())
 		}
-		return nil
+		return handleResponse(res)
 	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	defer res.Body.Close()
-
-	return handleResponse(res)
 }
 
 func (a api) post(url *url.URL, bodyType string, payload io.Reader) ([]byte, error) {


### PR DESCRIPTION
## Context

`handleResonse` is currently run outside of retry handler. But in `golang` Timeout in inclusive of time spent in parsing response body.

## Objective

Bring `handleResponse` function under retry protection for timeout.

## References

1. https://github.com/screwdriver-cd/launcher/blob/master/screwdriver/screwdriver.go#L223-L247
2 https://golang.org/pkg/net/http/#Client
```
 The timeout includes connection time, any
    // redirects, and reading the response body.
```

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
