### PR TITLE
fix: exit launcher script on error

### DIFF
--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 I_AM_ROOT=false
 
 if [ `whoami` = "root" ]; then


### PR DESCRIPTION
## Context

Launcher entry point is not exiting on error, leading to Kubernetes build pods stuck forever.

## Objective

Exit launcher entry script on error

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
