### PR TITLE
fix: add skopeo binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,8 +87,8 @@ RUN set -x \
    && mv sonar-scanner-*-linux sonarscanner-cli-linux \
    && mv sonar-scanner-*-macosx sonarscanner-cli-macosx \
    # Install skope
-   && wget -q -O skopeo-linux.zip 'https://bintray.com/screwdrivercd/screwdrivercd/download_file?file_path=skopeo-1.0.0-linux.zip' \
-   && unzip -q skopeo-linux.zip \
+   && wget -q -O skopeo-linux.tar.gz 'https://bintray.com/screwdrivercd/screwdrivercd/download_file?file_path=skopeo-1.0.0-linux.tar.gz' \
+   && tar -C . -ozxvf skopeo-linux.tar.gz \
    && chmod +x skopeo && cp skopeo /opt/sd/skopeo \
    # Cleanup Habitat Files
    && rm -rf /hab/cache /opt/sd/hab.tar.gz /opt/sd/hab-* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,7 @@ RUN set -x \
    # Install skope
    && wget -q -O skopeo-linux.tar.gz 'https://bintray.com/screwdrivercd/screwdrivercd/download_file?file_path=skopeo-1.0.0-linux.tar.gz' \
    && tar -C . -ozxvf skopeo-linux.tar.gz \
-   && chmod +x skopeo && cp skopeo /opt/sd/skopeo \
+   && chmod +x skopeo \
    # Cleanup Habitat Files
    && rm -rf /hab/cache /opt/sd/hab.tar.gz /opt/sd/hab-* \
    # Cleanup docs and man pages (how could this go wrong)

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,8 +96,8 @@ RUN set -x \
    && find /hab -name doc -exec rm -r {} + \
    && find /hab -name docs -exec rm -r {} + \
    && find /hab -name man -exec rm -r {} + \
-   # Cleanup Sonar scanner cli files
-   && rm -rf /opt/sd/skopeo-linux.zip /opt/sd/sonarscanner-cli-linux.zip /opt/sd/sonarscanner-cli-macosx.zip /opt/sd/sonar-scanner-*-linux /opt/sd/sonar-scanner-*-macosx \
+   # Cleanup Skopeo and Sonar scanner cli files
+   && rm -rf /opt/sd/skopeo-linux.tar.gz /opt/sd/sonarscanner-cli-linux.zip /opt/sd/sonarscanner-cli-macosx.zip /opt/sd/sonar-scanner-*-linux /opt/sd/sonar-scanner-*-macosx \
    # Cleanup packages
    && apk del --purge .build-dependencies \
    # bin link bash if not present

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,10 @@ RUN set -x \
    && unzip -q sonarscanner-cli-macosx.zip \
    && mv sonar-scanner-*-linux sonarscanner-cli-linux \
    && mv sonar-scanner-*-macosx sonarscanner-cli-macosx \
+   # Install skope
+   && wget -q -O skopeo-linux.zip 'https://bintray.com/screwdrivercd/screwdrivercd/download_file?file_path=skopeo-1.0.0-linux.zip' \
+   && unzip -q skopeo-linux.zip \
+   && chmod +x skopeo && cp skopeo /opt/sd/skopeo \
    # Cleanup Habitat Files
    && rm -rf /hab/cache /opt/sd/hab.tar.gz /opt/sd/hab-* \
    # Cleanup docs and man pages (how could this go wrong)
@@ -93,7 +97,7 @@ RUN set -x \
    && find /hab -name docs -exec rm -r {} + \
    && find /hab -name man -exec rm -r {} + \
    # Cleanup Sonar scanner cli files
-   && rm -rf /opt/sd/sonarscanner-cli-linux.zip /opt/sd/sonarscanner-cli-macosx.zip /opt/sd/sonar-scanner-*-linux /opt/sd/sonar-scanner-*-macosx \
+   && rm -rf /opt/sd/skopeo-linux.zip /opt/sd/sonarscanner-cli-linux.zip /opt/sd/sonarscanner-cli-macosx.zip /opt/sd/sonar-scanner-*-linux /opt/sd/sonar-scanner-*-macosx \
    # Cleanup packages
    && apk del --purge .build-dependencies \
    # bin link bash if not present


### PR DESCRIPTION
## Context

Display the docker image sha in the init or compatibility bookend to examine it for diffs or backtrack purpose.

## Objective

Add Skopeo, Skopeo is a command-line utility that performs various operations on container images and image repositories.

Comparing image digests docker n skopeo

`docker images --digests`
| Image | sha256 |
| :--- | :--- |
|alpine:latest|sha256:d9a7354e3845ea8466bb00b22224d9116b183e594527fb5b6c3d30bc01a20378   
|ruby:2.5.5|sha256:219b0f233f8214793ccc8cdc787224dc6cfb728e98af9ea2c991f23bf1aee1ab   

`./skopeo inspect docker://docker.io/alpine:latest
./skopeo inspect docker://docker.io/ruby:2.5.5`
| Image | Digest |
| :--- | :--- |
|alpine:latest|sha256:d9a7354e3845ea8466bb00b22224d9116b183e594527fb5b6c3d30bc01a20378   
|ruby:2.5.5|sha256:219b0f233f8214793ccc8cdc787224dc6cfb728e98af9ea2c991f23bf1aee1ab   

## References


## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
