### PR TITLE
fix: sd-local build error

### DIFF
--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -1,15 +1,15 @@
 #!/bin/sh
 set -e
 
-# Trap these SIGNALs and update build status to failure
-trap "cleanUp $@" HUP INT QUIT TERM EXIT
-
 cleanUp () {
   if [ $? -ne 0 ]; then
     /opt/sd/launch --container-error --token "${2}" --api-uri "${3}" --store-uri "${4}" --ui-uri "${7}" --emitter /sd/emitter --build-timeout "${5}" --cache-strategy "${8}" --pipeline-cache-dir "${9}" --job-cache-dir "${10}" --event-cache-dir "${11}" --cache-compress "${12}" --cache-md5check "${13}" --cache-max-size-mb "${14}" --cache-max-go-threads "${15}" "${6}"
     exit 1
   fi
 }
+
+# Trap these SIGNALs and update build status to failure
+trap 'cleanUp $@' HUP INT QUIT TERM
 
 I_AM_ROOT=false
 


### PR DESCRIPTION
## Context

sd-local build fails with error "/opt/sd/launcher_entrypoint.sh: trap: line 5: /bin/echo set up bin: invalid signal specification". Suspecting becoz of EXIT signal. Removing EXIT signal from trap.

## References

https://github.com/screwdriver-cd/launcher/pull/374

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
