### PR TITLE
fix: binlink hab jq

### DIFF
--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -66,6 +66,11 @@ if ! binary_exists bash; then
     smart_run /opt/sd/bin/hab pkg binlink core/bash bash || echo 'Failed to symlink bash'
 fi
 
+# Binlinking jq from core/jq into /bin
+if ! binary_exists jq; then
+    smart_run /opt/sd/bin/hab pkg binlink core/jq-static || echo 'Failed to symlink jq'
+fi
+
 echo 'Creating workspace and log pipe'
 date
 # Create FIFO for emitter

--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -68,7 +68,7 @@ fi
 
 # Binlinking jq from core/jq into /bin
 if ! binary_exists jq; then
-    smart_run /opt/sd/bin/hab pkg binlink core/jq-static || echo 'Failed to symlink jq'
+    smart_run /opt/sd/bin/hab pkg binlink core/jq-static jq || echo 'Failed to symlink jq'
 fi
 
 echo 'Creating workspace and log pipe'


### PR DESCRIPTION
## Context

jq: command not found in sd setup steps since jq is not binlink'd.

## Objective

binlink hab jq

## References

https://github.com/screwdriver-cd/launcher/pull/390

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
