### PR TITLE
fix(2152): Support more coverage env vars [4]

### DIFF
--- a/data/emitter
+++ b/data/emitter
@@ -1,0 +1,9 @@
+{"t":1595884118557,"m":"Screwdriver Launcher information","s":"sd-setup-launcher"}
+{"t":1595884118557,"m":"Version:        vdev","s":"sd-setup-launcher"}
+{"t":1595884118557,"m":"Pipeline:       #3","s":"sd-setup-launcher"}
+{"t":1595884118557,"m":"Job:            main","s":"sd-setup-launcher"}
+{"t":1595884118557,"m":"Build:          #1","s":"sd-setup-launcher"}
+{"t":1595884118557,"m":"Workspace Dir:  /var/folders/_p/8_qbdnfs26s_kztl7y2kgfv80000gp/T/ArtifactDir083986560","s":"sd-setup-launcher"}
+{"t":1595884118557,"m":"Checkout Dir:     /var/folders/_p/8_qbdnfs26s_kztl7y2kgfv80000gp/T/ArtifactDir083986560/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
+{"t":1595884118557,"m":"Source Dir:     /var/folders/_p/8_qbdnfs26s_kztl7y2kgfv80000gp/T/ArtifactDir083986560/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
+{"t":1595884118557,"m":"Artifacts Dir:  /var/folders/_p/8_qbdnfs26s_kztl7y2kgfv80000gp/T/ArtifactDir083986560/artifacts","s":"sd-setup-launcher"}

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -53,7 +53,7 @@ func (f MockAPI) GetAPIURL() (string, error) {
 	return "http://foo.bar", nil
 }
 
-func (f MockAPI) GetCoverageInfo() (screwdriver.Coverage, error) {
+func (f MockAPI) GetCoverageInfo(jobID, pipelineID int, jobName, pipelineName string) (screwdriver.Coverage, error) {
 	return screwdriver.Coverage{}, nil
 }
 

--- a/launch.go
+++ b/launch.go
@@ -526,7 +526,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 	}
 
 	// Add coverage env vars
-	coverageInfo, err := api.GetCoverageInfo()
+	coverageInfo, err := api.GetCoverageInfo(job.ID, job.PipelineID, job.Name, pipeline.ScmRepo.Name)
 	if err != nil {
 		log.Printf("Failed to get coverage info for build %v so skip it\n", build.ID)
 	} else {

--- a/launch_test.go
+++ b/launch_test.go
@@ -100,7 +100,7 @@ func mockAPI(t *testing.T, testBuildID, testJobID, testPipelineID int, testStatu
 		getAPIURL: func() (string, error) {
 			return "https://api.screwdriver.cd/v4/", nil
 		},
-		getCoverageInfo: func() (screwdriver.Coverage, error) {
+		getCoverageInfo: func(jobID, pipelineID int, jobName, pipelineName string) (screwdriver.Coverage, error) {
 			return screwdriver.Coverage(FakeCoverage{EnvVars: TestEnvVars}), nil
 		},
 		getBuildToken: func(buildID int, buildTimeoutMinutes int) (string, error) {
@@ -129,7 +129,7 @@ type MockAPI struct {
 	updateStepStop    func(buildID int, stepName string, exitCode int) error
 	secretsForBuild   func(build screwdriver.Build) (screwdriver.Secrets, error)
 	getAPIURL         func() (string, error)
-	getCoverageInfo   func() (screwdriver.Coverage, error)
+	getCoverageInfo   func(jobID, pipelineID int, jobName, pipelineName string) (screwdriver.Coverage, error)
 	getBuildToken     func(buildID int, buildTimeoutMinutes int) (string, error)
 }
 
@@ -137,8 +137,8 @@ func (f MockAPI) GetAPIURL() (string, error) {
 	return f.getAPIURL()
 }
 
-func (f MockAPI) GetCoverageInfo() (screwdriver.Coverage, error) {
-	return f.getCoverageInfo()
+func (f MockAPI) GetCoverageInfo(jobID, pipelineID int, jobName, pipelineName string) (screwdriver.Coverage, error) {
+	return f.getCoverageInfo(jobID, pipelineID, jobName, pipelineName)
 }
 
 func (f MockAPI) SecretsForBuild(build screwdriver.Build) (screwdriver.Secrets, error) {

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -52,7 +52,7 @@ type API interface {
 	UpdateStepStop(buildID int, stepName string, exitCode int) error
 	SecretsForBuild(build Build) (Secrets, error)
 	GetAPIURL() (string, error)
-	GetCoverageInfo() (Coverage, error)
+	GetCoverageInfo(jobID, pipelineID int, jobName, pipelineName string) (Coverage, error)
 	GetBuildToken(buildID int, buildTimeoutMinutes int) (string, error)
 }
 
@@ -311,8 +311,8 @@ func (a api) GetAPIURL() (string, error) {
 }
 
 // Get coverage object with coverage information
-func (a api) GetCoverageInfo() (coverage Coverage, err error) {
-	url, err := a.makeURL(fmt.Sprintf("coverage/info"))
+func (a api) GetCoverageInfo(jobID, pipelineID int, jobName, pipelineName string) (coverage Coverage, err error) {
+	url, err := a.makeURL(fmt.Sprintf("coverage/info?jobId=%d&pipelineId=%d&jobName=%s&pipelineName=%s", jobID, pipelineID, jobName, pipelineName))
 	body, err := a.get(url)
 	if err != nil {
 		return coverage, err

--- a/screwdriver/screwdriver_local.go
+++ b/screwdriver/screwdriver_local.go
@@ -85,7 +85,7 @@ func (a localApi) GetAPIURL() (string, error) {
 	return url.String(), err
 }
 
-func (a localApi) GetCoverageInfo() (Coverage, error) {
+func (a localApi) GetCoverageInfo(jobID, pipelineID int, jobName, pipelineName string) (Coverage, error) {
 	coverage := Coverage{}
 
 	return coverage, nil

--- a/screwdriver/screwdriver_local_test.go
+++ b/screwdriver/screwdriver_local_test.go
@@ -129,7 +129,7 @@ func TestGetCoverageInfoLocal(t *testing.T) {
 	testAPI := localApi{"http://fakeurl", "testJob", Build{}}
 	expected := Coverage{}
 
-	actual, err := testAPI.GetCoverageInfo()
+	actual, err := testAPI.GetCoverageInfo(123, 456, "main", "d2lam/mytest")
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("actual: %#v, expected: %#v", actual, expected)
 	}

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -257,14 +257,14 @@ func TestGetCoverageInfo(t *testing.T) {
 		{
 			coverage:   Coverage{},
 			statusCode: 500,
-			err: errors.New("WARNING: received error from GET(http://fakeurl/v4/coverage/info): " +
-				"Get \"http://fakeurl/v4/coverage/info\": " +
-				"GET http://fakeurl/v4/coverage/info giving up after 5 attempts "),
+			err: errors.New("WARNING: received error from GET(http://fakeurl/v4/coverage/info?jobId=123&pipelineId=456&jobName=main&pipelineName=d2lam/mytest): " +
+				"Get \"http://fakeurl/v4/coverage/info?jobId=123&pipelineId=456&jobName=main&pipelineName=d2lam/mytest\": " +
+				"GET http://fakeurl/v4/coverage/info?jobId=123&pipelineId=456&jobName=main&pipelineName=d2lam/mytest giving up after 5 attempts "),
 		},
 		{
 			coverage:   Coverage{},
 			statusCode: 404,
-			err:        errors.New("WARNING: received response 404 from http://fakeurl/v4/coverage/info "),
+			err:        errors.New("WARNING: received response 404 from http://fakeurl/v4/coverage/info?jobId=123&pipelineId=456&jobName=main&pipelineName=d2lam/mytest "),
 		},
 	}
 
@@ -279,7 +279,7 @@ func TestGetCoverageInfo(t *testing.T) {
 		client.HTTPClient = makeFakeHTTPClient(t, test.statusCode, string(JSON))
 		testAPI := api{"http://fakeurl", "faketoken", client}
 
-		coverage, err := testAPI.GetCoverageInfo()
+		coverage, err := testAPI.GetCoverageInfo(123, 456, "main", "d2lam/mytest")
 
 		if !reflect.DeepEqual(err, test.err) {
 			t.Errorf("Unexpected error from GetCoverageInfo: \n%v\n want \n%v", err.Error(), test.err.Error())


### PR DESCRIPTION
## Context

It would be nice if users could see their project key and name as env vars in their builds.

## Objective

This PR modifies the call to get coverageInfo so more environment variables can be passed back.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2152

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
