### PR TITLE
fix(2364): fix to read `build.QueueEntertime`

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -369,7 +369,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 	}
 
 	buildCreateTime, _ = time.Parse(time.RFC3339, build.Createtime)
-	queueEnterTime, _ = time.Parse(time.RFC3339, build.QueueEntertime)
+	queueEnterTime, _ = time.Parse(time.RFC3339, build.Stats.QueueEntertime)
 
 	log.Printf("Fetching Job %d", build.JobID)
 	job, err := api.JobFromID(build.JobID)

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -169,10 +169,6 @@ type CommandDef struct {
 // Need a generic interface to take in an int or array of ints
 type IntOrArray interface{}
 
-type Stats struct {
-	QueueEntertime string `json:"queueEnterTime"`
-}
-
 // Build is a Screwdriver Build
 type Build struct {
 	ID            int                    `json:"id"`
@@ -184,7 +180,9 @@ type Build struct {
 	Meta          map[string]interface{} `json:"meta"`
 	EventID       int                    `json:"eventId"`
 	Createtime    string                 `json:"createTime"`
-	Stats         Stats                  `json:"stats"`
+	Stats         struct {
+		QueueEntertime string `json:"queueEnterTime"`
+	} `json:"stats"`
 }
 
 // Coverage is a Coverage object returned when getInfo is called

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -169,18 +169,22 @@ type CommandDef struct {
 // Need a generic interface to take in an int or array of ints
 type IntOrArray interface{}
 
+type Stats struct {
+	QueueEntertime string `json:"queueEnterTime"`
+}
+
 // Build is a Screwdriver Build
 type Build struct {
-	ID             int                    `json:"id"`
-	JobID          int                    `json:"jobId"`
-	SHA            string                 `json:"sha"`
-	Commands       []CommandDef           `json:"steps"`
-	Environment    []map[string]string    `json:"environment"`
-	ParentBuildID  IntOrArray             `json:"parentBuildId"`
-	Meta           map[string]interface{} `json:"meta"`
-	EventID        int                    `json:"eventId"`
-	Createtime     string                 `json:"createTime"`
-	QueueEntertime string                 `json:"stats.queueEnterTime"`
+	ID            int                    `json:"id"`
+	JobID         int                    `json:"jobId"`
+	SHA           string                 `json:"sha"`
+	Commands      []CommandDef           `json:"steps"`
+	Environment   []map[string]string    `json:"environment"`
+	ParentBuildID IntOrArray             `json:"parentBuildId"`
+	Meta          map[string]interface{} `json:"meta"`
+	EventID       int                    `json:"eventId"`
+	Createtime    string                 `json:"createTime"`
+	Stats         Stats                  `json:"stats"`
 }
 
 // Coverage is a Coverage object returned when getInfo is called

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -140,7 +140,9 @@ func TestBuildFromID(t *testing.T) {
 				Commands:    testCmds,
 				Environment: testEnv,
 				Createtime:  "2020-04-28T20:34:01.907Z",
-				Stats: Stats{
+				Stats: struct {
+					QueueEntertime string `json:"queueEnterTime"`
+				}{
 					QueueEntertime: "2020-05-01T20:15:31.508Z",
 				},
 			},

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -133,14 +133,16 @@ func TestBuildFromID(t *testing.T) {
 	}{
 		{
 			build: Build{
-				ID:             1555,
-				JobID:          3777,
-				EventID:        8765,
-				SHA:            "testSHA",
-				Commands:       testCmds,
-				Environment:    testEnv,
-				Createtime:     "2020-04-28T20:34:01.907Z",
-				QueueEntertime: "2020-05-01T20:15:31.508Z",
+				ID:          1555,
+				JobID:       3777,
+				EventID:     8765,
+				SHA:         "testSHA",
+				Commands:    testCmds,
+				Environment: testEnv,
+				Createtime:  "2020-04-28T20:34:01.907Z",
+				Stats: Stats{
+					QueueEntertime: "2020-05-01T20:15:31.508Z",
+				},
 			},
 			statusCode: 200,
 			err:        nil,


### PR DESCRIPTION
## Context
`json.Unmarshal` does not support nested key in struct tag. This PR makes `Build` struct possible to have `QueueEntertime`.

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- Add `Stats` struct
- Add `Stats` key to `Build` struct
- Remove duplicated `QueueEntertime` key in `Build`
- Fix references for `Build.QueueEntertime`
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
screwdriver-cd/screwdriver#2364
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
