### PR TITLE
feat(818): push image metrics to prometheus

### DIFF
--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -2,7 +2,7 @@
 
 # push data to prometheus via pushgateway url
 function pushToPrometheus {
-  curl -m 10 --data-binary @- "$PUSHGATEWAY_URL/metrics/job/containerd$1" || true
+  curl -s -m 10 --data-binary @- "$PUSHGATEWAY_URL/metrics/job/containerd$1" &>/dev/null &
 }
 
 # Get push gateway url and container image from env variable

--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -6,7 +6,7 @@ function pushToPrometheus {
 }
 
 # Get push gateway url and container image from env variable
-if [[ ! -z "$PUSHGATEWAY_URL" ]] && [[ ! -z "$CONTAINER_IMAGE" ]] && [[ !z "$SD_PIPELINE_ID" ]]; then
+if [[ ! -z "$PUSHGATEWAY_URL" ]] && [[ ! -z "$CONTAINER_IMAGE" ]] && [[ ! -z "$SD_PIPELINE_ID" ]]; then
   echo "Push metrics to prometheus"
   cat <<EOF | pushToPrometheus "$5"
 sd_build_image{image_name="$CONTAINER_IMAGE", pipeline_id="$SD_PIPELINE_ID", node="$5"} 1

--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -1,4 +1,17 @@
 #!/bin/sh
 
+# push data to prometheus via pushgateway url
+function pushToPrometheus {
+  curl -m 10 --data-binary @- "$PUSHGATEWAY_URL/metrics/job/containerd$1" || true
+}
+
+# Get push gateway url and container image from env variable
+if [[ ! -z "$PUSHGATEWAY_URL" ]] && [[ ! -z "$CONTAINER_IMAGE" ]] && [[ !z "$SD_PIPELINE_ID" ]]; then
+  echo "Push metrics to prometheus"
+  cat <<EOF | pushToPrometheus "$5"
+sd_build_image{image_name="$CONTAINER_IMAGE", pipeline_id="$SD_PIPELINE_ID", node="$5"} 1
+EOF
+fi
+
 # wrapper script for run build in multiple executors.
 SD_TOKEN=`/opt/sd/launch --only-fetch-token --token "$1" --api-uri "$2" --store-uri "$3" --ui-uri "$6" --emitter /sd/emitter --build-timeout "$4" --cache-strategy "$7" --pipeline-cache-dir "$8" --job-cache-dir "$9" --event-cache-dir "${10}" --cache-compress "${11}" --cache-md5check "${12}" --cache-max-size-mb "${13}" "$5"` && (/opt/sd/launch --token "$SD_TOKEN" --api-uri "$2" --store-uri "$3" --ui-uri "$6" --emitter /sd/emitter --build-timeout "$4" --cache-strategy "$7" --pipeline-cache-dir "$8" --job-cache-dir "$9" --event-cache-dir "${10}" --cache-compress "${11}" --cache-md5check "${12}" --cache-max-size-mb "${13}" "$5" & /opt/sd/logservice --token "$SD_TOKEN" --emitter /sd/emitter --api-uri "$2" --store-uri "$3" --build "$5" & wait $(jobs -p))


### PR DESCRIPTION
## Context

Top images to be cached in the node are not available as part of the node warm-up.

## Objective

Send image metrics to Prometheus via pushgateway configuration. These metrics will be used to query top n images and cached in node as part of the node warm-up. Environment variables are passed from executor-k8s.

When Docker/run.sh is called via executor-k8s-vm, it will skip metrics push to Prometheus. It's already implemented via hyperctl-docker scripts.

## References

[Evaluate Kata Containers over HyperD](https://github.com/screwdriver-cd/screwdriver/issues/818)
[Executor-k8s PR-117](https://github.com/screwdriver-cd/executor-k8s/pull/117)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
