### PR TITLE
fix(2152): add coverageKey to build meta

### DIFF
--- a/data/emitter
+++ b/data/emitter
@@ -1,9 +1,9 @@
-{"t":1596577614729,"m":"Screwdriver Launcher information","s":"sd-setup-launcher"}
-{"t":1596577614729,"m":"Version:        vdev","s":"sd-setup-launcher"}
-{"t":1596577614729,"m":"Pipeline:       #3","s":"sd-setup-launcher"}
-{"t":1596577614729,"m":"Job:            main","s":"sd-setup-launcher"}
-{"t":1596577614729,"m":"Build:          #1","s":"sd-setup-launcher"}
-{"t":1596577614729,"m":"Workspace Dir:  /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir186959688","s":"sd-setup-launcher"}
-{"t":1596577614729,"m":"Checkout Dir:     /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir186959688/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
-{"t":1596577614729,"m":"Source Dir:     /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir186959688/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
-{"t":1596577614729,"m":"Artifacts Dir:  /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir186959688/artifacts","s":"sd-setup-launcher"}
+{"t":1596752006603,"m":"Screwdriver Launcher information","s":"sd-setup-launcher"}
+{"t":1596752006603,"m":"Version:        vdev","s":"sd-setup-launcher"}
+{"t":1596752006603,"m":"Pipeline:       #3","s":"sd-setup-launcher"}
+{"t":1596752006603,"m":"Job:            main","s":"sd-setup-launcher"}
+{"t":1596752006603,"m":"Build:          #1","s":"sd-setup-launcher"}
+{"t":1596752006603,"m":"Workspace Dir:  /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir810902245","s":"sd-setup-launcher"}
+{"t":1596752006603,"m":"Checkout Dir:     /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir810902245/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
+{"t":1596752006603,"m":"Source Dir:     /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir810902245/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
+{"t":1596752006603,"m":"Artifacts Dir:  /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir810902245/artifacts","s":"sd-setup-launcher"}


### PR DESCRIPTION
## Context

UI and clients with build data need an easy way to query Sonar coverage data. For this caller needs access to Sonar Project Key without having to re-compute it again.

## Objective

Add sonar project key into  metadata at `build.coverageKey`

## References

https://github.com/screwdriver-cd/screwdriver/issues/2152

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
