### PR TITLE
fix(2278): Reset local version of external meta

### DIFF
--- a/data/emitter
+++ b/data/emitter
@@ -1,9 +1,9 @@
-{"t":1607642589804,"m":"Screwdriver Launcher information","s":"sd-setup-launcher"}
-{"t":1607642589804,"m":"Version:        vdev","s":"sd-setup-launcher"}
-{"t":1607642589804,"m":"Pipeline:       #3","s":"sd-setup-launcher"}
-{"t":1607642589804,"m":"Job:            main","s":"sd-setup-launcher"}
-{"t":1607642589804,"m":"Build:          #1","s":"sd-setup-launcher"}
-{"t":1607642589804,"m":"Workspace Dir:  /var/folders/_p/8_qbdnfs26s_kztl7y2kgfv80000gp/T/ArtifactDir864759998","s":"sd-setup-launcher"}
-{"t":1607642589804,"m":"Checkout Dir:     /var/folders/_p/8_qbdnfs26s_kztl7y2kgfv80000gp/T/ArtifactDir864759998/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
-{"t":1607642589804,"m":"Source Dir:     /var/folders/_p/8_qbdnfs26s_kztl7y2kgfv80000gp/T/ArtifactDir864759998/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
-{"t":1607642589804,"m":"Artifacts Dir:  /var/folders/_p/8_qbdnfs26s_kztl7y2kgfv80000gp/T/ArtifactDir864759998/artifacts","s":"sd-setup-launcher"}
+{"t":1608079158474,"m":"Screwdriver Launcher information","s":"sd-setup-launcher"}
+{"t":1608079158474,"m":"Version:        vdev","s":"sd-setup-launcher"}
+{"t":1608079158475,"m":"Pipeline:       #3","s":"sd-setup-launcher"}
+{"t":1608079158475,"m":"Job:            main","s":"sd-setup-launcher"}
+{"t":1608079158475,"m":"Build:          #1","s":"sd-setup-launcher"}
+{"t":1608079158475,"m":"Workspace Dir:  /var/folders/_p/8_qbdnfs26s_kztl7y2kgfv80000gp/T/ArtifactDir615535592","s":"sd-setup-launcher"}
+{"t":1608079158475,"m":"Checkout Dir:     /var/folders/_p/8_qbdnfs26s_kztl7y2kgfv80000gp/T/ArtifactDir615535592/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
+{"t":1608079158475,"m":"Source Dir:     /var/folders/_p/8_qbdnfs26s_kztl7y2kgfv80000gp/T/ArtifactDir615535592/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
+{"t":1608079158475,"m":"Artifacts Dir:  /var/folders/_p/8_qbdnfs26s_kztl7y2kgfv80000gp/T/ArtifactDir615535592/artifacts","s":"sd-setup-launcher"}

--- a/launch.go
+++ b/launch.go
@@ -308,9 +308,17 @@ func SetExternalMeta(api screwdriver.API, pipelineID, parentBuildID int, mergedM
 			if join {
 				resultMeta = deepMergeJSON(parentBuild.Meta, resultMeta)
 			}
-			externalMetaKey := "sd." + strconv.Itoa(parentJob.PipelineID) + "." + parentJob.Name
-			// delete stored external meta key
-			delete(resultMeta, externalMetaKey)
+
+			// delete local version of external meta
+			pIDString := strconv.Itoa(parentJob.PipelineID)
+			pjn := parentJob.Name
+			if sdMeta, ok := resultMeta["sd"]; ok {
+				if externalPipelineMeta, ok := sdMeta.(map[string]interface{})[pIDString]; ok {
+					if _, ok := externalPipelineMeta.(map[string]interface{})[pjn]; ok {
+						delete(externalPipelineMeta.(map[string]interface{}), pjn)
+					}
+				}
+			}
 		} else {
 			resultMeta = deepMergeJSON(parentBuild.Meta, resultMeta)
 		}


### PR DESCRIPTION
## Context

We need to reset the local version of external meta so it can be fetched from the external file, since meta-cli will check local version first, then check external file: https://github.com/screwdriver-cd/meta-cli/blob/master/meta.go#L86

## Objective

This PR checks if a local version of the desired external meta exists, then sets it to `null`. 

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2278

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
