### PR TITLE
feat: Add tini for hyperd builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,28 @@ RUN set -x \
       | egrep -o '/screwdriver-cd/store-cli/releases/download/v[0-9.]*/store-cli_linux_amd64' \
       | wget --base=http://github.com/ -i - -O store-cli \
    && chmod +x store-cli \
+   # Download Tini Static
+   && wget -q -O - https://github.com/krallin/tini/releases/latest \
+      | egrep -o '/krallin/tini/releases/download/v[0-9.]*/tini-static' \
+      | head -1 \
+      | wget --base=http://github.com/ -i - -O tini-static \
+   && wget -q -O - https://github.com/krallin/tini/releases/latest \
+      | egrep -o '/krallin/tini/releases/download/v[0-9.]*/tini-static.asc' \
+      | wget --base=http://github.com/ -i - -O tini-static.asc \
+   && found=''; \
+      ( \
+      gpg --no-tty --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 || \
+      gpg --no-tty --keyserver pgp.mit.edu --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 || \
+      gpg --no-tty --keyserver keyserver.pgp.com --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 || \
+      gpg --no-tty --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 || \
+      gpg --no-tty --keyserver ha.pool.sks-keyservers.net --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
+      ) \
+   && found=yes && break; \
+     test -z "$found" && echo >&2 "error: failed to fetch GPG key 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7" && exit 1; \
+     gpg --verify tini-static.asc  \
+   && rm tini-static.asc \
+   && mv tini-static tini \
+   && chmod +x tini \
    # Download dumb-init
    && wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 \
    && chmod +x /usr/local/bin/dumb-init \


### PR DESCRIPTION
## Context

Tini was removed to use dumb-init as the init system, however hyperd builds in SD still use tini.

## Objective

This PR adds tini static download to the dockerfile.

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
