### PR TITLE
fix: add smart_run

### DIFF
--- a/Docker/local_run.sh
+++ b/Docker/local_run.sh
@@ -19,7 +19,7 @@ smart_run () {
 
 # Create FIFO for emitter
 mkdir -p /sd
-mkfifo -m 666 /sd/emitter
+smart_run mkfifo -m 666 /sd/emitter
 
 echo 'Symlink hab cache'
 date


### PR DESCRIPTION
## Context

sd-local failed with an error 
```
mkfifo: cannot create fifo ‘/sd/emitter’: Permission denied
```
This happens if `/sd` already exists

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
