### PR TITLE
fix(1314): export setup log before following steps are executed

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -102,6 +102,31 @@ func copyLinesUntil(r io.Reader, w io.Writer, match string) (int, error) {
 	return ExitOk, nil
 }
 
+func doRunSetupCommand(emitter screwdriver.Emitter, f *os.File, r io.Reader, setupCommands []string) error {
+	var (
+		t      string
+		err    error
+		reader = bufio.NewReader(r)
+	)
+
+	shargs := strings.Join(setupCommands, " && ")
+
+	f.Write([]byte(shargs))
+
+	t, err = readln(reader)
+	for err == nil {
+		if t == "" {
+			return nil
+		}
+		fmt.Fprintln(emitter, t)
+		t, err = readln(reader)
+	}
+	if err != nil {
+		return fmt.Errorf("Error with reader: %v", err)
+	}
+	return nil
+}
+
 func doRunCommand(guid, path string, emitter screwdriver.Emitter, f *os.File, fReader io.Reader) (int, error) {
 	executionCommand := []string{
 		"export SD_STEP_ID=" + guid,
@@ -237,12 +262,13 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 			"EXITCODE=$?; " +
 			exportEnvCmd +
 			"echo $SD_STEP_ID $EXITCODE; }", //mv newfile to file
-		"trap finish EXIT;\n",
+		"trap finish EXIT;\necho ;\n",
 	}
 
-	shargs := strings.Join(setupCommands, " && ")
-
-	f.Write([]byte(shargs))
+	setupReader := bufio.NewReader(f)
+	if err := doRunSetupCommand(emitter, f, setupReader, setupCommands); err != nil {
+		return err
+	}
 
 	var firstError error
 	var code int


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Currently, setup-launcher command logs are shown in following steps command when use sd-local.
```
sd-setup-launcher: Screwdriver Launcher information
sd-setup-launcher: Version:        v6.0.49
sd-setup-launcher: Pipeline:       #0
sd-setup-launcher: Job:            test
sd-setup-launcher: Build:          #0
sd-setup-launcher: Workspace Dir:  /sd/workspace
sd-setup-launcher: Checkout Dir:     /sd/workspace/src/screwdriver.cd/sd-local/local-build
sd-setup-launcher: Source Dir:     /sd/workspace/src/screwdriver.cd/sd-local/local-build
sd-setup-launcher: Artifacts Dir:  /sd/workspace/artifacts
init: $ echo 'Init step'
init: set -e && export PATH=$PATH:/opt/sd && finish() { EXITCODE=$?; tmpfile=/tmp/env_tmp; exportfile=/tmp/env_export; export -p | grep -vi "PS1=" > $tmpfile && mv $tmpfile $exportfile; echo $SD_STEP_ID $EXITCODE; } && trap finish EXIT;
init: Init step
```
This is because the command `sd-setup-launcher` was executed before the next step, but its log is output at the same time as the output of the next command.
In online Screwdriver, each step logs export to each file. However, in sd-local, all logs export to one file.
Therefore, this problem only happen in sd-local.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Export `sd-setup-launcher` output to log before next step's commands are executed.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
