### PR TITLE
fix(818): add more metrics

### DIFF
--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -137,6 +137,7 @@ type Build struct {
 	ParentBuildID IntOrArray             `json:"parentBuildId"`
 	Meta          map[string]interface{} `json:"meta"`
 	EventID       int                    `json:"eventId"`
+	Createtime    string                 `json:"createTime"`
 }
 
 // Coverage is a Coverage object returned when getInfo is called

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -113,6 +113,7 @@ func TestBuildFromID(t *testing.T) {
 				SHA:         "testSHA",
 				Commands:    testCmds,
 				Environment: testEnv,
+				Createtime:  "2020-04-28T20:34:01.907Z",
 			},
 			statusCode: 200,
 			err:        nil,


### PR DESCRIPTION
## Context

Simplify metrics API call and add two more metrics

## Objective

This PR simplifies three different metrics API calls to single API call and add sd_build_time_secs and sd_build_queued_time_secs metrics.

## References

[feat(818): Evaluate Kata Containers over HyperD](https://github.com/screwdriver-cd/screwdriver/issues/818)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
