### PR TITLE
fix(818): docker in kata containers

### DIFF
--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -x
 
 I_AM_ROOT=false
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,10 +64,6 @@ RUN set -x \
    && rm tini-static.asc \
    && mv tini-static tini \
    && chmod +x tini \
-   # Download Docker Binary
-   && wget -O docker.tar.gz "https://download.docker.com/linux/static/stable/x86_64/docker-19.03.8.tgz" \
-   && tar -C . -ozxvf docker.tar.gz \
-   && mv docker /opt/sd/ \
    # Install Habitat
    && mkdir -p /hab/bin /opt/sd/bin \
    # Download Habitat Binary
@@ -78,7 +74,7 @@ RUN set -x \
    # @TODO Remove this, I don't think it belongs here.  We should use /hab/bin/hab instead.
    && cp /hab/bin/hab /opt/sd/bin/hab \
    # Install Habitat packages
-   && /hab/bin/hab pkg install core/bash core/git core/zip core/unzip core/kmod core/iptables core/wget core/sed \
+   && /hab/bin/hab pkg install core/bash core/git core/zip core/unzip core/kmod core/iptables core/wget core/sed anonymous/docker \
    # Install curl 7.54.1 since we use that version in artifact-bookend
    # https://github.com/screwdriver-cd/artifact-bookend/blob/master/commands.txt
    && /hab/bin/hab pkg install core/curl/7.54.1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,6 @@ RUN set -x \
    && wget -O docker.tar.gz "https://download.docker.com/linux/static/stable/x86_64/docker-19.03.8.tgz" \
    && tar -C . -ozxvf docker.tar.gz \
    && mv docker /opt/sd/ \
-   && rm -rf docker* \
    # Install Habitat
    && mkdir -p /hab/bin /opt/sd/bin \
    # Download Habitat Binary

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,11 @@ RUN set -x \
    && rm tini-static.asc \
    && mv tini-static tini \
    && chmod +x tini \
-
+   # Download Docker Binary
+   && wget -O docker.tar.gz "https://download.docker.com/linux/static/stable/x86_64/docker-19.03.8.tgz" \
+   && tar -C . -ozxvf docker.tar.gz \
+   && mv docker /opt/sd/ \
+   && rm -rf docker* \
    # Install Habitat
    && mkdir -p /hab/bin /opt/sd/bin \
    # Download Habitat Binary
@@ -75,7 +79,7 @@ RUN set -x \
    # @TODO Remove this, I don't think it belongs here.  We should use /hab/bin/hab instead.
    && cp /hab/bin/hab /opt/sd/bin/hab \
    # Install Habitat packages
-   && /hab/bin/hab pkg install core/bash core/git core/zip core/unzip core/kmod core/iptables core/docker/18.03.0 core/wget core/sed \
+   && /hab/bin/hab pkg install core/bash core/git core/zip core/unzip core/kmod core/iptables core/wget core/sed \
    # Install curl 7.54.1 since we use that version in artifact-bookend
    # https://github.com/screwdriver-cd/artifact-bookend/blob/master/commands.txt
    && /hab/bin/hab pkg install core/curl/7.54.1 \


### PR DESCRIPTION
## Context

Error when running docker in kata containers for docker versions below 19.03.0.

Error: OCI runtime create failed: container_linux.go:348: starting container process caused "process_linux.go:402: container init caused \"could not create session key: function not implemented\"": unknown 

## Objective

Upgrade docker version to 19.03.8 and use hab pkg anonymous/docker published by @DekusDenial.

## References

[feat(818): Evaluate Kata Containers over HyperD](https://github.com/screwdriver-cd/screwdriver/issues/818)


## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
