### PR TITLE
feat(2152): pass coverage scope to coverage info end point

### DIFF
--- a/data/emitter
+++ b/data/emitter
@@ -1,9 +1,9 @@
-{"t":1596478770981,"m":"Screwdriver Launcher information","s":"sd-setup-launcher"}
-{"t":1596478770981,"m":"Version:        vdev","s":"sd-setup-launcher"}
-{"t":1596478770981,"m":"Pipeline:       #3","s":"sd-setup-launcher"}
-{"t":1596478770981,"m":"Job:            main","s":"sd-setup-launcher"}
-{"t":1596478770981,"m":"Build:          #1","s":"sd-setup-launcher"}
-{"t":1596478770981,"m":"Workspace Dir:  /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir999641686","s":"sd-setup-launcher"}
-{"t":1596478770981,"m":"Checkout Dir:     /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir999641686/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
-{"t":1596478770981,"m":"Source Dir:     /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir999641686/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
-{"t":1596478770981,"m":"Artifacts Dir:  /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir999641686/artifacts","s":"sd-setup-launcher"}
+{"t":1596486229469,"m":"Screwdriver Launcher information","s":"sd-setup-launcher"}
+{"t":1596486229469,"m":"Version:        vdev","s":"sd-setup-launcher"}
+{"t":1596486229469,"m":"Pipeline:       #3","s":"sd-setup-launcher"}
+{"t":1596486229469,"m":"Job:            main","s":"sd-setup-launcher"}
+{"t":1596486229469,"m":"Build:          #1","s":"sd-setup-launcher"}
+{"t":1596486229469,"m":"Workspace Dir:  /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir326881263","s":"sd-setup-launcher"}
+{"t":1596486229469,"m":"Checkout Dir:     /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir326881263/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
+{"t":1596486229469,"m":"Source Dir:     /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir326881263/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
+{"t":1596486229469,"m":"Artifacts Dir:  /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir326881263/artifacts","s":"sd-setup-launcher"}

--- a/data/emitter
+++ b/data/emitter
@@ -1,9 +1,9 @@
-{"t":1595884118557,"m":"Screwdriver Launcher information","s":"sd-setup-launcher"}
-{"t":1595884118557,"m":"Version:        vdev","s":"sd-setup-launcher"}
-{"t":1595884118557,"m":"Pipeline:       #3","s":"sd-setup-launcher"}
-{"t":1595884118557,"m":"Job:            main","s":"sd-setup-launcher"}
-{"t":1595884118557,"m":"Build:          #1","s":"sd-setup-launcher"}
-{"t":1595884118557,"m":"Workspace Dir:  /var/folders/_p/8_qbdnfs26s_kztl7y2kgfv80000gp/T/ArtifactDir083986560","s":"sd-setup-launcher"}
-{"t":1595884118557,"m":"Checkout Dir:     /var/folders/_p/8_qbdnfs26s_kztl7y2kgfv80000gp/T/ArtifactDir083986560/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
-{"t":1595884118557,"m":"Source Dir:     /var/folders/_p/8_qbdnfs26s_kztl7y2kgfv80000gp/T/ArtifactDir083986560/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
-{"t":1595884118557,"m":"Artifacts Dir:  /var/folders/_p/8_qbdnfs26s_kztl7y2kgfv80000gp/T/ArtifactDir083986560/artifacts","s":"sd-setup-launcher"}
+{"t":1596478770981,"m":"Screwdriver Launcher information","s":"sd-setup-launcher"}
+{"t":1596478770981,"m":"Version:        vdev","s":"sd-setup-launcher"}
+{"t":1596478770981,"m":"Pipeline:       #3","s":"sd-setup-launcher"}
+{"t":1596478770981,"m":"Job:            main","s":"sd-setup-launcher"}
+{"t":1596478770981,"m":"Build:          #1","s":"sd-setup-launcher"}
+{"t":1596478770981,"m":"Workspace Dir:  /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir999641686","s":"sd-setup-launcher"}
+{"t":1596478770981,"m":"Checkout Dir:     /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir999641686/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
+{"t":1596478770981,"m":"Source Dir:     /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir999641686/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
+{"t":1596478770981,"m":"Artifacts Dir:  /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir999641686/artifacts","s":"sd-setup-launcher"}

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -53,7 +53,7 @@ func (f MockAPI) GetAPIURL() (string, error) {
 	return "http://foo.bar", nil
 }
 
-func (f MockAPI) GetCoverageInfo(jobID, pipelineID int, jobName, pipelineName string) (screwdriver.Coverage, error) {
+func (f MockAPI) GetCoverageInfo(jobID, pipelineID int, jobName, pipelineName, scope, prNum, prParentJobId string) (screwdriver.Coverage, error) {
 	return screwdriver.Coverage{}, nil
 }
 

--- a/launch.go
+++ b/launch.go
@@ -526,7 +526,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 	}
 
 	// Add coverage env vars
-	coverageInfo, err := api.GetCoverageInfo(job.ID, job.PipelineID, job.Name, pipeline.ScmRepo.Name)
+	coverageInfo, err := api.GetCoverageInfo(job.ID, job.PipelineID, job.Name, pipeline.ScmRepo.Name, job.Permutations[0].Annotations.CoverageScope)
 	if err != nil {
 		log.Printf("Failed to get coverage info for build %v so skip it\n", build.ID)
 	} else {

--- a/launch.go
+++ b/launch.go
@@ -526,7 +526,11 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 	}
 
 	// Add coverage env vars
-	coverageInfo, err := api.GetCoverageInfo(job.ID, job.PipelineID, job.Name, pipeline.ScmRepo.Name, job.Permutations[0].Annotations.CoverageScope)
+	coverageScope := ""
+	if len(job.Permutations) > 0 {
+		coverageScope = job.Permutations[0].Annotations.CoverageScope
+	}
+	coverageInfo, err := api.GetCoverageInfo(job.ID, job.PipelineID, job.Name, pipeline.ScmRepo.Name, coverageScope, pr, strconv.Itoa(job.PrParentJobID))
 	if err != nil {
 		log.Printf("Failed to get coverage info for build %v so skip it\n", build.ID)
 	} else {

--- a/launch_test.go
+++ b/launch_test.go
@@ -100,7 +100,7 @@ func mockAPI(t *testing.T, testBuildID, testJobID, testPipelineID int, testStatu
 		getAPIURL: func() (string, error) {
 			return "https://api.screwdriver.cd/v4/", nil
 		},
-		getCoverageInfo: func(jobID, pipelineID int, jobName, pipelineName string) (screwdriver.Coverage, error) {
+		getCoverageInfo: func(jobID, pipelineID int, jobName, pipelineName, scope, prNum, prParentJobId string) (screwdriver.Coverage, error) {
 			return screwdriver.Coverage(FakeCoverage{EnvVars: TestEnvVars}), nil
 		},
 		getBuildToken: func(buildID int, buildTimeoutMinutes int) (string, error) {
@@ -129,7 +129,7 @@ type MockAPI struct {
 	updateStepStop    func(buildID int, stepName string, exitCode int) error
 	secretsForBuild   func(build screwdriver.Build) (screwdriver.Secrets, error)
 	getAPIURL         func() (string, error)
-	getCoverageInfo   func(jobID, pipelineID int, jobName, pipelineName string) (screwdriver.Coverage, error)
+	getCoverageInfo   func(jobID, pipelineID int, jobName, pipelineName, scope, prNum, prParentJobId string) (screwdriver.Coverage, error)
 	getBuildToken     func(buildID int, buildTimeoutMinutes int) (string, error)
 }
 
@@ -137,8 +137,8 @@ func (f MockAPI) GetAPIURL() (string, error) {
 	return f.getAPIURL()
 }
 
-func (f MockAPI) GetCoverageInfo(jobID, pipelineID int, jobName, pipelineName string) (screwdriver.Coverage, error) {
-	return f.getCoverageInfo(jobID, pipelineID, jobName, pipelineName)
+func (f MockAPI) GetCoverageInfo(jobID, pipelineID int, jobName, pipelineName, scope, prNum, prParentJobId string) (screwdriver.Coverage, error) {
+	return f.getCoverageInfo(jobID, pipelineID, jobName, pipelineName, scope, prNum, prParentJobId)
 }
 
 func (f MockAPI) SecretsForBuild(build screwdriver.Build) (screwdriver.Secrets, error) {

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -133,12 +133,21 @@ type ScmRepo struct {
 	Name string `json:"name"`
 }
 
+type JobAnnotations struct {
+	CoverageScope string `json:"screwdriver.cd/coverageScope"`
+}
+
+type JobPermutation struct {
+	Annotations JobAnnotations `json:"annotations"`
+}
+
 // Job is a Screwdriver Job.
 type Job struct {
-	ID            int    `json:"id"`
-	PipelineID    int    `json:"pipelineId"`
-	Name          string `json:"name"`
-	PrParentJobID int    `json:"prParentJobId"`
+	ID            int              `json:"id"`
+	PipelineID    int              `json:"pipelineId"`
+	Name          string           `json:"name"`
+	PrParentJobID int              `json:"prParentJobId"`
+	Permutations  []JobPermutation `json:"permutations" json:"omitempty"`
 }
 
 // CommandDef is the definition of a single executable command.

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -52,7 +52,7 @@ type API interface {
 	UpdateStepStop(buildID int, stepName string, exitCode int) error
 	SecretsForBuild(build Build) (Secrets, error)
 	GetAPIURL() (string, error)
-	GetCoverageInfo(jobID, pipelineID int, jobName, pipelineName string) (Coverage, error)
+	GetCoverageInfo(jobID, pipelineID int, jobName, pipelineName, scope string) (Coverage, error)
 	GetBuildToken(buildID int, buildTimeoutMinutes int) (string, error)
 }
 
@@ -134,7 +134,7 @@ type ScmRepo struct {
 }
 
 type JobAnnotations struct {
-	CoverageScope string `json:"screwdriver.cd/coverageScope"`
+	CoverageScope string `json:"screwdriver.cd/coverageScope,omitempty"`
 }
 
 type JobPermutation struct {
@@ -147,7 +147,7 @@ type Job struct {
 	PipelineID    int              `json:"pipelineId"`
 	Name          string           `json:"name"`
 	PrParentJobID int              `json:"prParentJobId"`
-	Permutations  []JobPermutation `json:"permutations" json:"omitempty"`
+	Permutations  []JobPermutation `json:"permutations,omitempty"`
 }
 
 // CommandDef is the definition of a single executable command.
@@ -320,8 +320,8 @@ func (a api) GetAPIURL() (string, error) {
 }
 
 // Get coverage object with coverage information
-func (a api) GetCoverageInfo(jobID, pipelineID int, jobName, pipelineName string) (coverage Coverage, err error) {
-	url, err := a.makeURL(fmt.Sprintf("coverage/info?jobId=%d&pipelineId=%d&jobName=%s&pipelineName=%s", jobID, pipelineID, jobName, pipelineName))
+func (a api) GetCoverageInfo(jobID, pipelineID int, jobName, pipelineName, scope string) (coverage Coverage, err error) {
+	url, err := a.makeURL(fmt.Sprintf("coverage/info?jobId=%d&pipelineId=%d&jobName=%s&pipelineName=%s&scope=%s", jobID, pipelineID, jobName, pipelineName, scope))
 	body, err := a.get(url)
 	if err != nil {
 		return coverage, err

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -19,6 +19,8 @@ import (
 
 var sleep = time.Sleep
 
+const CoverageURL = "coverage/info?jobId=%d&pipelineId=%d&jobName=%s&pipelineName=%s&scope=%s&prNum=%s&prParentJobId=%s"
+
 // BuildStatus is the status of a Screwdriver build
 type BuildStatus string
 
@@ -52,7 +54,7 @@ type API interface {
 	UpdateStepStop(buildID int, stepName string, exitCode int) error
 	SecretsForBuild(build Build) (Secrets, error)
 	GetAPIURL() (string, error)
-	GetCoverageInfo(jobID, pipelineID int, jobName, pipelineName, scope string) (Coverage, error)
+	GetCoverageInfo(jobID, pipelineID int, jobName, pipelineName, scope, prNum, prParentJobId string) (Coverage, error)
 	GetBuildToken(buildID int, buildTimeoutMinutes int) (string, error)
 }
 
@@ -134,7 +136,7 @@ type ScmRepo struct {
 }
 
 type JobAnnotations struct {
-	CoverageScope string `json:"screwdriver.cd/coverageScope,omitempty"`
+	CoverageScope string `json:"screwdriver.cd/coverageScope,omitempty" default:""`
 }
 
 type JobPermutation struct {
@@ -320,8 +322,8 @@ func (a api) GetAPIURL() (string, error) {
 }
 
 // Get coverage object with coverage information
-func (a api) GetCoverageInfo(jobID, pipelineID int, jobName, pipelineName, scope string) (coverage Coverage, err error) {
-	url, err := a.makeURL(fmt.Sprintf("coverage/info?jobId=%d&pipelineId=%d&jobName=%s&pipelineName=%s&scope=%s", jobID, pipelineID, jobName, pipelineName, scope))
+func (a api) GetCoverageInfo(jobID, pipelineID int, jobName, pipelineName, scope, prNum, prParentJobId string) (coverage Coverage, err error) {
+	url, err := a.makeURL(fmt.Sprintf(CoverageURL, jobID, pipelineID, jobName, pipelineName, scope, prNum, prParentJobId))
 	body, err := a.get(url)
 	if err != nil {
 		return coverage, err

--- a/screwdriver/screwdriver_local.go
+++ b/screwdriver/screwdriver_local.go
@@ -46,6 +46,7 @@ func (a localApi) JobFromID(jobID int) (job Job, err error) {
 		PipelineID:    0,
 		Name:          a.jobName,
 		PrParentJobID: 0,
+		Permutations:  []JobPermutation{},
 	}
 
 	return job, nil
@@ -85,7 +86,7 @@ func (a localApi) GetAPIURL() (string, error) {
 	return url.String(), err
 }
 
-func (a localApi) GetCoverageInfo(jobID, pipelineID int, jobName, pipelineName string) (Coverage, error) {
+func (a localApi) GetCoverageInfo(jobID, pipelineID int, jobName, pipelineName, scope string) (Coverage, error) {
 	coverage := Coverage{}
 
 	return coverage, nil

--- a/screwdriver/screwdriver_local.go
+++ b/screwdriver/screwdriver_local.go
@@ -86,7 +86,7 @@ func (a localApi) GetAPIURL() (string, error) {
 	return url.String(), err
 }
 
-func (a localApi) GetCoverageInfo(jobID, pipelineID int, jobName, pipelineName, scope string) (Coverage, error) {
+func (a localApi) GetCoverageInfo(jobID, pipelineID int, jobName, pipelineName, scope, prNum, prParentJobId string) (Coverage, error) {
 	coverage := Coverage{}
 
 	return coverage, nil

--- a/screwdriver/screwdriver_local_test.go
+++ b/screwdriver/screwdriver_local_test.go
@@ -130,7 +130,7 @@ func TestGetCoverageInfoLocal(t *testing.T) {
 	testAPI := localApi{"http://fakeurl", "testJob", Build{}}
 	expected := Coverage{}
 
-	actual, err := testAPI.GetCoverageInfo(123, 456, "main", "d2lam/mytest")
+	actual, err := testAPI.GetCoverageInfo(123, 456, "main", "d2lam/mytest", "")
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("actual: %#v, expected: %#v", actual, expected)
 	}

--- a/screwdriver/screwdriver_local_test.go
+++ b/screwdriver/screwdriver_local_test.go
@@ -130,7 +130,7 @@ func TestGetCoverageInfoLocal(t *testing.T) {
 	testAPI := localApi{"http://fakeurl", "testJob", Build{}}
 	expected := Coverage{}
 
-	actual, err := testAPI.GetCoverageInfo(123, 456, "main", "d2lam/mytest", "")
+	actual, err := testAPI.GetCoverageInfo(123, 456, "main", "d2lam/mytest", "", "", "")
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("actual: %#v, expected: %#v", actual, expected)
 	}

--- a/screwdriver/screwdriver_local_test.go
+++ b/screwdriver/screwdriver_local_test.go
@@ -47,6 +47,7 @@ func TestJobFromIDLocal(t *testing.T) {
 		0,
 		testAPI.jobName,
 		0,
+		[]JobPermutation{},
 	}
 
 	actual, err := testAPI.JobFromID(0)

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -257,14 +257,14 @@ func TestGetCoverageInfo(t *testing.T) {
 		{
 			coverage:   Coverage{},
 			statusCode: 500,
-			err: errors.New("WARNING: received error from GET(http://fakeurl/v4/coverage/info?jobId=123&pipelineId=456&jobName=main&pipelineName=d2lam/mytest): " +
-				"Get \"http://fakeurl/v4/coverage/info?jobId=123&pipelineId=456&jobName=main&pipelineName=d2lam/mytest\": " +
-				"GET http://fakeurl/v4/coverage/info?jobId=123&pipelineId=456&jobName=main&pipelineName=d2lam/mytest giving up after 5 attempts "),
+			err: errors.New("WARNING: received error from GET(http://fakeurl/v4/coverage/info?jobId=123&pipelineId=456&jobName=main&pipelineName=d2lam/mytest&scope=): " +
+				"Get \"http://fakeurl/v4/coverage/info?jobId=123&pipelineId=456&jobName=main&pipelineName=d2lam/mytest&scope=\": " +
+				"GET http://fakeurl/v4/coverage/info?jobId=123&pipelineId=456&jobName=main&pipelineName=d2lam/mytest&scope= giving up after 5 attempts "),
 		},
 		{
 			coverage:   Coverage{},
 			statusCode: 404,
-			err:        errors.New("WARNING: received response 404 from http://fakeurl/v4/coverage/info?jobId=123&pipelineId=456&jobName=main&pipelineName=d2lam/mytest "),
+			err:        errors.New("WARNING: received response 404 from http://fakeurl/v4/coverage/info?jobId=123&pipelineId=456&jobName=main&pipelineName=d2lam/mytest&scope= "),
 		},
 	}
 
@@ -279,7 +279,7 @@ func TestGetCoverageInfo(t *testing.T) {
 		client.HTTPClient = makeFakeHTTPClient(t, test.statusCode, string(JSON))
 		testAPI := api{"http://fakeurl", "faketoken", client}
 
-		coverage, err := testAPI.GetCoverageInfo(123, 456, "main", "d2lam/mytest")
+		coverage, err := testAPI.GetCoverageInfo(123, 456, "main", "d2lam/mytest", "")
 
 		if !reflect.DeepEqual(err, test.err) {
 			t.Errorf("Unexpected error from GetCoverageInfo: \n%v\n want \n%v", err.Error(), test.err.Error())

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -257,14 +257,14 @@ func TestGetCoverageInfo(t *testing.T) {
 		{
 			coverage:   Coverage{},
 			statusCode: 500,
-			err: errors.New("WARNING: received error from GET(http://fakeurl/v4/coverage/info?jobId=123&pipelineId=456&jobName=main&pipelineName=d2lam/mytest&scope=): " +
-				"Get \"http://fakeurl/v4/coverage/info?jobId=123&pipelineId=456&jobName=main&pipelineName=d2lam/mytest&scope=\": " +
-				"GET http://fakeurl/v4/coverage/info?jobId=123&pipelineId=456&jobName=main&pipelineName=d2lam/mytest&scope= giving up after 5 attempts "),
+			err: errors.New("WARNING: received error from GET(http://fakeurl/v4/coverage/info?jobId=123&pipelineId=456&jobName=main&pipelineName=d2lam/mytest&scope=&prNum=&prParentJobId=): " +
+				"Get \"http://fakeurl/v4/coverage/info?jobId=123&pipelineId=456&jobName=main&pipelineName=d2lam/mytest&scope=&prNum=&prParentJobId=\": " +
+				"GET http://fakeurl/v4/coverage/info?jobId=123&pipelineId=456&jobName=main&pipelineName=d2lam/mytest&scope=&prNum=&prParentJobId= giving up after 5 attempts "),
 		},
 		{
 			coverage:   Coverage{},
 			statusCode: 404,
-			err:        errors.New("WARNING: received response 404 from http://fakeurl/v4/coverage/info?jobId=123&pipelineId=456&jobName=main&pipelineName=d2lam/mytest&scope= "),
+			err:        errors.New("WARNING: received response 404 from http://fakeurl/v4/coverage/info?jobId=123&pipelineId=456&jobName=main&pipelineName=d2lam/mytest&scope=&prNum=&prParentJobId= "),
 		},
 	}
 
@@ -279,7 +279,7 @@ func TestGetCoverageInfo(t *testing.T) {
 		client.HTTPClient = makeFakeHTTPClient(t, test.statusCode, string(JSON))
 		testAPI := api{"http://fakeurl", "faketoken", client}
 
-		coverage, err := testAPI.GetCoverageInfo(123, 456, "main", "d2lam/mytest", "")
+		coverage, err := testAPI.GetCoverageInfo(123, 456, "main", "d2lam/mytest", "", "", "")
 
 		if !reflect.DeepEqual(err, test.err) {
 			t.Errorf("Unexpected error from GetCoverageInfo: \n%v\n want \n%v", err.Error(), test.err.Error())

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -302,6 +302,13 @@ func TestJobFromID(t *testing.T) {
 				ID:         1555,
 				PipelineID: 2666,
 				Name:       "testName",
+				Permutations: []JobPermutation{
+					{
+						Annotations: JobAnnotations{
+							CoverageScope: "job",
+						},
+					},
+				},
 			},
 			statusCode: 200,
 			err:        nil,


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective

Use coverage scope data present in Job endpoint for `/coverage/info` endpoint to re-use existing info 

## References

https://github.com/screwdriver-cd/screwdriver/issues/2152

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
