### PR TITLE
feat: add user teardown steps on abort

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -398,11 +398,10 @@ func RunTeardownOnAbort(path string, env []string, emitter screwdriver.Emitter, 
 	var stepExitCode int
 	var cmdErr error
 
-	_, sdTeardownCommands, _ := filterTeardowns(build)
-	// teardownCommands := append(userTeardownCommands, sdTeardownCommands...)
-	// add check for artifact bookend
+	_, sdTeardownCommands, userTeardownCommands := filterTeardowns(build)
+	teardownCommands := append(userTeardownCommands, sdTeardownCommands...)
 
-	for index, cmd := range sdTeardownCommands {
+	for index, cmd := range teardownCommands {
 		if index == 0 && firstError == nil {
 			// Exit shell only if previous user steps ran successfully
 			f.Write([]byte{4})

--- a/launch.go
+++ b/launch.go
@@ -233,12 +233,11 @@ func createWorkspace(isLocal bool, rootDir string, srcPaths ...string) (Workspac
 	return w, nil
 }
 
-func getWorkspace(isLocal bool, rootDir string, srcPaths ...string) (Workspace, error) {
-	srcPaths = append([]string{"src"}, srcPaths...)
+func getWorkspace(isLocal bool, rootDir string, rootPath string, artifactPath string, srcPaths ...string) (Workspace, error) {
 	src := path.Join(srcPaths...)
 
-	src = path.Join(rootDir, src)
-	artifacts := path.Join(rootDir, "artifacts")
+	src = path.Join(rootDir, rootPath, src)
+	artifacts := path.Join(rootDir, artifactPath)
 
 	paths := []string{
 		src,
@@ -679,7 +678,7 @@ func startTeardownPhase(api screwdriver.API, buildID int, rootDir, emitterPath, 
 	}
 
 	log.Printf("Get Workspace in %v", rootDir)
-	w, err := getWorkspace(isLocal, rootDir, scm.Host, scm.Org, scm.Repo)
+	w, err := getWorkspace(isLocal, rootDir, "src", "artifacts", scm.Host, scm.Org, scm.Repo)
 	if err != nil {
 		return err
 	}

--- a/launch_test.go
+++ b/launch_test.go
@@ -1513,3 +1513,44 @@ func TestSignalsAreDelivered(t *testing.T) {
 	main()
 	t.Logf("sigterm...")
 }
+
+func TestGetWorkspace(t *testing.T) {
+	oldMkdirAll := mkdirAll
+	defer func() { mkdirAll = oldMkdirAll }()
+	mkdirAll = os.MkdirAll
+	tmp, err := ioutil.TempDir("", "sd")
+	tmp1, err1 := ioutil.TempDir(tmp, "src")
+	tmp2, _ := ioutil.TempDir(tmp1, "launcher")
+	tmp3, _ := ioutil.TempDir(tmp, "artifacts")
+
+	fmt.Println(tmp1)
+	fmt.Println(tmp2)
+	fmt.Println(tmp3)
+
+	if err != nil || err1 != nil {
+		t.Fatalf("Couldn't create temp dir: %v %v", err, err1)
+	}
+
+	expectedWorkspace := Workspace{
+		Root:      tmp,
+		Src:       tmp2,
+		Artifacts: tmp3,
+	}
+	srcDr := tmp1[strings.LastIndex(tmp1, "/")+1:]
+	artDir := tmp3[strings.LastIndex(tmp3, "/")+1:]
+	launcherDir := tmp2[strings.LastIndex(tmp2, "/")+1:]
+	actualWorkspace, err := getWorkspace(true, tmp, srcDr, artDir, launcherDir)
+
+	defer os.RemoveAll(tmp)
+	defer os.RemoveAll(tmp1)
+	defer os.RemoveAll(tmp2)
+	defer os.RemoveAll(tmp3)
+
+	if err != nil {
+		t.Errorf("Unexpected error getting workspace: %v", err)
+	}
+
+	if actualWorkspace != expectedWorkspace {
+		t.Errorf("workspace = %q, want %q", expectedWorkspace, actualWorkspace)
+	}
+}


### PR DESCRIPTION
## Context

Currently if a build is aborted the custom user teardown steps don't run and hence additional processing on teardown is not configurable.

## Objective

This PR adds change to run the users teardown steps along with the sd teaerdown in a build

## References

https://github.com/screwdriver-cd/screwdriver/issues/2301

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
