### PR TITLE
feat(2084): Add env for periodic build

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -538,7 +538,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		"SD_CACHE_MD5CHECK":       fmt.Sprintf("%v", cacheMd5Check),
 		"SD_CACHE_MAX_SIZE_MB":    fmt.Sprintf("%v", cacheMaxSizeInMB),
 		"SD_CACHE_MAX_GO_THREADS": fmt.Sprintf("%v", cacheMaxGoThreads),
-		"SD_SCHEDULING_BUILD":     isScheduler,
+		"SD_SCHEDULED_BUILD":     isScheduler,
 	}
 
 	// Add coverage env vars

--- a/launch.go
+++ b/launch.go
@@ -538,7 +538,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		"SD_CACHE_MD5CHECK":       fmt.Sprintf("%v", cacheMd5Check),
 		"SD_CACHE_MAX_SIZE_MB":    fmt.Sprintf("%v", cacheMaxSizeInMB),
 		"SD_CACHE_MAX_GO_THREADS": fmt.Sprintf("%v", cacheMaxGoThreads),
-		"SD_SCHEDULED_BUILD":     isScheduler,
+		"SD_SCHEDULED_BUILD":      isScheduler,
 	}
 
 	// Add coverage env vars

--- a/launch.go
+++ b/launch.go
@@ -499,6 +499,8 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 
 	isCI := strconv.FormatBool(!isLocal)
 
+	isScheduler := strconv.FormatBool(event.Creator["username"] == "sd:scheduler")
+
 	defaultEnv := map[string]string{
 		"PS1":                     "",
 		"SCREWDRIVER":             isCI,
@@ -536,6 +538,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		"SD_CACHE_MD5CHECK":       fmt.Sprintf("%v", cacheMd5Check),
 		"SD_CACHE_MAX_SIZE_MB":    fmt.Sprintf("%v", cacheMaxSizeInMB),
 		"SD_CACHE_MAX_GO_THREADS": fmt.Sprintf("%v", cacheMaxGoThreads),
+		"SD_SCHEDULING_BUILD":     isScheduler,
 	}
 
 	// Add coverage env vars

--- a/launch_test.go
+++ b/launch_test.go
@@ -790,7 +790,7 @@ func TestSetEnv(t *testing.T) {
 		"SD_PIPELINE_CACHE_DIR":  "",
 		"SD_JOB_CACHE_DIR":       "",
 		"SD_EVENT_CACHE_DIR":     "",
-		"SD_SCHEDULED_BUILD":    "false",
+		"SD_SCHEDULED_BUILD":     "false",
 	}
 
 	api := mockAPI(t, TestBuildID, TestJobID, TestPipelineID, "RUNNING")

--- a/launch_test.go
+++ b/launch_test.go
@@ -790,6 +790,7 @@ func TestSetEnv(t *testing.T) {
 		"SD_PIPELINE_CACHE_DIR":  "",
 		"SD_JOB_CACHE_DIR":       "",
 		"SD_EVENT_CACHE_DIR":     "",
+		"SD_SCHEDULING_BUILD":    "false",
 	}
 
 	api := mockAPI(t, TestBuildID, TestJobID, TestPipelineID, "RUNNING")

--- a/launch_test.go
+++ b/launch_test.go
@@ -790,7 +790,7 @@ func TestSetEnv(t *testing.T) {
 		"SD_PIPELINE_CACHE_DIR":  "",
 		"SD_JOB_CACHE_DIR":       "",
 		"SD_EVENT_CACHE_DIR":     "",
-		"SD_SCHEDULING_BUILD":    "false",
+		"SD_SCHEDULED_BUILD":    "false",
 	}
 
 	api := mockAPI(t, TestBuildID, TestJobID, TestPipelineID, "RUNNING")

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -186,7 +186,7 @@ type Event struct {
 	ID            int                    `json:"id"`
 	Meta          map[string]interface{} `json:"meta"`
 	ParentEventID int                    `json:"parentEventId"`
-	Creator       map[string]interface{} `json:"creator"`
+	Creator       map[string]string      `json:"creator"`
 }
 
 // Secret is a Screwdriver build secret.

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -186,7 +186,7 @@ type Event struct {
 	ID            int                    `json:"id"`
 	Meta          map[string]interface{} `json:"meta"`
 	ParentEventID int                    `json:"parentEventId"`
-	Event         map[string]interface{} `json:"creator"`
+	Creator       map[string]interface{} `json:"creator"`
 }
 
 // Secret is a Screwdriver build secret.

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -186,6 +186,7 @@ type Event struct {
 	ID            int                    `json:"id"`
 	Meta          map[string]interface{} `json:"meta"`
 	ParentEventID int                    `json:"parentEventId"`
+	Event         map[string]interface{} `json:"creator"`
 }
 
 // Secret is a Screwdriver build secret.

--- a/screwdriver/screwdriver_local.go
+++ b/screwdriver/screwdriver_local.go
@@ -35,7 +35,7 @@ func (a localApi) EventFromID(eventID int) (event Event, err error) {
 		ID:            0,
 		Meta:          make(map[string]interface{}),
 		ParentEventID: 0,
-		Creator:       make(map[string]interface{}),
+		Creator:       make(map[string]string),
 	}
 
 	return event, nil

--- a/screwdriver/screwdriver_local.go
+++ b/screwdriver/screwdriver_local.go
@@ -35,6 +35,7 @@ func (a localApi) EventFromID(eventID int) (event Event, err error) {
 		ID:            0,
 		Meta:          make(map[string]interface{}),
 		ParentEventID: 0,
+		Creator:       make(map[string]interface{}),
 	}
 
 	return event, nil

--- a/screwdriver/screwdriver_local_test.go
+++ b/screwdriver/screwdriver_local_test.go
@@ -29,6 +29,7 @@ func TestEventFromIDLocal(t *testing.T) {
 		0,
 		make(map[string]interface{}),
 		0,
+		make(map[string]interface{}),
 	}
 
 	actual, err := testAPI.EventFromID(0)

--- a/screwdriver/screwdriver_local_test.go
+++ b/screwdriver/screwdriver_local_test.go
@@ -29,7 +29,7 @@ func TestEventFromIDLocal(t *testing.T) {
 		0,
 		make(map[string]interface{}),
 		0,
-		make(map[string]interface{}),
+		make(map[string]string),
 	}
 
 	actual, err := testAPI.EventFromID(0)

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -196,6 +196,9 @@ func TestEventFromID(t *testing.T) {
 			event: Event{
 				ID:            1555,
 				ParentEventID: 8765,
+				Creator: map[string]interface{}{
+					"username": "testUsername",
+				},
 			},
 			statusCode: 200,
 			err:        nil,

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -196,7 +196,7 @@ func TestEventFromID(t *testing.T) {
 			event: Event{
 				ID:            1555,
 				ParentEventID: 8765,
-				Creator: map[string]interface{}{
+				Creator: map[string]string{
 					"username": "testUsername",
 				},
 			},


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Add `SD_SCHEDULING_BUILD` for periodic build.
If the build is triggered by scheduler, `SD_SCHEDULING_BUILD` is `true`.
Otherwise, `SD_SCHEDULING_BUILD` is `false`.
If there are any other appropriate environment name, I'll fix the environment name.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
If an event is created by scheduler, event's creator username is `sd:scheduler`.
https://github.com/screwdriver-cd/queue-service/blob/415aa19006f30be7e69753c8736eb03bf3d9c1ea/plugins/queue/scheduler.js#L46-L54
In such case, set env `SD_SCHEDULING_BUILD` true.


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2084

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
