### PR TITLE
fix(818): install docker from hab core/docker

### DIFF
--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -20,12 +20,10 @@ smart_run mkdir -p -m 777 /hab/bin || echo 'Failed to create /hab/bin'
 smart_run ln -sf /opt/sd/bin/hab /hab/bin/hab || echo 'Failed to symlink hab bin'
 smart_run mkdir -p -m 777 /hab/pkgs || echo 'Failed to create /hab/pkgs/'
 smart_run mkdir -p -m 777 /hab/pkgs/core  || echo 'Failed to create /hab/pkgs/core'
-smart_run mkdir -p -m 777 /hab/pkgs/anonymous  || echo 'Failed to create /hab/pkgs/anonymous'
-# this cmd will create dirs for all hab pkgs in this format: /hab/pkgs/core/curl/7.54.1, /hab/pkgs/anonymous/docker/19.03.8
-find /opt/sd/hab/pkgs/ -mindepth 3 -maxdepth 3 -exec sh -c 'mkdir -p `echo $1 | sed "s/\/opt\/sd//"`' -- {} \; || echo 'Failed to create /hab/pkgs/core/*'
+# this cmd will create dirs for all hab pkgs in this format: /hab/pkgs/core/curl/7.54.1
+find /opt/sd/hab/pkgs/core -mindepth 2 -maxdepth 2 -exec sh -c 'mkdir -p `echo $1 | sed "s/\/opt\/sd//"`' -- {} \; || echo 'Failed to create /hab/pkgs/core/*'
 # this cmd will symlink the specific version: ln -s  /opt/sd/hab/pkgs/core/curl/7.54.1/20181008145326 /hab/pkgs/core/curl/7.54.1
-#                                             ln -s  /opt/sd/hab/pkgs/anonymous/docker/19.03.8/20200504230035 /hab/pkgs/anonymous/docker/19.03.8
-find /opt/sd/hab/pkgs/ -mindepth 4 -maxdepth 4 -exec sh -c 'ln -s $1 `dirname $1 | sed "s/\/opt\/sd//"`' -- {} \; || echo 'Failed to symlink hab cache'
+find /opt/sd/hab/pkgs/core -mindepth 3 -maxdepth 3 -exec sh -c 'ln -s $1 `dirname $1 | sed "s/\/opt\/sd//"`' -- {} \; || echo 'Failed to symlink hab cache'
 
 echo 'Creating workspace and log pipe'
 date

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ RUN set -x \
    # @TODO Remove this, I don't think it belongs here.  We should use /hab/bin/hab instead.
    && cp /hab/bin/hab /opt/sd/bin/hab \
    # Install Habitat packages
-   && /hab/bin/hab pkg install core/bash core/git core/zip core/unzip core/kmod core/iptables core/docker core/wget core/sed \
+   && /hab/bin/hab pkg install core/bash core/git core/zip core/unzip core/kmod core/iptables core/docker core/wget core/sed core/jq-static/1.6 \
    # Install curl 7.54.1 since we use that version in artifact-bookend
    # https://github.com/screwdriver-cd/artifact-bookend/blob/master/commands.txt
    && /hab/bin/hab pkg install core/curl/7.54.1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ RUN set -x \
    # @TODO Remove this, I don't think it belongs here.  We should use /hab/bin/hab instead.
    && cp /hab/bin/hab /opt/sd/bin/hab \
    # Install Habitat packages
-   && /hab/bin/hab pkg install core/bash core/git core/zip core/unzip core/kmod core/iptables core/wget core/sed anonymous/docker \
+   && /hab/bin/hab pkg install core/bash core/git core/zip core/unzip core/kmod core/iptables core/docker core/wget core/sed \
    # Install curl 7.54.1 since we use that version in artifact-bookend
    # https://github.com/screwdriver-cd/artifact-bookend/blob/master/commands.txt
    && /hab/bin/hab pkg install core/curl/7.54.1 \


### PR DESCRIPTION
## Context

Install docker from hab core/docker, revert changes related to [PR#347](https://github.com/screwdriver-cd/launcher/pull/347), [PR#348](https://github.com/screwdriver-cd/launcher/pull/348)

also added jq per @DekusDenial request

## References

[feat(818): Evaluate Kata Containers over HyperD](https://github.com/screwdriver-cd/screwdriver/issues/818)


## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
