### PR TITLE
feat(818): update hab, log pipe n launch setup

### DIFF
--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -32,15 +32,15 @@ date
 smart_run mkdir -p /sd
 smart_run mkfifo -m 666 /sd/emitter
 
-echo 'Waiting for log pipe and launch to be ready'
+echo 'Waiting for log pipe to be ready'
 date
 # Make sure everything is ready
-while ! [ -p /sd/emitter ] || ! [ -f /opt/sd/launch ]
+while ! [ -p /sd/emitter ]
 do
     sleep 1
 done
 
-echo 'Symlink hab, log pipe and launch are ready'
+echo 'Symlink hab cache, log pipe is ready'
 date
 
 # Entrypoint

--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -25,12 +25,22 @@ find /opt/sd/hab/pkgs/core -mindepth 2 -maxdepth 2 -exec sh -c 'mkdir -p `echo $
 # this cmd will symlink the specific version: ln -s  /opt/sd/hab/pkgs/core/curl/7.54.1/20181008145326 /hab/pkgs/core/curl/7.54.1
 find /opt/sd/hab/pkgs/core -mindepth 3 -maxdepth 3 -exec sh -c 'ln -s $1 `dirname $1 | sed "s/\/opt\/sd//"`' -- {} \; || echo 'Failed to symlink hab cache'
 
+echo 'Creating workspace and log pipe'
+date
 # Create FIFO for emitter
 # https://github.com/screwdriver-cd/screwdriver/issues/979
 smart_run mkdir -p /sd
 smart_run mkfifo -m 666 /sd/emitter
 
-echo 'Symlink hab, log pipe and launch are done'
+echo 'Waiting for log pipe and launch to be ready'
+date
+# Make sure everything is ready
+while ! [ -p /sd/emitter ] || ! [ -f /opt/sd/launch ]
+do
+    sleep 1
+done
+
+echo 'Symlink hab, log pipe and launch are ready'
 date
 
 # Entrypoint

--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -14,10 +14,24 @@ smart_run () {
     fi
 }
 
+echo 'Symlink hab cache'
+date
+smart_run mkdir -p -m 777 /hab/bin || echo 'Failed to create /hab/bin'
+smart_run ln -sf /opt/sd/bin/hab /hab/bin/hab || echo 'Failed to symlink hab bin'
+smart_run mkdir -p -m 777 /hab/pkgs || echo 'Failed to create /hab/pkgs/'
+smart_run mkdir -p -m 777 /hab/pkgs/core  || echo 'Failed to create /hab/pkgs/core'
+# this cmd will create dirs for all hab pkgs in this format: /hab/pkgs/core/curl/7.54.1
+find /opt/sd/hab/pkgs/core -mindepth 2 -maxdepth 2 -exec sh -c 'mkdir -p `echo $1 | sed "s/\/opt\/sd//"`' -- {} \; || echo 'Failed to create /hab/pkgs/core/*'
+# this cmd will symlink the specific version: ln -s  /opt/sd/hab/pkgs/core/curl/7.54.1/20181008145326 /hab/pkgs/core/curl/7.54.1
+find /opt/sd/hab/pkgs/core -mindepth 3 -maxdepth 3 -exec sh -c 'ln -s $1 `dirname $1 | sed "s/\/opt\/sd//"`' -- {} \; || echo 'Failed to symlink hab cache'
+
 # Create FIFO for emitter
 # https://github.com/screwdriver-cd/screwdriver/issues/979
 smart_run mkdir -p /sd
 smart_run mkfifo -m 666 /sd/emitter
+
+echo 'Symlink hab, log pipe and launch are done'
+date
 
 # Entrypoint
 exec /opt/sd/tini -- /bin/sh -c "$@"


### PR DESCRIPTION
## Context

Symlink hab cache, log pipe and launcher missing which is required for kata.

## Objective

Symlink hab cache, log pipe and launcher configuration updated in the launcher. The Source of truth for this script is from hyper setup.sh.

## References

[feat(818): Evaluate Kata Containers over HyperD](https://github.com/screwdriver-cd/screwdriver/issues/818)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
