### PR TITLE
fix(1314): Fix about local-mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,7 @@ COPY Docker/launcher_entrypoint.sh /opt/sd/launcher_entrypoint.sh
 
 # Copy wrapper script to the image
 COPY Docker/run.sh /opt/sd/run.sh
+COPY Docker/local_run.sh /opt/sd/local_run.sh
 
 VOLUME /opt/sd
 VOLUME /hab

--- a/launch.go
+++ b/launch.go
@@ -116,7 +116,7 @@ type Workspace struct {
 // e.g. ["github.com", "screwdriver-cd" "screwdriver"] creates
 //     /sd/workspace/src/github.com/screwdriver-cd/screwdriver
 //     /sd/workspace/artifacts
-func createWorkspace(rootDir string, srcPaths ...string) (Workspace, error) {
+func createWorkspace(isLocal bool, rootDir string, srcPaths ...string) (Workspace, error) {
 	srcPaths = append([]string{"src"}, srcPaths...)
 	src := path.Join(srcPaths...)
 
@@ -129,7 +129,7 @@ func createWorkspace(rootDir string, srcPaths ...string) (Workspace, error) {
 	}
 	for _, p := range paths {
 		_, err := stat(p)
-		if err == nil {
+		if err == nil && !isLocal {
 			msg := "Cannot create workspace path %q, path already exists."
 			return Workspace{}, fmt.Errorf(msg, p)
 		}
@@ -366,7 +366,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 	}
 
 	log.Printf("Creating Workspace in %v", rootDir)
-	w, err := createWorkspace(rootDir, scm.Host, scm.Org, scm.Repo)
+	w, err := createWorkspace(isLocal, rootDir, scm.Host, scm.Org, scm.Repo)
 	if err != nil {
 		return err
 	}

--- a/launch_test.go
+++ b/launch_test.go
@@ -382,7 +382,7 @@ func TestCreateWorkspace(t *testing.T) {
 		madeDirs[path] = perm
 		return nil
 	}
-	workspace, err := createWorkspace(TestWorkspace, "screwdriver-cd", "launcher")
+	workspace, err := createWorkspace(false, TestWorkspace, "screwdriver-cd", "launcher")
 
 	if err != nil {
 		t.Errorf("Unexpected error creating workspace: %v", err)
@@ -454,7 +454,7 @@ func TestCreateWorkspaceBadStat(t *testing.T) {
 
 	wantWorkspace := Workspace{}
 
-	workspace, err := createWorkspace(TestWorkspace, "screwdriver-cd", "launcher")
+	workspace, err := createWorkspace(false, TestWorkspace, "screwdriver-cd", "launcher")
 
 	if err.Error() != "Cannot create workspace path \"/sd/workspace/src/screwdriver-cd/launcher\", path already exists." {
 		t.Errorf("Error is wrong, got %v", err)

--- a/launch_test.go
+++ b/launch_test.go
@@ -465,6 +465,31 @@ func TestCreateWorkspaceBadStat(t *testing.T) {
 	}
 }
 
+func TestCreateWorkspaceBadStatLocal(t *testing.T) {
+	oldStat := stat
+	defer func() { stat = oldStat }()
+
+	stat = func(path string) (info os.FileInfo, err error) {
+		return nil, nil
+	}
+
+	wantWorkspace := Workspace{
+		Root:      TestWorkspace,
+		Src:       "/sd/workspace/src/screwdriver-cd/launcher",
+		Artifacts: "/sd/workspace/artifacts",
+	}
+
+	workspace, err := createWorkspace(true, TestWorkspace, "screwdriver-cd", "launcher")
+
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+
+	if workspace != wantWorkspace {
+		t.Errorf("Workspace == %q, want %q", workspace, wantWorkspace)
+	}
+}
+
 func TestUpdateBuildStatusError(t *testing.T) {
 	api := mockAPI(t, TestBuildID, 0, 0, screwdriver.Running)
 	api.updateBuildStatus = func(status screwdriver.BuildStatus, meta map[string]interface{}, buildID int) error {

--- a/screwdriver/screwdriver_local.go
+++ b/screwdriver/screwdriver_local.go
@@ -54,7 +54,7 @@ func (a localApi) JobFromID(jobID int) (job Job, err error) {
 func (a localApi) PipelineFromID(pipelineID int) (pipeline Pipeline, err error) {
 	pipeline = Pipeline{
 		ID:      0,
-		ScmRepo: ScmRepo{"local-build/src"},
+		ScmRepo: ScmRepo{"sd-local/local-build"},
 		ScmURI:  "screwdriver.cd:123456:master",
 	}
 

--- a/screwdriver/screwdriver_local.go
+++ b/screwdriver/screwdriver_local.go
@@ -54,8 +54,8 @@ func (a localApi) JobFromID(jobID int) (job Job, err error) {
 func (a localApi) PipelineFromID(pipelineID int) (pipeline Pipeline, err error) {
 	pipeline = Pipeline{
 		ID:      0,
-		ScmRepo: ScmRepo{"screwdriver-cd/screwdriver"},
-		ScmURI:  "github.com:123456:master",
+		ScmRepo: ScmRepo{"local-build/src"},
+		ScmURI:  "screwdriver.cd:123456:master",
 	}
 
 	return pipeline, nil

--- a/screwdriver/screwdriver_local_test.go
+++ b/screwdriver/screwdriver_local_test.go
@@ -62,7 +62,7 @@ func TestPipelineFromIDLocal(t *testing.T) {
 	testAPI := localApi{"http://fakeurl", "testJob", Build{}}
 	expected := Pipeline{
 		0,
-		ScmRepo{"local-build/src"},
+		ScmRepo{"sd-local/local-build"},
 		"screwdriver.cd:123456:master",
 	}
 

--- a/screwdriver/screwdriver_local_test.go
+++ b/screwdriver/screwdriver_local_test.go
@@ -62,8 +62,8 @@ func TestPipelineFromIDLocal(t *testing.T) {
 	testAPI := localApi{"http://fakeurl", "testJob", Build{}}
 	expected := Pipeline{
 		0,
-		ScmRepo{"screwdriver-cd/screwdriver"},
-		"github.com:123456:master",
+		ScmRepo{"local-build/src"},
+		"screwdriver.cd:123456:master",
 	}
 
 	actual, err := testAPI.PipelineFromID(0)

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -460,7 +460,7 @@ func TestUpdateStepStart(t *testing.T) {
 	http := makeValidatedFakeHTTPClient(t, 200, "{}", func(r *http.Request) {
 		buf := new(bytes.Buffer)
 		buf.ReadFrom(r.Body)
-		want := regexp.MustCompile(`{"startTime":"[\d-]+T[\d:.Z-]+"}`)
+		want := regexp.MustCompile(`{"startTime":"[\d-]+T[\d:.(Z-|Z+)]+"}`)
 		if !want.MatchString(buf.String()) {
 			t.Errorf("buf.String() = %q", buf.String())
 		}
@@ -478,7 +478,7 @@ func TestUpdateStepStop(t *testing.T) {
 	http := makeValidatedFakeHTTPClient(t, 200, "{}", func(r *http.Request) {
 		buf := new(bytes.Buffer)
 		buf.ReadFrom(r.Body)
-		want := regexp.MustCompile(`{"endTime":"[\d-]+T[\d:.Z-]+","code":10}`)
+		want := regexp.MustCompile(`{"endTime":"[\d-]+T[\d:.(Z-|Z+)]+","code":10}`)
 		if !want.MatchString(buf.String()) {
 			t.Errorf("buf.String() = %q", buf.String())
 		}


### PR DESCRIPTION
## Context
`sd-local` mounts workspace from host filesystem, but launcher check it has already existed, and if so launcher throws error.
To avoid this, this PR makes launcher not to throw that error.
And, we forgot to copy `local_run.sh` to Docker Image.
And furthermore, we want to use `/sd/workspace/src/{dummyScmHost}/{dummyScmOrg}/{dummyScmRepo}` as source directory in local-mode
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- make `createWorkspace` function not to throw error about `path already exists` in local-mode
- copy `local_run.sh` to Docker Image
- fix dummy `Pipeline` information
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
screwdriver-cd/screwdriver#1314
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
