### PR TITLE
fix(818): upd to include sd_build_status metrics

### DIFF
--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -13,7 +13,7 @@ if ([ ! -z "$PUSHGATEWAY_URL" ] && [ ! -z "$CONTAINER_IMAGE" ] && [ ! -z "$SD_PI
   duration=$(($ts - $launcherendts))
   launcherduration=$(($launcherendts - $launcherstartts))
   cat <<EOF | curl -s -m 10 --data-binary @- "$PUSHGATEWAY_URL/metrics/job/containerd/instance/$5" &>/dev/null &
-sd_build_scheduled{image_name="$CONTAINER_IMAGE", pipeline_id="$SD_PIPELINE_ID", node="$NODE_ID"} 1
+sd_build_status{image_name="$CONTAINER_IMAGE", pipeline_id="$SD_PIPELINE_ID", node="$NODE_ID", status="RUNNING"} 1
 sd_build_image_pull_time_secs{image_name="$CONTAINER_IMAGE", pipeline_id="$SD_PIPELINE_ID", node="$NODE_ID"} $duration
 sd_build_launcher_time_secs{image_name="$CONTAINER_IMAGE", pipeline_id="$SD_PIPELINE_ID", node="$NODE_ID"} $launcherduration
 EOF

--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -3,6 +3,7 @@
 # Get push gateway url and container image from env variable
 if ([ ! -z "$PUSHGATEWAY_URL" ] && [ ! -z "$CONTAINER_IMAGE" ] && [ ! -z "$SD_PIPELINE_ID" ]); then
   ts=`date "+%s"`
+  export SD_BUILD_START_TS=$ts
   echo "push build image metrics to prometheus"
   launcherstartts=$(cat /workspace/metrics | grep launcher_start_ts | awk -F':' '{print $2}')
   [ -z "$launcherstartts" ] && launcherstartts=$ts

--- a/launch.go
+++ b/launch.go
@@ -98,7 +98,7 @@ func pushMetrics(status string, buildID int) error {
 		buildQueuedSecs := launcherStartTS - buildCreateTS
 
 		// data need to be specified in this format for pushgateway
-		data := `sd_build_completed{image_name="` + image + `",pipeline_id="` + pipelineId + `",node="` + node + `",job_id="` + jobId + `",job_name="` + jobName + `",scm_url="` + scmUrl + `",status="` + status + `"} 1
+		data := `sd_build_status{image_name="` + image + `",pipeline_id="` + pipelineId + `",node="` + node + `",job_id="` + jobId + `",job_name="` + jobName + `",scm_url="` + scmUrl + `",status="` + status + `"} 1
 sd_build_run_time_secs{image_name="` + image + `",pipeline_id="` + pipelineId + `",node="` + node + `",job_id="` + jobId + `",job_name="` + jobName + `",scm_url="` + scmUrl + `",status="` + status + `"} ` + strconv.FormatInt(buildRunDurationSecs, 10) + `
 sd_build_time_secs{image_name="` + image + `",pipeline_id="` + pipelineId + `",node="` + node + `",job_id="` + jobId + `",job_name="` + jobName + `",scm_url="` + scmUrl + `",status="` + status + `"} ` + strconv.FormatInt(buildDurationSecs, 10) + `
 sd_build_queued_time_secs{image_name="` + image + `",pipeline_id="` + pipelineId + `",node="` + node + `",job_id="` + jobId + `",job_name="` + jobName + `",scm_url="` + scmUrl + `",status="` + status + `"} ` + strconv.FormatInt(buildQueuedSecs, 10) + `

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -129,15 +129,16 @@ type IntOrArray interface{}
 
 // Build is a Screwdriver Build
 type Build struct {
-	ID            int                    `json:"id"`
-	JobID         int                    `json:"jobId"`
-	SHA           string                 `json:"sha"`
-	Commands      []CommandDef           `json:"steps"`
-	Environment   []map[string]string    `json:"environment"`
-	ParentBuildID IntOrArray             `json:"parentBuildId"`
-	Meta          map[string]interface{} `json:"meta"`
-	EventID       int                    `json:"eventId"`
-	Createtime    string                 `json:"createTime"`
+	ID             int                    `json:"id"`
+	JobID          int                    `json:"jobId"`
+	SHA            string                 `json:"sha"`
+	Commands       []CommandDef           `json:"steps"`
+	Environment    []map[string]string    `json:"environment"`
+	ParentBuildID  IntOrArray             `json:"parentBuildId"`
+	Meta           map[string]interface{} `json:"meta"`
+	EventID        int                    `json:"eventId"`
+	Createtime     string                 `json:"createTime"`
+	QueueEntertime string                 `json:"stats.queueEnterTime"`
 }
 
 // Coverage is a Coverage object returned when getInfo is called

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -107,13 +107,14 @@ func TestBuildFromID(t *testing.T) {
 	}{
 		{
 			build: Build{
-				ID:          1555,
-				JobID:       3777,
-				EventID:     8765,
-				SHA:         "testSHA",
-				Commands:    testCmds,
-				Environment: testEnv,
-				Createtime:  "2020-04-28T20:34:01.907Z",
+				ID:             1555,
+				JobID:          3777,
+				EventID:        8765,
+				SHA:            "testSHA",
+				Commands:       testCmds,
+				Environment:    testEnv,
+				Createtime:     "2020-04-28T20:34:01.907Z",
+				QueueEntertime: "2020-05-01T20:15:31.508Z",
 			},
 			statusCode: 200,
 			err:        nil,


### PR DESCRIPTION
## Context

With the existing metrics, not able to plot a graph trend for builds running vs completed.

## Objective

Include sd_build_status metrics, to show running vs completed (success, failure, aborted) trend

## References

[feat(818): Evaluate Kata Containers over HyperD](https://github.com/screwdriver-cd/screwdriver/issues/818)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
