### PR TITLE
fix: init container stuck/hang for errors

### DIFF
--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -1,6 +1,18 @@
 #!/bin/sh
-
 set -e
+
+args=($@)
+
+# Trap these SIGNALs and update build status to failure
+trap 'cleanUp' HUP INT QUIT TERM EXIT
+
+cleanUp () {
+  if [ $? -ne 0 ]; then
+    # args element is enclosed in double-quotes, which results in error; eval strips double-quotes
+    /opt/sd/launch --container-error --token $(eval echo ${args[1]}) --api-uri $(eval echo ${args[2]}) --store-uri $(eval echo ${args[3]}) --ui-uri $(eval echo ${args[6]}) --emitter /sd/emitter --build-timeout $(eval echo ${args[4]}) --cache-strategy $(eval echo ${args[7]}) --pipeline-cache-dir $(eval echo ${args[8]}) --job-cache-dir $(eval echo ${args[9]}) --event-cache-dir $(eval echo ${args[10]}) --cache-compress $(eval echo ${args[11]}) --cache-md5check $(eval echo ${args[12]}) --cache-max-size-mb $(eval echo ${args[13]}) --cache-max-go-threads $(eval echo ${args[14]}) $(eval echo ${args[5]})
+    exit 1
+  fi
+}
 
 I_AM_ROOT=false
 
@@ -15,6 +27,9 @@ smart_run () {
         $@
     fi
 }
+
+echo 'sudo available in Container?'
+smart_run whoami
 
 echo 'Symlink hab cache'
 date

--- a/data/emitter
+++ b/data/emitter
@@ -1,9 +1,9 @@
-{"t":1596754933962,"m":"Screwdriver Launcher information","s":"sd-setup-launcher"}
-{"t":1596754933962,"m":"Version:        vdev","s":"sd-setup-launcher"}
-{"t":1596754933962,"m":"Pipeline:       #3","s":"sd-setup-launcher"}
-{"t":1596754933962,"m":"Job:            main","s":"sd-setup-launcher"}
-{"t":1596754933962,"m":"Build:          #1","s":"sd-setup-launcher"}
-{"t":1596754933962,"m":"Workspace Dir:  /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir063478828","s":"sd-setup-launcher"}
-{"t":1596754933962,"m":"Checkout Dir:     /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir063478828/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
-{"t":1596754933962,"m":"Source Dir:     /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir063478828/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
-{"t":1596754933962,"m":"Artifacts Dir:  /var/folders/zt/9k2xlsbj2tq6l4300nth1q6m0000gn/T/ArtifactDir063478828/artifacts","s":"sd-setup-launcher"}
+{"t":1603401345668,"m":"Screwdriver Launcher information","s":"sd-setup-launcher"}
+{"t":1603401345668,"m":"Version:        vdev","s":"sd-setup-launcher"}
+{"t":1603401345668,"m":"Pipeline:       #3","s":"sd-setup-launcher"}
+{"t":1603401345668,"m":"Job:            main","s":"sd-setup-launcher"}
+{"t":1603401345668,"m":"Build:          #1","s":"sd-setup-launcher"}
+{"t":1603401345668,"m":"Workspace Dir:  /var/folders/05/c1358r4s0p3f7pqsdcr3vxyr0000gn/T/ArtifactDir235033765","s":"sd-setup-launcher"}
+{"t":1603401345668,"m":"Checkout Dir:     /var/folders/05/c1358r4s0p3f7pqsdcr3vxyr0000gn/T/ArtifactDir235033765/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
+{"t":1603401345668,"m":"Source Dir:     /var/folders/05/c1358r4s0p3f7pqsdcr3vxyr0000gn/T/ArtifactDir235033765/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
+{"t":1603401345668,"m":"Artifacts Dir:  /var/folders/05/c1358r4s0p3f7pqsdcr3vxyr0000gn/T/ArtifactDir235033765/artifacts","s":"sd-setup-launcher"}

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -41,7 +41,7 @@ func (f MockAPI) PipelineFromID(pipelineID int) (screwdriver.Pipeline, error) {
 	return screwdriver.Pipeline{}, nil
 }
 
-func (f MockAPI) UpdateBuildStatus(status screwdriver.BuildStatus, meta map[string]interface{}, buildID int) error {
+func (f MockAPI) UpdateBuildStatus(status screwdriver.BuildStatus, meta map[string]interface{}, buildID int, statusMessage string) error {
 	return nil
 }
 

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -50,7 +50,7 @@ type API interface {
 	EventFromID(eventID int) (Event, error)
 	JobFromID(jobID int) (Job, error)
 	PipelineFromID(pipelineID int) (Pipeline, error)
-	UpdateBuildStatus(status BuildStatus, meta map[string]interface{}, buildID int) error
+	UpdateBuildStatus(status BuildStatus, meta map[string]interface{}, buildID int, statusMessage string) error
 	UpdateStepStart(buildID int, stepName string) error
 	UpdateStepStop(buildID int, stepName string, exitCode int) error
 	SecretsForBuild(build Build) (Secrets, error)
@@ -106,6 +106,13 @@ func New(url, token string) (API, error) {
 type BuildStatusPayload struct {
 	Status string                 `json:"status"`
 	Meta   map[string]interface{} `json:"meta"`
+}
+
+// BuildStatusMessagePayload is a Screwdriver Build Status Message payload.
+type BuildStatusMessagePayload struct {
+	Status        string                 `json:"status"`
+	Meta          map[string]interface{} `json:"meta"`
+	StatusMessage string                 `json:"statusMessage"`
 }
 
 // StepStartPayload is a Screwdriver Step Start payload.
@@ -412,7 +419,7 @@ func (a api) PipelineFromID(pipelineID int) (pipeline Pipeline, err error) {
 	return pipeline, nil
 }
 
-func (a api) UpdateBuildStatus(status BuildStatus, meta map[string]interface{}, buildID int) error {
+func (a api) UpdateBuildStatus(status BuildStatus, meta map[string]interface{}, buildID int, statusMessage string) error {
 	switch status {
 	case Running:
 	case Success:
@@ -427,11 +434,21 @@ func (a api) UpdateBuildStatus(status BuildStatus, meta map[string]interface{}, 
 		return fmt.Errorf("creating url: %v", err)
 	}
 
-	bs := BuildStatusPayload{
-		Status: status.String(),
-		Meta:   meta,
+	var payload []byte
+	if statusMessage != "" {
+		bs := BuildStatusMessagePayload{
+			Status:        status.String(),
+			Meta:          meta,
+			StatusMessage: statusMessage,
+		}
+		payload, err = json.Marshal(bs)
+	} else {
+		bs := BuildStatusPayload{
+			Status: status.String(),
+			Meta:   meta,
+		}
+		payload, err = json.Marshal(bs)
 	}
-	payload, err := json.Marshal(bs)
 	if err != nil {
 		return fmt.Errorf("Marshaling JSON for Build Status: %v", err)
 	}

--- a/screwdriver/screwdriver_local.go
+++ b/screwdriver/screwdriver_local.go
@@ -62,7 +62,7 @@ func (a localApi) PipelineFromID(pipelineID int) (pipeline Pipeline, err error) 
 	return pipeline, nil
 }
 
-func (a localApi) UpdateBuildStatus(status BuildStatus, meta map[string]interface{}, buildID int) error {
+func (a localApi) UpdateBuildStatus(status BuildStatus, meta map[string]interface{}, buildID int, statusMessag string) error {
 	return nil
 }
 

--- a/screwdriver/screwdriver_local_test.go
+++ b/screwdriver/screwdriver_local_test.go
@@ -79,7 +79,7 @@ func TestPipelineFromIDLocal(t *testing.T) {
 func TestUpdateBuildStatusLocal(t *testing.T) {
 	testAPI := localApi{"http://fakeurl", "testJob", Build{}}
 
-	actual := testAPI.UpdateBuildStatus("", make(map[string]interface{}), 0)
+	actual := testAPI.UpdateBuildStatus("", make(map[string]interface{}), 0, "")
 	if actual != nil {
 		t.Errorf("actual: %v, expected: %v", actual, nil)
 	}

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -411,17 +411,19 @@ func TestUpdateBuildStatus(t *testing.T) {
 	_ = json.Unmarshal(mockJSON, &meta)
 
 	tests := []struct {
-		status     BuildStatus
-		meta       map[string]interface{}
-		statusCode int
-		err        error
+		status        BuildStatus
+		statusMessage string
+		meta          map[string]interface{}
+		statusCode    int
+		err           error
 	}{
-		{Success, meta, 200, nil},
-		{Failure, meta, 200, nil},
-		{Aborted, meta, 200, nil},
-		{Running, meta, 200, nil},
-		{"NOTASTATUS", meta, 200, errors.New("Invalid build status: NOTASTATUS")},
-		{Success, meta, 500, errors.New("Posting to Build Status: " +
+		{Success, "", meta, 200, nil},
+		{Failure, "Error: Build failed to start. Please check if your image is valid with curl, openssh installed and default user root or sudo NOPASSWD enabled.", meta, 200, nil},
+		{Failure, "", meta, 200, nil},
+		{Aborted, "", meta, 200, nil},
+		{Running, "", meta, 200, nil},
+		{"NOTASTATUS", "", meta, 200, errors.New("Invalid build status: NOTASTATUS")},
+		{Success, "", meta, 500, errors.New("Posting to Build Status: " +
 			"WARNING: received error from PUT(http://fakeurl/v4/builds/15): " +
 			"Put \"http://fakeurl/v4/builds/15\": " +
 			"PUT http://fakeurl/v4/builds/15 giving up after 5 attempts ")},
@@ -433,7 +435,7 @@ func TestUpdateBuildStatus(t *testing.T) {
 		client.HTTPClient = makeFakeHTTPClient(t, test.statusCode, "{}")
 		testAPI := api{"http://fakeurl", "faketoken", client}
 
-		err := testAPI.UpdateBuildStatus(test.status, test.meta, 15)
+		err := testAPI.UpdateBuildStatus(test.status, test.meta, 15, test.statusMessage)
 
 		if !reflect.DeepEqual(err, test.err) {
 			t.Errorf("Unexpected error from UpdateBuildStatus: \n%v\n want \n%v", err, test.err)


### PR DESCRIPTION
## Context

Build hangs indefinitely in init step for any error in launcher_entrypoint.sh (e.g. default user root or sudo NOPASSWD not enabled in container). At cluster level, build terminates with error but error is not propagated back.

## Objective

This PR will trap termination signals from launcher_entrypoint script and for any error it will update build with status `Failure` and message `Error: Build failed to start. Please check if your image is valid with curl, openssh installed and default user root or sudo NOPASSWD enabled`. Part of it for e.g. invalid container image is already handled in executor-k8s.

## References

https://github.com/screwdriver-cd/executor-k8s/pull/138
https://github.com/screwdriver-cd/executor-k8s/pull/139
https://github.com/screwdriver-cd/executor-k8s/pull/140
https://github.com/screwdriver-cd/executor-k8s/pull/141

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
