### PR TITLE
fix: Unify environment variables for retry

### DIFF
--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -76,13 +76,13 @@ type api struct {
 // New returns a new API object
 func New(url, token string) (API, error) {
 	// read config from env variables
-	if strings.TrimSpace(os.Getenv("LAUNCHER_SDAPI_TIMEOUT_SECS")) != "" {
-		apiTimeout, _ := strconv.Atoi(os.Getenv("LAUNCHER_SDAPI_TIMEOUT_SECS"))
+	if strings.TrimSpace(os.Getenv("SDAPI_TIMEOUT_SECS")) != "" {
+		apiTimeout, _ := strconv.Atoi(os.Getenv("SDAPI_TIMEOUT_SECS"))
 		httpTimeout = time.Duration(apiTimeout) * time.Second
 	}
 
-	if strings.TrimSpace(os.Getenv("LAUNCHER_SDAPI_MAXRETRIES")) != "" {
-		maxRetries, _ = strconv.Atoi(os.Getenv("LAUNCHER_SDAPI_MAXRETRIES"))
+	if strings.TrimSpace(os.Getenv("SDAPI_MAXRETRIES")) != "" {
+		maxRetries, _ = strconv.Atoi(os.Getenv("SDAPI_MAXRETRIES"))
 	}
 
 	retryClient := retryablehttp.NewClient()

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -560,16 +560,16 @@ func TestNewDefaults(t *testing.T) {
 	maxRetries = 5
 	httpTimeout = time.Duration(20) * time.Second
 
-	os.Setenv("LAUNCHER_SDAPI_TIMEOUT_SECS", "")
-	os.Setenv("LAUNCHER_SDAPI_MAXRETRIES", "")
+	os.Setenv("SDAPI_TIMEOUT_SECS", "")
+	os.Setenv("SDAPI_MAXRETRIES", "")
 	_, _ = New("http://fakeurl", "fake")
 	assert.Equal(t, httpTimeout, time.Duration(20)*time.Second)
 	assert.Equal(t, maxRetries, 5)
 }
 
 func TestNew(t *testing.T) {
-	os.Setenv("LAUNCHER_SDAPI_TIMEOUT_SECS", "10")
-	os.Setenv("LAUNCHER_SDAPI_MAXRETRIES", "1")
+	os.Setenv("SDAPI_TIMEOUT_SECS", "10")
+	os.Setenv("SDAPI_MAXRETRIES", "1")
 	_, _ = New("http://fakeurl", "fake")
 	assert.Equal(t, httpTimeout, time.Duration(10)*time.Second)
 	assert.Equal(t, maxRetries, 1)


### PR DESCRIPTION
## Context
The environment variables for retry exist separately in launcher and log-service, so we unify them.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- rename `LAUNCHER_SDAPI_TIMEOUT_SEC` to `SDAPI_TIMEOUT_SECS`
- rename `LAUNCHER_SDAPI_MAXRETRIES` to `SDAPI_MAXRETRIES`
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/launcher/pull/357#discussion_r444359365
https://github.com/screwdriver-cd/log-service/pull/35
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
