### PR TITLE
fix(818): randomness in pushmetrics

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -43,7 +43,7 @@ var marshal = json.Marshal
 var unmarshal = json.Unmarshal
 var cyanFprintf = color.New(color.FgCyan).Add(color.Underline).FprintfFunc()
 var blackSprint = color.New(color.FgHiBlack).SprintFunc()
-var pushgatewayUrlTimeout = 10
+var pushgatewayUrlTimeout = 15
 var buildCreateTime time.Time
 var queueEnterTime time.Time
 
@@ -134,6 +134,7 @@ sd_build_setup_time_secs{image_name="` + image + `",pipeline_id="` + pipelineId 
 
 // exit sets the build status and exits successfully
 func exit(status screwdriver.BuildStatus, buildID int, api screwdriver.API, metaSpace string) {
+	_ = pushMetrics(status.String(), buildID)
 	if api != nil {
 		var metaInterface map[string]interface{}
 
@@ -154,7 +155,6 @@ func exit(status screwdriver.BuildStatus, buildID int, api screwdriver.API, meta
 			log.Printf("Failed updating the build status: %v", err)
 		}
 	}
-	_ = pushMetrics(status.String(), buildID)
 	cleanExit()
 }
 

--- a/launch.go
+++ b/launch.go
@@ -74,6 +74,7 @@ buildID => sd build id
 */
 func pushMetrics(status string, buildID int) error {
 	// push metrics if pushgateway url is available
+	log.Printf("push metrics for buildID:[%v], status:[%v]", buildID, status)
 	if strings.TrimSpace(os.Getenv("PUSHGATEWAY_URL")) != "" && strings.TrimSpace(os.Getenv("CONTAINER_IMAGE")) != "" && strings.TrimSpace(os.Getenv("SD_PIPELINE_ID")) != "" && buildID > 0 {
 		timeout := time.Duration(pushgatewayUrlTimeout) * time.Second
 		client.HTTPClient.Timeout = timeout


### PR DESCRIPTION
## Context

pushMetrics doesn't trigger randomly.

## Objective

Moving pushMetrics function to the top of the exit function to narrow down the issue.

## References

[feat(818): Evaluate Kata Containers over HyperD](https://github.com/screwdriver-cd/screwdriver/issues/818)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
