### PR TITLE
fix: upgrade sonar scanner cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ data/emitter
 vendor/
 # we dont want to maintain partial updates
 glide.lock
+
+.idea/
+launch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.12
 MAINTAINER The Screwdrivers <screwdriver.cd>
 
 WORKDIR /opt/sd
@@ -10,7 +10,7 @@ RUN set -x \
    && apk add --no-cache --update ca-certificates \
    && apk add --virtual .build-dependencies wget \
    && apk add --virtual .build-dependencies gpgme \
-
+   && apk add --no-cache --virtual .build-dependencies unzip \
    # Download Launcher
    && wget -q -O - https://github.com/screwdriver-cd/launcher/releases/latest \
       | egrep -o '/screwdriver-cd/launcher/releases/download/v[0-9.]*/launcher_linux_amd64' \
@@ -41,7 +41,6 @@ RUN set -x \
       | egrep -o '/screwdriver-cd/store-cli/releases/download/v[0-9.]*/store-cli_linux_amd64' \
       | wget --base=http://github.com/ -i - -O store-cli \
    && chmod +x store-cli \
-
    # Download Tini Static
    && wget -q -O - https://github.com/krallin/tini/releases/latest \
       | egrep -o '/krallin/tini/releases/download/v[0-9.]*/tini-static' \
@@ -78,13 +77,21 @@ RUN set -x \
    # Install curl 7.54.1 since we use that version in artifact-bookend
    # https://github.com/screwdriver-cd/artifact-bookend/blob/master/commands.txt
    && /hab/bin/hab pkg install core/curl/7.54.1 \
+   # Install sonar scanner cli
+   && wget -O sonarscanner-cli-linux.zip 'https://github.com/SonarSource/sonar-scanner-cli/releases/download/4.4.0.2170/sonar-scanner-cli-4.4.0.2170-linux.zip' \
+   && wget -O sonarscanner-cli-macosx.zip 'https://github.com/SonarSource/sonar-scanner-cli/releases/download/4.4.0.2170/sonar-scanner-cli-4.4.0.2170-macosx.zip' \
+   && unzip -q sonarscanner-cli-linux.zip \
+   && unzip -q sonarscanner-cli-macosx.zip \
+   && mv sonar-scanner-*-linux sonarscanner-cli-linux \
+   && mv sonar-scanner-*-macosx sonarscanner-cli-macosx \
    # Cleanup Habitat Files
    && rm -rf /hab/cache /opt/sd/hab.tar.gz /opt/sd/hab-* \
    # Cleanup docs and man pages (how could this go wrong)
    && find /hab -name doc -exec rm -r {} + \
    && find /hab -name docs -exec rm -r {} + \
    && find /hab -name man -exec rm -r {} + \
-
+   # Cleanup Sonar files
+   && rm -rf /opt/sd/sonarscanner-cli-linux.zip /opt/sd/sonarscanner-cli-macosx.zip /opt/sd/sonar-scanner-*-linux /opt/sd/sonar-scanner-*-macosx \
    # Cleanup packages
    && apk del --purge .build-dependencies
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,8 +78,8 @@ RUN set -x \
    # https://github.com/screwdriver-cd/artifact-bookend/blob/master/commands.txt
    && /hab/bin/hab pkg install core/curl/7.54.1 \
    # Install Sonar scanner cli
-   && wget -O sonarscanner-cli-linux.zip 'https://github.com/SonarSource/sonar-scanner-cli/releases/download/4.4.0.2170/sonar-scanner-cli-4.4.0.2170-linux.zip' \
-   && wget -O sonarscanner-cli-macosx.zip 'https://github.com/SonarSource/sonar-scanner-cli/releases/download/4.4.0.2170/sonar-scanner-cli-4.4.0.2170-macosx.zip' \
+   && wget -O sonarscanner-cli-linux.zip 'https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.4.0.2170-linux.zip' \
+   && wget -O sonarscanner-cli-macosx.zip 'https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.4.0.2170-macosx.zip' \
    && unzip -q sonarscanner-cli-linux.zip \
    && unzip -q sonarscanner-cli-macosx.zip \
    && mv sonar-scanner-*-linux sonarscanner-cli-linux \

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,7 @@ RUN set -x \
    # Install curl 7.54.1 since we use that version in artifact-bookend
    # https://github.com/screwdriver-cd/artifact-bookend/blob/master/commands.txt
    && /hab/bin/hab pkg install core/curl/7.54.1 \
-   # Install sonar scanner cli
+   # Install Sonar scanner cli
    && wget -O sonarscanner-cli-linux.zip 'https://github.com/SonarSource/sonar-scanner-cli/releases/download/4.4.0.2170/sonar-scanner-cli-4.4.0.2170-linux.zip' \
    && wget -O sonarscanner-cli-macosx.zip 'https://github.com/SonarSource/sonar-scanner-cli/releases/download/4.4.0.2170/sonar-scanner-cli-4.4.0.2170-macosx.zip' \
    && unzip -q sonarscanner-cli-linux.zip \
@@ -90,7 +90,7 @@ RUN set -x \
    && find /hab -name doc -exec rm -r {} + \
    && find /hab -name docs -exec rm -r {} + \
    && find /hab -name man -exec rm -r {} + \
-   # Cleanup Sonar files
+   # Cleanup Sonar scanner cli files
    && rm -rf /opt/sd/sonarscanner-cli-linux.zip /opt/sd/sonarscanner-cli-macosx.zip /opt/sd/sonar-scanner-*-linux /opt/sd/sonar-scanner-*-macosx \
    # Cleanup packages
    && apk del --purge .build-dependencies


### PR DESCRIPTION
## Context

Upgrade sonar-scanner-CLI to the latest 4.4.0.2170 released June 23, 2020.

## Objective

Upgrade alpine from 3.8 to 3.12 to fix unzip errors `lchmod (file attributes) error and unzip: compressed symlink is not supported` and download and unzip sonar-scanner-CLI 4.4.0.2170 (Linux and Mac).

## References

[https://github.com/screwdriver-cd/coverage-sonar/pull/38](https://github.com/screwdriver-cd/coverage-sonar/pull/38)
[sonar-scanner-cli:4.4.0.2170](https://github.com/SonarSource/sonar-scanner-cli/releases/tag/4.4.0.2170)
[sonar-scanner-cli:3.3.0.1492...4.4.0.2170](https://github.com/SonarSource/sonar-scanner-cli/compare/3.3.0.1492...4.4.0.2170)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
