### PR TITLE
feat: Run teardown steps on abort build

### DIFF
--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -9,7 +9,7 @@ clean_up () {
 }
 
 # Trap these SIGNALs and run teardown
-trap 'clean_up $@'  SIGINT SIGTERM EXIT SIGQUIT SIGHUP
+trap 'clean_up $@' HUP INT QUIT TERM EXIT
 
 I_AM_ROOT=false
 

--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -1,18 +1,15 @@
 #!/bin/sh
 set -e
 
-args=($@)
-
 clean_up () {
   if [ $? -ne 0 ]; then
-    # args element is enclosed in double-quotes, which results in error; eval strips double-quotes
-    /opt/sd/launch  --run-teardown --token $(eval echo ${args[1]}) --api-uri $(eval echo ${args[2]}) --store-uri $(eval echo ${args[3]}) --ui-uri $(eval echo ${args[6]}) --emitter /sd/emitter --build-timeout $(eval echo ${args[4]}) --cache-strategy $(eval echo ${args[7]}) --pipeline-cache-dir $(eval echo ${args[8]}) --job-cache-dir $(eval echo ${args[9]}) --event-cache-dir $(eval echo ${args[10]}) --cache-compress $(eval echo ${args[11]}) --cache-md5check $(eval echo ${args[12]}) --cache-max-size-mb $(eval echo ${args[13]}) --cache-max-go-threads $(eval echo ${args[14]}) $(eval echo ${args[5]})
-    exit 1
+    /opt/sd/launch  --run-teardown --token "${2}" --api-uri "${3}" --store-uri "${4}" --ui-uri "${7}" --emitter /sd/emitter --build-timeout "${5}" --cache-strategy "${8}" --pipeline-cache-dir "${9}" --job-cache-dir "${10}" --event-cache-dir "${11}" --cache-compress "${12}" --cache-md5check "${13}" --cache-max-size-mb "${14}" --exit-code "500" --cache-max-go-threads "${15}" "${6}"
+   exit 1
   fi
 }
 
 # Trap these SIGNALs and run teardown
-trap 'clean_up' SIGINT SIGTERM EXIT SIGQUIT SIGHUP
+trap 'clean_up $@'  SIGINT SIGTERM EXIT SIGQUIT SIGHUP
 
 I_AM_ROOT=false
 

--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -57,6 +57,14 @@ find /opt/sd/hab/pkgs/core -mindepth 2 -maxdepth 2 -exec sh -c 'mkdir -p `echo $
 # this cmd will symlink the specific version: ln -s  /opt/sd/hab/pkgs/core/curl/7.54.1/20181008145326 /hab/pkgs/core/curl/7.54.1
 find /opt/sd/hab/pkgs/core -mindepth 3 -maxdepth 3 -exec sh -c 'ln -s $1 `dirname $1 | sed "s/\/opt\/sd//"`' -- {} \; || echo 'Failed to symlink hab cache'
 
+# Binlinking bash from core/bash into /bin
+binary_exists() {
+    smart_run command -v "$1" >/dev/null 2>&1
+}
+if ! binary_exists bash; then
+    smart_run /opt/sd/bin/hab pkg binlink core/bash bash
+fi
+
 echo 'Creating workspace and log pipe'
 date
 # Create FIFO for emitter

--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -43,6 +43,10 @@ smart_run () {
     fi
 }
 
+binary_exists() {
+    smart_run command -v "$1" >/dev/null 2>&1
+}
+
 echo 'sudo available in Container?'
 smart_run whoami
 
@@ -58,9 +62,6 @@ find /opt/sd/hab/pkgs/core -mindepth 2 -maxdepth 2 -exec sh -c 'mkdir -p `echo $
 find /opt/sd/hab/pkgs/core -mindepth 3 -maxdepth 3 -exec sh -c 'ln -s $1 `dirname $1 | sed "s/\/opt\/sd//"`' -- {} \; || echo 'Failed to symlink hab cache'
 
 # Binlinking bash from core/bash into /bin
-binary_exists() {
-    smart_run command -v "$1" >/dev/null 2>&1
-}
 if ! binary_exists bash; then
     smart_run /opt/sd/bin/hab pkg binlink core/bash bash
 fi

--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -2,10 +2,8 @@
 set -e
 
 clean_up () {
-  if [ $? -ne 0 ]; then
-    /opt/sd/launch  --run-teardown --token "${2}" --api-uri "${3}" --store-uri "${4}" --ui-uri "${7}" --emitter /sd/emitter --build-timeout "${5}" --cache-strategy "${8}" --pipeline-cache-dir "${9}" --job-cache-dir "${10}" --event-cache-dir "${11}" --cache-compress "${12}" --cache-md5check "${13}" --cache-max-size-mb "${14}" --exit-code "500" --cache-max-go-threads "${15}" "${6}"
+   /opt/sd/launch  --run-teardown --token "${2}" --api-uri "${3}" --store-uri "${4}" --ui-uri "${7}" --emitter /sd/emitter --build-timeout "${5}" --cache-strategy "${8}" --pipeline-cache-dir "${9}" --job-cache-dir "${10}" --event-cache-dir "${11}" --cache-compress "${12}" --cache-md5check "${13}" --cache-max-size-mb "${14}" --exit-code "500" --cache-max-go-threads "${15}" "${6}"
    exit 1
-  fi
 }
 
 # Trap these SIGNALs and run teardown

--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -1,6 +1,18 @@
 #!/bin/sh
-
 set -e
+
+args=($@)
+
+clean_up () {
+  if [ $? -ne 0 ]; then
+    # args element is enclosed in double-quotes, which results in error; eval strips double-quotes
+    /opt/sd/launch  --run-teardown --token $(eval echo ${args[1]}) --api-uri $(eval echo ${args[2]}) --store-uri $(eval echo ${args[3]}) --ui-uri $(eval echo ${args[6]}) --emitter /sd/emitter --build-timeout $(eval echo ${args[4]}) --cache-strategy $(eval echo ${args[7]}) --pipeline-cache-dir $(eval echo ${args[8]}) --job-cache-dir $(eval echo ${args[9]}) --event-cache-dir $(eval echo ${args[10]}) --cache-compress $(eval echo ${args[11]}) --cache-md5check $(eval echo ${args[12]}) --cache-max-size-mb $(eval echo ${args[13]}) --cache-max-go-threads $(eval echo ${args[14]}) $(eval echo ${args[5]})
+    exit 1
+  fi
+}
+
+# Trap these SIGNALs and run teardown
+trap 'clean_up' SIGINT SIGTERM EXIT SIGQUIT SIGHUP
 
 I_AM_ROOT=false
 

--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 args=$@

--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -1,21 +1,6 @@
 #!/bin/sh
 set -e
 
-# Trap these SIGNALs and run teardown
-trap 'clean_up $@' HUP INT QUIT TERM EXIT
-
-clean_up () {
-    if [ $? -ne 0 ]; then
-        echo "Running contianer error command"
-        /opt/sd/launch --container-error --token "${2}" --api-uri "${3}" --store-uri "${4}" --ui-uri "${7}" --emitter /sd/emitter --build-timeout "${5}" --cache-strategy "${8}" --pipeline-cache-dir "${9}" --job-cache-dir "${10}" --event-cache-dir "${11}" --cache-compress "${12}" --cache-md5check "${13}" --cache-max-size-mb "${14}" --cache-max-go-threads "${15}" "${6}"
-        exit 1
-    else
-        echo "Running teardown command"
-        /opt/sd/launch  --run-teardown --token "${2}" --api-uri "${3}" --store-uri "${4}" --ui-uri "${7}" --emitter /sd/emitter --build-timeout "${5}" --cache-strategy "${8}" --pipeline-cache-dir "${9}" --job-cache-dir "${10}" --event-cache-dir "${11}" --cache-compress "${12}" --cache-md5check "${13}" --cache-max-size-mb "${14}" --exit-code "500" --cache-max-go-threads "${15}" "${6}"
-        exit 1
-   fi
-}
-
 I_AM_ROOT=false
 
 if [ `whoami` = "root" ]; then
@@ -62,5 +47,5 @@ done
 echo 'Symlink hab cache, log pipe is ready'
 date
 
-# Entrypoint
-exec /opt/sd/tini -- /bin/sh -c "$@"
+# exec run.sh using dumbinit
+exec /opt/sd/dumb-init -- /bin/bash -c "$@"

--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -1,13 +1,20 @@
 #!/bin/sh
 set -e
 
-clean_up () {
-   /opt/sd/launch  --run-teardown --token "${2}" --api-uri "${3}" --store-uri "${4}" --ui-uri "${7}" --emitter /sd/emitter --build-timeout "${5}" --cache-strategy "${8}" --pipeline-cache-dir "${9}" --job-cache-dir "${10}" --event-cache-dir "${11}" --cache-compress "${12}" --cache-md5check "${13}" --cache-max-size-mb "${14}" --exit-code "500" --cache-max-go-threads "${15}" "${6}"
-   exit 1
-}
-
 # Trap these SIGNALs and run teardown
 trap 'clean_up $@' HUP INT QUIT TERM EXIT
+
+clean_up () {
+    if [ $? -ne 0 ]; then
+        echo "Running contianer error command"
+        /opt/sd/launch --container-error --token "${2}" --api-uri "${3}" --store-uri "${4}" --ui-uri "${7}" --emitter /sd/emitter --build-timeout "${5}" --cache-strategy "${8}" --pipeline-cache-dir "${9}" --job-cache-dir "${10}" --event-cache-dir "${11}" --cache-compress "${12}" --cache-md5check "${13}" --cache-max-size-mb "${14}" --cache-max-go-threads "${15}" "${6}"
+        exit 1
+    else
+        echo "Running teardown command"
+        /opt/sd/launch  --run-teardown --token "${2}" --api-uri "${3}" --store-uri "${4}" --ui-uri "${7}" --emitter /sd/emitter --build-timeout "${5}" --cache-strategy "${8}" --pipeline-cache-dir "${9}" --job-cache-dir "${10}" --event-cache-dir "${11}" --cache-compress "${12}" --cache-md5check "${13}" --cache-max-size-mb "${14}" --exit-code "500" --cache-max-go-threads "${15}" "${6}"
+        exit 1
+   fi
+}
 
 I_AM_ROOT=false
 

--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 args=$@

--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -6,7 +6,9 @@ trap 'trap_handler $@' INT TERM
 trap_handler () {
     code=$?
     if [ $code -ne 0 ]; then
-        echo "Exit code:$code received, run command"
+        echo "Exit code:$code received in run.sh, waiting for $SD_TERMINATION_GRACE_PERIOD_SECONDS seconds"
+        # this trap does not wait for launcher SIGTERM processing completion 
+        # so add sleep until timeoutgraceperiodseconds is elapsed
         sleep $SD_TERMINATION_GRACE_PERIOD_SECONDS
     fi
 }

--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -6,7 +6,8 @@ trap 'trap_handler $@' INT TERM
 trap_handler () {
     code=$?
     if [ $code -ne 0 ]; then
-        echo "Exit code:$code received, run teardown steps"
+        echo "Exit code:$code received, run command"
+        sleep $SD_TERMINATION_GRACE_PERIOD_SECONDS
     fi
 }
 

--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Get push gateway url and container image from env variable
 if ([ ! -z "$SD_PUSHGATEWAY_URL" ] && [ ! -z "$CONTAINER_IMAGE" ] && [ ! -z "$SD_PIPELINE_ID" ]); then

--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # Get push gateway url and container image from env variable
 if ([ ! -z "$SD_PUSHGATEWAY_URL" ] && [ ! -z "$CONTAINER_IMAGE" ] && [ ! -z "$SD_PIPELINE_ID" ]); then

--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -23,3 +23,14 @@ fi
 echo "run launch"
 # wrapper script for run build in multiple executors.
 SD_TOKEN=`/opt/sd/launch --only-fetch-token --token "$1" --api-uri "$2" --store-uri "$3" --ui-uri "$6" --emitter /sd/emitter --build-timeout "$4" --cache-strategy "$7" --pipeline-cache-dir "$8" --job-cache-dir "$9" --event-cache-dir "${10}" --cache-compress "${11}" --cache-md5check "${12}" --cache-max-size-mb "${13}" --cache-max-go-threads "${14}" "$5"` && (/opt/sd/launch --token "$SD_TOKEN" --api-uri "$2" --store-uri "$3" --ui-uri "$6" --emitter /sd/emitter --build-timeout "$4" --cache-strategy "$7" --pipeline-cache-dir "$8" --job-cache-dir "$9" --event-cache-dir "${10}" --cache-compress "${11}" --cache-md5check "${12}" --cache-max-size-mb "${13}" --cache-max-go-threads "${14}" "$5" & /opt/sd/logservice --token "$SD_TOKEN" --emitter /sd/emitter --api-uri "$2" --store-uri "$3" --build "$5" & wait $(jobs -p))
+
+# Trap these SIGNALs and run teardown
+trap 'trap_handler $@' INT QUIT TERM EXIT
+
+trap_handler () {
+    code=$?
+    if [ $code -ne 0 ]; then
+        echo "Exit code:$code received, run teardown steps"
+        /opt/sd/launch  --run-teardown --token "${SD_TOKEN}" --api-uri "${2}" --store-uri "${3}" --ui-uri "${67}" --emitter /sd/emitter --build-timeout "${4}" --cache-strategy "${7}" --pipeline-cache-dir "${8}" --job-cache-dir "${9}" --event-cache-dir "${10}" --cache-compress "${11}" --cache-md5check "${12}" --cache-max-size-mb "${13}" --exit-code "500" --cache-max-go-threads "${14}" "${5}"
+    fi
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,4 @@ VOLUME /opt/sd
 VOLUME /hab
 
 # Set Entrypoint
-ENTRYPOINT ["/opt/sd/dumb-init", "--"]
-
-CMD ["/opt/sd/launcher_entrypoint.sh", ""]
+ENTRYPOINT ["/opt/sd/launcher_entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,28 +39,10 @@ RUN set -x \
       | egrep -o '/screwdriver-cd/store-cli/releases/download/v[0-9.]*/store-cli_linux_amd64' \
       | wget --base=http://github.com/ -i - -O store-cli \
    && chmod +x store-cli \
-   # Download Tini Static
-   && wget -q -O - https://github.com/krallin/tini/releases/latest \
-      | egrep -o '/krallin/tini/releases/download/v[0-9.]*/tini-static' \
-      | head -1 \
-      | wget --base=http://github.com/ -i - -O tini-static \
-   && wget -q -O - https://github.com/krallin/tini/releases/latest \
-      | egrep -o '/krallin/tini/releases/download/v[0-9.]*/tini-static.asc' \
-      | wget --base=http://github.com/ -i - -O tini-static.asc \
-   && found=''; \
-      ( \
-      gpg --no-tty --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 || \
-      gpg --no-tty --keyserver pgp.mit.edu --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 || \
-      gpg --no-tty --keyserver keyserver.pgp.com --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 || \
-      gpg --no-tty --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 || \
-      gpg --no-tty --keyserver ha.pool.sks-keyservers.net --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
-      ) \
-   && found=yes && break; \
-     test -z "$found" && echo >&2 "error: failed to fetch GPG key 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7" && exit 1; \
-     gpg --verify tini-static.asc  \
-   && rm tini-static.asc \
-   && mv tini-static tini \
-   && chmod +x tini \
+   # Download dumb-init
+   && wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 \
+   && chmod +x /usr/local/bin/dumb-init \
+   && cp /usr/local/bin/dumb-init /opt/sd/dumb-init \
    # Install Habitat
    && mkdir -p /hab/bin /opt/sd/bin \
    # Download Habitat Binary
@@ -104,4 +86,6 @@ VOLUME /opt/sd
 VOLUME /hab
 
 # Set Entrypoint
-ENTRYPOINT ["/opt/sd/launcher_entrypoint.sh"]
+ENTRYPOINT ["/opt/sd/dumb-init", "--"]
+
+CMD ["/opt/sd/launcher_entrypoint.sh", ""]

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,9 @@ RUN set -x \
    # Cleanup Sonar scanner cli files
    && rm -rf /opt/sd/sonarscanner-cli-linux.zip /opt/sd/sonarscanner-cli-macosx.zip /opt/sd/sonar-scanner-*-linux /opt/sd/sonar-scanner-*-macosx \
    # Cleanup packages
-   && apk del --purge .build-dependencies
+   && apk del --purge .build-dependencies \
+   # bin link bash if not present
+   && if [[ -z $(command -v bash) ]]; then /hab/bin/hab pkg binlink core/bash bash ; fi
 
 # Copy optional entrypoint script to the image
 COPY Docker/launcher_entrypoint.sh /opt/sd/launcher_entrypoint.sh

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -398,10 +398,11 @@ func RunTeardownOnAbort(path string, env []string, emitter screwdriver.Emitter, 
 	var stepExitCode int
 	var cmdErr error
 
-	_, sdTeardownCommands, userTeardownCommands := filterTeardowns(build)
-	teardownCommands := append(userTeardownCommands, sdTeardownCommands...)
+	_, sdTeardownCommands, _ := filterTeardowns(build)
+	// teardownCommands := append(userTeardownCommands, sdTeardownCommands...)
+	// add check for artifact bookend
 
-	for index, cmd := range teardownCommands {
+	for index, cmd := range sdTeardownCommands {
 		if index == 0 && firstError == nil {
 			// Exit shell only if previous user steps ran successfully
 			f.Write([]byte{4})

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -641,3 +641,36 @@ func TestUserShell(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 }
+
+func TestRunTeardownOnAbort(t *testing.T) {
+	envFilepath := "/tmp/testAllStepsPassed"
+	setupTestCase(t, envFilepath)
+	commands := []screwdriver.CommandDef{
+		{Cmd: "ls", Name: "test ls"},
+		{Cmd: "echo 1", Name: "teardown-user-step"},
+		{Cmd: "exit $SD_STEP_EXIT_CODE", Name: "sd-teardown-last-tear-down"},
+	}
+	testBuild := screwdriver.Build{
+		ID:          12345,
+		Commands:    commands,
+		Environment: []map[string]string{},
+	}
+	testAPI := screwdriver.API(MockAPI{
+		updateStepStart: func(buildID int, stepName string) error {
+			if buildID != testBuild.ID {
+				t.Errorf("wrong build id got %v, want %v", buildID, testBuild.ID)
+			}
+			return nil
+		},
+		updateStepStop: func(buildID int, stepName string, code int) error {
+			if stepName == "sd-teardown-last-tear-down" && code != 0 { // should expect 0 b/c all previous steps passed
+				t.Errorf("step %v should return exit code of %v instead of %v", stepName, 0, code)
+			}
+			return nil
+		},
+	})
+	err := RunTeardownOnAbort("", nil, &MockEmitter{}, testBuild, testAPI, testBuild.ID, "/bin/sh", TestBuildTimeout, envFilepath, "")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}

--- a/launch.go
+++ b/launch.go
@@ -52,7 +52,7 @@ var pushgatewayUrlTimeout = 15
 var buildCreateTime time.Time
 var queueEnterTime time.Time
 
-var url string
+var apiUrl string
 var token string
 var workspace string
 var emitterPath string
@@ -841,7 +841,7 @@ func main() {
 		select {
 		case sig := <-sigs:
 			fmt.Printf("Got %s signal! starting teardown steps \n", sig)
-			temporalAPI, err := screwdriver.New(url, token)
+			temporalAPI, err := screwdriver.New(apiUrl, token)
 			if err != nil {
 				log.Printf("Error creating temporal Screwdriver API %v: %v", buildID, err)
 				exit(screwdriver.Failure, buildID, nil, metaSpace, "")
@@ -1004,7 +1004,7 @@ func main() {
 	}
 
 	app.Action = func(c *cli.Context) error {
-		url = c.String("api-uri")
+		apiUrl = c.String("api-uri")
 		token := c.String("token")
 		workspace = c.String("workspace")
 		emitterPath = c.String("emitter")
@@ -1041,7 +1041,7 @@ func main() {
 		}
 
 		if containerError {
-			temporalApi, err := screwdriver.New(url, token)
+			temporalApi, err := screwdriver.New(apiUrl, token)
 			if err != nil {
 				log.Printf("Error creating temporal Screwdriver API %v: %v", buildID, err)
 				exit(screwdriver.Failure, buildID, nil, metaSpace, "")
@@ -1051,7 +1051,7 @@ func main() {
 		}
 
 		if fetchFlag {
-			temporalApi, err := screwdriver.New(url, token)
+			temporalApi, err := screwdriver.New(apiUrl, token)
 			if err != nil {
 				log.Printf("Error creating temporal Screwdriver API %v: %v", buildID, err)
 				exit(screwdriver.Failure, buildID, nil, metaSpace, "")
@@ -1081,14 +1081,14 @@ func main() {
 				cleanExit()
 			}
 
-			api, err = screwdriver.NewLocal(url, localJobName, localBuild)
+			api, err = screwdriver.NewLocal(apiUrl, localJobName, localBuild)
 		} else {
-			api, err = screwdriver.New(url, token)
+			api, err = screwdriver.New(apiUrl, token)
 		}
 
 		if runTearDown {
 			log.Printf("starting teardown steps on abort")
-			temporalAPI, err := screwdriver.New(url, token)
+			temporalAPI, err := screwdriver.New(apiUrl, token)
 			if err != nil {
 				log.Printf("Error creating temporal Screwdriver API %v: %v", buildID, err)
 				exit(screwdriver.Failure, buildID, nil, metaSpace, "")

--- a/launch.go
+++ b/launch.go
@@ -992,8 +992,6 @@ func main() {
 			return cli.ShowAppHelp(c)
 		}
 
-		log.Printf("New launcher version: v7")
-
 		log.Printf("cache strategy, directories (pipeline, job, event), compress, md5check, maxsize: %v, %v, %v, %v, %v, %v, %v \n", cacheStrategy, pipelineCacheDir, jobCacheDir, eventCacheDir, cacheCompress, cacheMd5Check, cacheMaxSizeInMB)
 
 		if !isLocal && len(token) == 0 {

--- a/launch.go
+++ b/launch.go
@@ -709,9 +709,10 @@ func launchAction(api screwdriver.API, buildID int, rootDir, emitterPath, metaSp
 		}
 
 		exit(screwdriver.Failure, buildID, api, metaSpace, "")
-	} else {
-		exit(screwdriver.Success, buildID, api, metaSpace, "")
+		return nil
 	}
+
+	exit(screwdriver.Success, buildID, api, metaSpace, "")
 
 	return nil
 }
@@ -874,16 +875,7 @@ func main() {
 		cli.BoolFlag{
 			Name:  "container-error",
 			Usage: "container error",
-		},
-		cli.BoolFlag{
-			Name:  "run-teardown",
-			Usage: "run teardown down process",
-		},
-		cli.StringFlag{
-			Name:  "exit-code",
-			Usage: "exit code for sd build success(200) or failure(500)",
-			Value: "500",
-		},
+		}
 	}
 
 	app.Action = func(c *cli.Context) error {
@@ -896,7 +888,7 @@ func main() {
 		uiURL := c.String("ui-uri")
 		shellBin := c.String("shell-bin")
 		buildID, err := strconv.Atoi(c.Args().Get(0))
-		buildTimeoutSeconds := c.Int("build-timeout")
+		buildTimeoutSeconds := c.Int("build-timeout") * 60
 		fetchFlag := c.Bool("only-fetch-token")
 		cacheStrategy := c.String("cache-strategy")
 		pipelineCacheDir := c.String("pipeline-cache-dir")
@@ -992,7 +984,6 @@ func main() {
 		// This should never happen...
 		log.Println("Unexpected return in launcher. Failing the build.")
 		exit(screwdriver.Failure, buildID, api, metaSpace, "")
-
 		return nil
 	}
 	app.Run(os.Args)

--- a/launch.go
+++ b/launch.go
@@ -875,7 +875,7 @@ func main() {
 		cli.BoolFlag{
 			Name:  "container-error",
 			Usage: "container error",
-		}
+		},
 	}
 
 	app.Action = func(c *cli.Context) error {

--- a/launch.go
+++ b/launch.go
@@ -7,14 +7,12 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"os/signal"
 	"path"
 	"path/filepath"
 	"regexp"
 	"runtime/debug"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
@@ -809,22 +807,22 @@ func main() {
 	defer finalRecover()
 	defer recoverPanic(0, nil, "")
 
-	sigs := make(chan os.Signal, 1)
+	// sigs := make(chan os.Signal, 1)
 
-	go func() {
-		// waiting for a signal
-		select {
-		case sig := <-sigs:
-			fmt.Printf("Got %s signal. Aborting...\n", sig)
-			runCmd("/opt/sd/launch", "sd-cleanup")
-			cleanExit()
-		}
-		// unregister the signal handler
-		defer signal.Stop(sigs)
-	}()
+	// go func() {
+	// 	// waiting for a signal
+	// 	select {
+	// 	case sig := <-sigs:
+	// 		fmt.Printf("Got %s signal. Aborting...\n", sig)
+	// 		runCmd("/opt/sd/launch", "sd-cleanup")
+	// 		cleanExit()
+	// 	}
+	// 	// unregister the signal handler
+	// 	defer signal.Stop(sigs)
+	// }()
 
-	defer close(sigs)
-	signal.Notify(sigs, syscall.SIGTERM)
+	// defer close(sigs)
+	// signal.Notify(sigs, syscall.SIGTERM)
 
 	app := cli.NewApp()
 	app.Name = "launcher"

--- a/launch.go
+++ b/launch.go
@@ -7,14 +7,12 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"os/signal"
 	"path"
 	"path/filepath"
 	"regexp"
 	"runtime/debug"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
@@ -834,33 +832,33 @@ func main() {
 	defer finalRecover()
 	defer recoverPanic(0, nil, "")
 
-	sigs := make(chan os.Signal, 1)
+	// sigs := make(chan os.Signal, 1)
 
-	go func() {
-		// waiting for a signal
-		select {
-		case sig := <-sigs:
-			fmt.Printf("Got %s signal! starting teardown steps \n", sig)
-			temporalAPI, err := screwdriver.New(apiUrl, token)
-			if err != nil {
-				log.Printf("Error creating temporal Screwdriver API %v: %v", buildID, err)
-				exit(screwdriver.Failure, buildID, nil, metaSpace, "")
-			}
-			tearErr := startTeardownPhase(api, buildID, workspace, emitterPath, metaSpace, storeURL, uiURL, shellBin, buildTimeoutSeconds, token, cacheStrategy, pipelineCacheDir, jobCacheDir, eventCacheDir, cacheCompress, cacheMd5Check, isLocal, cacheMaxSizeInMB, cacheMaxGoThreads)
-			if _, ok := tearErr.(executor.ErrStatus); ok {
-				log.Printf("Failure due to non-zero exit code: %v\n", tearErr)
-			} else {
-				log.Printf("Error running teardown: %v\n", tearErr)
-			}
-			exit(screwdriver.Failure, buildID, temporalAPI, metaSpace, "")
-			cleanExit()
-		}
-		// unregister the signal handler
-		defer signal.Stop(sigs)
-	}()
+	// go func() {
+	// 	// waiting for a signal
+	// 	select {
+	// 	case sig := <-sigs:
+	// 		fmt.Printf("Got %s signal! starting teardown steps \n", sig)
+	// 		temporalAPI, err := screwdriver.New(apiUrl, token)
+	// 		if err != nil {
+	// 			log.Printf("Error creating temporal Screwdriver API %v: %v", buildID, err)
+	// 			exit(screwdriver.Failure, buildID, nil, metaSpace, "")
+	// 		}
+	// 		tearErr := startTeardownPhase(api, buildID, workspace, emitterPath, metaSpace, storeURL, uiURL, shellBin, buildTimeoutSeconds, token, cacheStrategy, pipelineCacheDir, jobCacheDir, eventCacheDir, cacheCompress, cacheMd5Check, isLocal, cacheMaxSizeInMB, cacheMaxGoThreads)
+	// 		if _, ok := tearErr.(executor.ErrStatus); ok {
+	// 			log.Printf("Failure due to non-zero exit code: %v\n", tearErr)
+	// 		} else {
+	// 			log.Printf("Error running teardown: %v\n", tearErr)
+	// 		}
+	// 		exit(screwdriver.Failure, buildID, temporalAPI, metaSpace, "")
+	// 		cleanExit()
+	// 	}
+	// 	// unregister the signal handler
+	// 	defer signal.Stop(sigs)
+	// }()
 
-	defer close(sigs)
-	signal.Notify(sigs, syscall.SIGTERM)
+	// defer close(sigs)
+	// signal.Notify(sigs, syscall.SIGTERM)
 
 	app := cli.NewApp()
 	app.Name = "launcher"

--- a/launch.go
+++ b/launch.go
@@ -613,7 +613,8 @@ func createEnvironment(base map[string]string, secrets screwdriver.Secrets, buil
 
 // Executes the command based on arguments from the CLI
 func launchAction(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, storeURI, uiURI, shellBin string, buildTimeout int, buildToken, cacheStrategy, pipelineCacheDir, jobCacheDir, eventCacheDir string, cacheCompress, cacheMd5Check, isLocal bool, cacheMaxSizeInMB int64, cacheMaxGoThreads int64) error {
-	log.Printf("Starting Build %v\n", buildID)
+	log.Printf("======Starting Build %v\n", buildID)
+	log.Printf("=========*** BUILD ***======== %v\n", buildID)
 	log.Printf("Cache strategy & directories (pipeline, job, event), compress, md5check, maxsize: %v, %v, %v, %v, %v, %v, %v \n", cacheStrategy, pipelineCacheDir, jobCacheDir, eventCacheDir, cacheCompress, cacheMd5Check, cacheMaxSizeInMB)
 
 	if err := launch(api, buildID, rootDir, emitterPath, metaSpace, storeURI, uiURI, shellBin, buildTimeout, buildToken, cacheStrategy, pipelineCacheDir, jobCacheDir, eventCacheDir, cacheCompress, cacheMd5Check, isLocal, cacheMaxSizeInMB, cacheMaxGoThreads); err != nil {
@@ -848,6 +849,8 @@ func main() {
 		if err != nil {
 			return cli.ShowAppHelp(c)
 		}
+
+		log.Printf("New launcher version: v7")
 
 		log.Printf("cache strategy, directories (pipeline, job, event), compress, md5check, maxsize: %v, %v, %v, %v, %v, %v, %v \n", cacheStrategy, pipelineCacheDir, jobCacheDir, eventCacheDir, cacheCompress, cacheMd5Check, cacheMaxSizeInMB)
 

--- a/launch.go
+++ b/launch.go
@@ -724,7 +724,7 @@ func startTeardownPhase(api screwdriver.API, buildID int, rootDir, emitterPath, 
 }
 
 // Executes the command based on arguments from the CLI
-func launchAction(done chan<- bool, api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, storeURI, uiURI, shellBin string, buildTimeout int, buildToken, cacheStrategy, pipelineCacheDir, jobCacheDir, eventCacheDir string, cacheCompress, cacheMd5Check, isLocal bool, cacheMaxSizeInMB int64, cacheMaxGoThreads int64) error {
+func launchAction(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, storeURI, uiURI, shellBin string, buildTimeout int, buildToken, cacheStrategy, pipelineCacheDir, jobCacheDir, eventCacheDir string, cacheCompress, cacheMd5Check, isLocal bool, cacheMaxSizeInMB int64, cacheMaxGoThreads int64) error {
 	log.Printf("Starting Build %v\n", buildID)
 	log.Printf("Cache strategy & directories (pipeline, job, event), compress, md5check, maxsize: %v, %v, %v, %v, %v, %v, %v \n", cacheStrategy, pipelineCacheDir, jobCacheDir, eventCacheDir, cacheCompress, cacheMd5Check, cacheMaxSizeInMB)
 
@@ -739,8 +739,6 @@ func launchAction(done chan<- bool, api screwdriver.API, buildID int, rootDir, e
 	} else {
 		exit(screwdriver.Success, buildID, api, metaSpace, "")
 	}
-
-	done <- true
 
 	return nil
 }

--- a/launch.go
+++ b/launch.go
@@ -850,10 +850,6 @@ func finalRecover() {
 	cleanExit()
 }
 
-func trapHandler() {
-
-}
-
 func main() {
 	defer finalRecover()
 	defer recoverPanic(0, nil, "")
@@ -1022,23 +1018,23 @@ func main() {
 		}
 
 		if containerError {
-			temporalApi, err := screwdriver.New(apiUrl, token)
+			temporalAPI, err := screwdriver.New(apiUrl, token)
 			if err != nil {
 				log.Printf("Error creating temporal Screwdriver API %v: %v", buildID, err)
 				exit(screwdriver.Failure, buildID, nil, metaSpace, "")
 			}
-			exit(screwdriver.Failure, buildID, temporalApi, metaSpace, "Error: Build failed to start. Please check if your image is valid with curl, openssh installed and default user root or sudo NOPASSWD enabled.")
+			exit(screwdriver.Failure, buildID, temporalAPI, metaSpace, "Error: Build failed to start. Please check if your image is valid with curl, openssh installed and default user root or sudo NOPASSWD enabled.")
 			cleanExit()
 		}
 
 		if fetchFlag {
-			temporalApi, err := screwdriver.New(apiUrl, token)
+			temporalAPI, err := screwdriver.New(apiUrl, token)
 			if err != nil {
 				log.Printf("Error creating temporal Screwdriver API %v: %v", buildID, err)
 				exit(screwdriver.Failure, buildID, nil, metaSpace, "")
 			}
 
-			buildToken, err := temporalApi.GetBuildToken(buildID, c.Int("build-timeout"))
+			buildToken, err := temporalAPI.GetBuildToken(buildID, c.Int("build-timeout"))
 			if err != nil {
 				log.Printf("Error getting Build Token %v: %v", buildID, err)
 				exit(screwdriver.Failure, buildID, nil, metaSpace, "")

--- a/launch.go
+++ b/launch.go
@@ -780,9 +780,6 @@ func launchAction(api screwdriver.API, buildID int, rootDir, emitterPath, metaSp
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
 	go func() {
-		defer signal.Stop(sigs)
-		defer close(sigs)
-
 		sig := <-sigs
 		fmt.Printf("Received %s signal! starting teardown steps \n", sig)
 


### PR DESCRIPTION
## Context

Currently if a build is aborted the teardown steps don't run and hence generated artifacts are not available in this case.

## Objective

This PR adds change to capture terminate signal and run the teardown step in the current build

## References

https://github.com/screwdriver-cd/screwdriver/issues/1125

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
