### PR TITLE
fix(1858): Empty the summary in meta at the start of the build

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -493,6 +493,9 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		}
 	}
 
+	// Initialize pr comments (Issue #1858)
+	delete(mergedMeta, "summary")
+
 	log.Println("Marshalling Merged Meta JSON")
 	metaByte, err = marshal(mergedMeta)
 

--- a/launch_test.go
+++ b/launch_test.go
@@ -1000,6 +1000,7 @@ func TestFetchPredefinedMeta(t *testing.T) {
 	var defaultMeta []byte
 	mockMeta := make(map[string]interface{})
 	mockMeta["foo"] = "bar"
+	mockMeta["summary"] = map[string]string{"comment": "it should be deleted"}
 
 	api := mockAPI(t, TestBuildID, TestJobID, 0, "RUNNING")
 	api.buildFromID = func(buildID int) (screwdriver.Build, error) {


### PR DESCRIPTION
## Context
When using chain PR, the same PR comments are sent multiple times.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Reset summary to empty at the start of the build.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/1858
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
