### PR TITLE
fix: force env file overwrite

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -268,7 +268,7 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 	// Command to Export Env. Use tmpfile just in case export -p takes some time
 	exportEnvCmd :=
 		"tmpfile=" + tmpFile + "; exportfile=" + exportFile + "; " +
-			"export -p | grep -vi \"PS1=\" > $tmpfile && mv $tmpfile $exportfile; "
+			"export -p | grep -vi \"PS1=\" > $tmpfile && mv -f $tmpfile $exportfile; "
 
 	// Run setup commands
 	setupCommands := []string{


### PR DESCRIPTION
## Context

when vespaengine/vespa-build-centos7 image is used; the export command is not overwriting and waiting for input.

## Objective

Force overwrite environment commands file

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
