### PR TITLE
fix:  support mixed data types for coverage info endpoint

### DIFF
--- a/data/emitter
+++ b/data/emitter
@@ -1,9 +1,9 @@
-{"t":1596486229469,"m":"Screwdriver Launcher information","s":"sd-setup-launcher"}
-{"t":1596486229469,"m":"Version:        vdev","s":"sd-setup-launcher"}
-{"t":1596486229469,"m":"Pipeline:       #3","s":"sd-setup-launcher"}
-{"t":1596486229469,"m":"Job:            main","s":"sd-setup-launcher"}
-{"t":1596486229469,"m":"Build:          #1","s":"sd-setup-launcher"}
-{"t":1596486229469,"m":"Workspace Dir:  /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir326881263","s":"sd-setup-launcher"}
-{"t":1596486229469,"m":"Checkout Dir:     /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir326881263/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
-{"t":1596486229469,"m":"Source Dir:     /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir326881263/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
-{"t":1596486229469,"m":"Artifacts Dir:  /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir326881263/artifacts","s":"sd-setup-launcher"}
+{"t":1596570264067,"m":"Screwdriver Launcher information","s":"sd-setup-launcher"}
+{"t":1596570264067,"m":"Version:        vdev","s":"sd-setup-launcher"}
+{"t":1596570264067,"m":"Pipeline:       #3","s":"sd-setup-launcher"}
+{"t":1596570264067,"m":"Job:            main","s":"sd-setup-launcher"}
+{"t":1596570264067,"m":"Build:          #1","s":"sd-setup-launcher"}
+{"t":1596570264067,"m":"Workspace Dir:  /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir357475711","s":"sd-setup-launcher"}
+{"t":1596570264067,"m":"Checkout Dir:     /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir357475711/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
+{"t":1596570264067,"m":"Source Dir:     /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir357475711/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
+{"t":1596570264067,"m":"Artifacts Dir:  /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir357475711/artifacts","s":"sd-setup-launcher"}

--- a/launch.go
+++ b/launch.go
@@ -532,7 +532,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 	}
 	coverageInfo, err := api.GetCoverageInfo(job.ID, job.PipelineID, job.Name, pipeline.ScmRepo.Name, coverageScope, pr, strconv.Itoa(job.PrParentJobID))
 	if err != nil {
-		log.Printf("Failed to get coverage info for build %v so skip it\n", build.ID)
+		log.Printf("Failed to get coverage info for build %v so skip it: %v\n", build.ID, err)
 	} else {
 		for key, value := range coverageInfo.EnvVars {
 			defaultEnv[key] = value

--- a/launch.go
+++ b/launch.go
@@ -535,7 +535,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		log.Printf("Failed to get coverage info for build %v so skip it: %v\n", build.ID, err)
 	} else {
 		for key, value := range coverageInfo.EnvVars {
-			defaultEnv[key] = value
+			defaultEnv[key] = value.(string)
 		}
 	}
 

--- a/launch_test.go
+++ b/launch_test.go
@@ -45,7 +45,7 @@ var TestParentBuildIDFloat interface{} = float64(1111)
 var TestParentBuildIDs = []float64{1111, 2222}
 var IDs = make([]interface{}, len(TestParentBuildIDs))
 var actual = make(map[string]interface{})
-var TestEnvVars = map[string]string{
+var TestEnvVars = map[string]interface{}{
 	"SD_SONAR_AUTH_URL": "https://api.screwdriver.cd/v4/coverage/token",
 	"SD_SONAR_HOST":     "https://sonar.screwdriver.cd",
 }
@@ -819,7 +819,7 @@ func TestSetEnv(t *testing.T) {
 	// in case of no coverage plugins
 	delete(tests, "SD_SONAR_AUTH_URL")
 	delete(tests, "SD_SONAR_HOST")
-	TestEnvVars = map[string]string{}
+	TestEnvVars = map[string]interface{}{}
 	foundEnv = map[string]string{}
 	err = launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUiURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0)
 	if err != nil {
@@ -836,7 +836,7 @@ func TestSetEnv(t *testing.T) {
 		return screwdriver.Pipeline(FakePipeline{ID: pipelineID, ScmURI: TestScmURI + ":lib", ScmRepo: TestScmRepo}), nil
 	}
 	tests["SD_SOURCE_DIR"] = tests["SD_SOURCE_DIR"] + "/lib"
-	TestEnvVars = map[string]string{}
+	TestEnvVars = map[string]interface{}{}
 	foundEnv = map[string]string{}
 	err = launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUiURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0)
 	if err != nil {

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -177,7 +177,7 @@ type Build struct {
 
 // Coverage is a Coverage object returned when getInfo is called
 type Coverage struct {
-	EnvVars map[string]string `json:"envVars"`
+	EnvVars map[string]interface{} `json:"envVars"`
 }
 
 // Event is a Screwdriver Event

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -238,9 +238,10 @@ func TestEventFromID(t *testing.T) {
 }
 
 func TestGetCoverageInfo(t *testing.T) {
-	envVars := map[string]string{
-		"SD_SONAR_AUTH_URL": "https://api.screwdriver.cd/v4/coverage/token",
-		"SD_SONAR_HOST":     "https://sonar.screwdriver.cd",
+	envVars := map[string]interface{}{
+		"SD_SONAR_AUTH_URL":   "https://api.screwdriver.cd/v4/coverage/token",
+		"SD_SONAR_HOST":       "https://sonar.screwdriver.cd",
+		"SD_SONAR_ENTERPRISE": false,
 	}
 	tests := []struct {
 		coverage   Coverage


### PR DESCRIPTION
## Context

```
2020/08/04 18:59:56 [DEBUG] GET https://api.screwdriver.cd/v4/coverage/info?jobId=7461&pipelineId=1077&jobName=main&pipelineName=jithine/sd-test&scope=&prNum=&prParentJobId=0
2020/08/04 18:59:56 Failed to get coverage info for build 432950 so skip it
```


## References

https://play.golang.org/p/2lULPLFnhxS

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
