### PR TITLE
fix(1858): the path of meta.summary is wrong

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -494,7 +494,9 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 	}
 
 	// Initialize pr comments (Issue #1858)
-	delete(mergedMeta, "summary")
+	if _, ok := mergedMeta["meta"]; ok {
+		delete(mergedMeta["meta"], "summary")
+	}
 
 	log.Println("Marshalling Merged Meta JSON")
 	metaByte, err = marshal(mergedMeta)

--- a/launch.go
+++ b/launch.go
@@ -494,8 +494,8 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 	}
 
 	// Initialize pr comments (Issue #1858)
-	if _, ok := mergedMeta["meta"]; ok {
-		delete(mergedMeta["meta"], "summary")
+	if metadata, ok := mergedMeta["meta"]; ok {
+		delete(metadata.(map[string]interface{}), "summary")
 	}
 
 	log.Println("Marshalling Merged Meta JSON")

--- a/launch_test.go
+++ b/launch_test.go
@@ -1001,7 +1001,7 @@ func TestFetchPredefinedMeta(t *testing.T) {
 	mockMeta := make(map[string]interface{})
 	mockMeta["foo"] = "bar"
 	mockMeta["meta"] = map[string]interface{}{
-		"baz": "qux",
+		"baz":     "qux",
 		"summary": map[string]string{"comment": "it should be deleted"},
 	}
 

--- a/launch_test.go
+++ b/launch_test.go
@@ -1000,7 +1000,10 @@ func TestFetchPredefinedMeta(t *testing.T) {
 	var defaultMeta []byte
 	mockMeta := make(map[string]interface{})
 	mockMeta["foo"] = "bar"
-	mockMeta["summary"] = map[string]string{"comment": "it should be deleted"}
+	mockMeta["meta"] = map[string]interface{}{
+		"baz": "qux",
+		"summary": map[string]string{"comment": "it should be deleted"},
+	}
 
 	api := mockAPI(t, TestBuildID, TestJobID, 0, "RUNNING")
 	api.buildFromID = func(buildID int) (screwdriver.Build, error) {
@@ -1020,7 +1023,7 @@ func TestFetchPredefinedMeta(t *testing.T) {
 	}
 
 	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
-	want := []byte("{\"build\":{\"buildId\":\"1234\",\"coverageKey\":\"job:fake\",\"eventId\":\"0\",\"jobId\":\"2345\",\"jobName\":\"main\",\"pipelineId\":\"3456\",\"sha\":\"\"},\"foo\":\"bar\"}")
+	want := []byte("{\"build\":{\"buildId\":\"1234\",\"coverageKey\":\"job:fake\",\"eventId\":\"0\",\"jobId\":\"2345\",\"jobName\":\"main\",\"pipelineId\":\"3456\",\"sha\":\"\"},\"foo\":\"bar\",\"meta\":{\"baz\":\"qux\"}}")
 
 	if err != nil || string(defaultMeta) != string(want) {
 		t.Errorf("Expected defaultMeta is %v, but: %v", string(want), string(defaultMeta))


### PR DESCRIPTION
## Context
I made a mistake in my previous PR https://github.com/screwdriver-cd/launcher/pull/384. The correct one is `meta.summary`.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/1858
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
