### PR TITLE
fix(818): add full permission to sd folder

### DIFF
--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -29,7 +29,7 @@ echo 'Creating workspace and log pipe'
 date
 # Create FIFO for emitter
 # https://github.com/screwdriver-cd/screwdriver/issues/979
-smart_run mkdir -p /sd
+smart_run mkdir -p -m 777 /sd
 smart_run mkfifo -m 666 /sd/emitter
 
 echo 'Waiting for log pipe to be ready'


### PR DESCRIPTION
## Context

sd-setup-launcher failed with error mkdir /sd/meta: permission denied

## Objective

Add full permission to /sd directory

## References

[feat(818): Evaluate Kata Containers over HyperD](https://github.com/screwdriver-cd/screwdriver/issues/818)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
