### PR TITLE
fix: Dockerfile for alpine:3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,7 @@ RUN set -x \
    && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2 \
    # Also, missing https for some magic reason
    && apk add --no-cache --update ca-certificates \
-   && apk add --virtual .build-dependencies wget \
-   && apk add --virtual .build-dependencies gpgme \
-   && apk add --no-cache --virtual .build-dependencies unzip \
+   && apk add --no-cache --virtual .build-dependencies wget gpgme unzip \
    # Download Launcher
    && wget -q -O - https://github.com/screwdriver-cd/launcher/releases/latest \
       | egrep -o '/screwdriver-cd/launcher/releases/download/v[0-9.]*/launcher_linux_amd64' \


### PR DESCRIPTION
## Context
Build with ci/dockercloud failed, and no new [launcher docker image](https://hub.docker.com/r/screwdrivercd/launcher/tags?page=1) has been created.
https://github.com/screwdriver-cd/launcher/commits/master

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
When I tried to do a docker build on my local machine, I got the following error.
```
/bin/sh: gpg: not found
```

In alpine 3.10 or later, the virtual parameter must be unique.
https://github.com/alpinelinux/apk-tools/commit/b45415b1096e76f40b32326d2798123f81fe5976

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
