### PR TITLE
feat(818): add metrics

### DIFF
--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -2,8 +2,17 @@
 
 # Get push gateway url and container image from env variable
 if ([ ! -z "$PUSHGATEWAY_URL" ] && [ ! -z "$CONTAINER_IMAGE" ] && [ ! -z "$SD_PIPELINE_ID" ]); then
+  ts=`date "+%s"`
   echo "push build image metrics to prometheus"
-  echo "sd_build_image{image_name=\"$CONTAINER_IMAGE\", pipeline_id=\"$SD_PIPELINE_ID\", node=\"$NODE_ID\"} 1" | curl -s -m 10 --data-binary @- "$PUSHGATEWAY_URL/metrics/job/containerd/instance/$5" &>/dev/null &
+  launcherstartts=$(cat /workspace/metrics | grep launcher_start_ts | awk -F':' '{print $2}')
+  [ -z "$launcherstartts" ] && launcherstartts=$ts
+  launcherendts=$(cat /workspace/metrics | grep launcher_end_ts | awk -F':' '{print $2}')
+  [ -z "$launcherendts" ] && launcherendts=$ts
+  duration=$(($ts - $launcherendts))
+  launcherduration=$(($launcherendts - $launcherstartts))
+  echo "sd_build_scheduled{image_name=\"$CONTAINER_IMAGE\", pipeline_id=\"$SD_PIPELINE_ID\", node=\"$NODE_ID\"} 1" | curl -s -m 10 --data-binary @- "$PUSHGATEWAY_URL/metrics/job/containerd/instance/$5" &>/dev/null &
+  echo "sd_build_image_pull_duration_secs{image_name=\"$CONTAINER_IMAGE\", pipeline_id=\"$SD_PIPELINE_ID\", node=\"$NODE_ID\"} $duration" | curl -s -m 10 --data-binary @- "$PUSHGATEWAY_URL/metrics/job/containerd/instance/$5" &>/dev/null &
+  echo "sd_build_launcher_duration_secs{image_name=\"$CONTAINER_IMAGE\", pipeline_id=\"$SD_PIPELINE_ID\", node=\"$NODE_ID\"} $launcherduration" | curl -s -m 10 --data-binary @- "$PUSHGATEWAY_URL/metrics/job/containerd/instance/$5" &>/dev/null &
 fi
 
 echo "run launch"

--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -8,6 +8,7 @@ if ([ ! -z "$PUSHGATEWAY_URL" ] && [ ! -z "$CONTAINER_IMAGE" ] && [ ! -z "$SD_PI
   [ -z "$launcherstartts" ] && launcherstartts=$ts
   launcherendts=$(cat /workspace/metrics | grep launcher_end_ts | awk -F':' '{print $2}')
   [ -z "$launcherendts" ] && launcherendts=$ts
+  export SD_LAUNCHER_END_TS=$launcherendts
   duration=$(($ts - $launcherendts))
   launcherduration=$(($launcherendts - $launcherstartts))
   echo "sd_build_scheduled{image_name=\"$CONTAINER_IMAGE\", pipeline_id=\"$SD_PIPELINE_ID\", node=\"$NODE_ID\"} 1" | curl -s -m 10 --data-binary @- "$PUSHGATEWAY_URL/metrics/job/containerd/instance/$5" &>/dev/null &


### PR DESCRIPTION
## Context

metrics missing in kata route

## Objective

Add metrics sd_build_scheduled, sd_build_image_pull_duration_secs, sd_build_launcher_duration_secs

## References

[feat(818): Evaluate Kata Containers over HyperD](https://github.com/screwdriver-cd/screwdriver/issues/818)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
