### PR TITLE
fix: Always merge event meta first

### DIFF
--- a/data/emitter
+++ b/data/emitter
@@ -1,9 +1,9 @@
-{"t":1608079158474,"m":"Screwdriver Launcher information","s":"sd-setup-launcher"}
-{"t":1608079158474,"m":"Version:        vdev","s":"sd-setup-launcher"}
-{"t":1608079158475,"m":"Pipeline:       #3","s":"sd-setup-launcher"}
-{"t":1608079158475,"m":"Job:            main","s":"sd-setup-launcher"}
-{"t":1608079158475,"m":"Build:          #1","s":"sd-setup-launcher"}
-{"t":1608079158475,"m":"Workspace Dir:  /var/folders/_p/8_qbdnfs26s_kztl7y2kgfv80000gp/T/ArtifactDir615535592","s":"sd-setup-launcher"}
-{"t":1608079158475,"m":"Checkout Dir:     /var/folders/_p/8_qbdnfs26s_kztl7y2kgfv80000gp/T/ArtifactDir615535592/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
-{"t":1608079158475,"m":"Source Dir:     /var/folders/_p/8_qbdnfs26s_kztl7y2kgfv80000gp/T/ArtifactDir615535592/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
-{"t":1608079158475,"m":"Artifacts Dir:  /var/folders/_p/8_qbdnfs26s_kztl7y2kgfv80000gp/T/ArtifactDir615535592/artifacts","s":"sd-setup-launcher"}
+{"t":1616100075736,"m":"Screwdriver Launcher information","s":"sd-setup-launcher"}
+{"t":1616100075736,"m":"Version:        vdev","s":"sd-setup-launcher"}
+{"t":1616100075736,"m":"Pipeline:       #3","s":"sd-setup-launcher"}
+{"t":1616100075736,"m":"Job:            main","s":"sd-setup-launcher"}
+{"t":1616100075736,"m":"Build:          #1","s":"sd-setup-launcher"}
+{"t":1616100075736,"m":"Workspace Dir:  /var/folders/_p/8_qbdnfs26s_kztl7y2kgfv80000gp/T/ArtifactDir466593915","s":"sd-setup-launcher"}
+{"t":1616100075736,"m":"Checkout Dir:     /var/folders/_p/8_qbdnfs26s_kztl7y2kgfv80000gp/T/ArtifactDir466593915/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
+{"t":1616100075736,"m":"Source Dir:     /var/folders/_p/8_qbdnfs26s_kztl7y2kgfv80000gp/T/ArtifactDir466593915/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
+{"t":1616100075736,"m":"Artifacts Dir:  /var/folders/_p/8_qbdnfs26s_kztl7y2kgfv80000gp/T/ArtifactDir466593915/artifacts","s":"sd-setup-launcher"}

--- a/launch.go
+++ b/launch.go
@@ -438,6 +438,14 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		return err
 	}
 
+	// Always merge event meta
+	if len(event.Meta) > 0 { // If has meta, marshal it
+		log.Printf("Fetching Event Meta JSON %v", event.ID)
+		if event.Meta != nil {
+			mergedMeta = deepMergeJSON(event.Meta, mergedMeta)
+		}
+	}
+
 	if len(parentBuildIDs) > 1 { // If has multiple parent build IDs, merge their metadata (join case)
 		// Get meta from all parent builds
 		for _, pbID := range parentBuildIDs {
@@ -465,12 +473,8 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		if parentEvent.Meta != nil {
 			mergedMeta = deepMergeJSON(parentEvent.Meta, mergedMeta)
 		}
+
 		metaLog = fmt.Sprintf(`Event(%v)`, parentEvent.ID)
-	} else if len(event.Meta) > 0 { // If has meta, marshal it
-		log.Printf("Fetching Event Meta JSON %v", event.ID)
-		if event.Meta != nil {
-			mergedMeta = deepMergeJSON(event.Meta, mergedMeta)
-		}
 	}
 
 	// Initialize pr comments (Issue #1858)

--- a/launch_test.go
+++ b/launch_test.go
@@ -1062,18 +1062,29 @@ func TestFetchParentBuildMeta(t *testing.T) {
 	initCoverageMeta()
 	oldWriteFile := writeFile
 	defer func() { writeFile = oldWriteFile }()
-	var mockMeta map[string]interface{}
-	mockMeta = make(map[string]interface{})
+	mockParentMeta := make(map[string]interface{})
+	mockParentMeta["hoge"] = "fuga"
+	mockEventMeta := make(map[string]interface{})
+	mockEventMeta["spooky"] = "ghost"
+
 	var parentMeta []byte
 	var buildMeta []byte
 
-	mockMeta["hoge"] = "fuga"
 	api := mockAPI(t, TestBuildID, TestJobID, 0, "RUNNING")
 	api.buildFromID = func(buildID int) (screwdriver.Build, error) {
 		if buildID == TestParentBuildID {
-			return screwdriver.Build(FakeBuild{ID: TestParentBuildID, JobID: TestParentJobID, Meta: mockMeta}), nil
+			return screwdriver.Build(FakeBuild{ID: TestParentBuildID, EventID: TestEventID, JobID: TestParentJobID, Meta: mockParentMeta}), nil
 		}
-		return screwdriver.Build(FakeBuild{ID: buildID, JobID: TestJobID, ParentBuildID: TestParentBuildIDFloat}), nil
+		return screwdriver.Build(FakeBuild{ID: buildID, EventID: TestEventID, JobID: TestJobID, ParentBuildID: TestParentBuildIDFloat}), nil
+	}
+	api.eventFromID = func(eventID int) (screwdriver.Event, error) {
+		if eventID == TestEventID {
+			return screwdriver.Event(FakeEvent{ID: TestEventID, Meta: mockEventMeta}), nil
+		}
+		if eventID == TestParentEventID {
+			return screwdriver.Event(FakeEvent{ID: TestParentEventID}), nil
+		}
+		return screwdriver.Event(FakeEvent{ID: TestEventID, ParentEventID: TestParentEventID}), nil
 	}
 	api.jobFromID = func(jobID int) (screwdriver.Job, error) {
 		if jobID == TestParentJobID {
@@ -1083,7 +1094,7 @@ func TestFetchParentBuildMeta(t *testing.T) {
 	}
 	api.pipelineFromID = func(pipelineID int) (screwdriver.Pipeline, error) {
 		if pipelineID == TestParentPipelineID {
-			return screwdriver.Pipeline(FakePipeline{ID: pipelineID, ScmURI: TestScmURI, ScmRepo: TestScmRepo}), nil
+			return screwdriver.Pipeline(FakePipeline{ID: TestParentPipelineID, ScmURI: TestScmURI, ScmRepo: TestScmRepo}), nil
 		}
 		return screwdriver.Pipeline(FakePipeline{ID: pipelineID, ScmURI: TestScmURI, ScmRepo: TestScmRepo}), nil
 	}
@@ -1098,11 +1109,11 @@ func TestFetchParentBuildMeta(t *testing.T) {
 	}
 
 	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
-	want := []byte("{\"build\":{\"buildId\":\"1234\",\"coverageKey\":\"job:fake\",\"eventId\":\"0\",\"jobId\":\"2345\",\"jobName\":\"main\",\"pipelineId\":\"3456\",\"sha\":\"\"}}")
+	want := []byte("{\"build\":{\"buildId\":\"1234\",\"coverageKey\":\"job:fake\",\"eventId\":\"2234\",\"jobId\":\"2345\",\"jobName\":\"main\",\"pipelineId\":\"3456\",\"sha\":\"\"},\"spooky\":\"ghost\"}")
 	wantParent := []byte("{\"hoge\":\"fuga\"}")
 
 	if err != nil || string(parentMeta) != string(wantParent) {
-		t.Errorf("Expected parentMeta is %v, but: %v", string(want), string(parentMeta))
+		t.Errorf("Expected parentMeta is %v, but: %v", string(wantParent), string(parentMeta))
 	}
 
 	if err != nil || string(buildMeta) != string(want) {


### PR DESCRIPTION
## Context

Currently, event meta is only set if none of the other cases are true (join, one parent build, parent event). This can cause problems when the user wants to get keys from event meta as well.

## Objective

This PR always merged event meta first, then handles other cases.

## References

N/A

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
