### PR TITLE
fix(818): enable logging launcher entrypoint

### DIFF
--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -x
 
 I_AM_ROOT=false
 


### PR DESCRIPTION
## Context

Build starts and status changes to Running but crashes immediately for some containers.

## Objective

Enable additional logging in launcher entry point to narrow down the root cause.

## References

[feat(818): Evaluate Kata Containers over HyperD](https://github.com/screwdriver-cd/screwdriver/issues/818)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
