### PR TITLE
fix(2422): Fix the order of meta merge.

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -310,7 +310,7 @@ func SetExternalMeta(api screwdriver.API, pipelineID, parentBuildID int, mergedM
 			externalMetaFile := "sd@" + strconv.Itoa(parentJob.PipelineID) + ":" + parentJob.Name + ".json"
 			writeMetafile(metaSpace, externalMetaFile, metaLog, parentBuild.Meta)
 			if join {
-				resultMeta = deepMergeJSON(parentBuild.Meta, resultMeta)
+				resultMeta = deepMergeJSON(resultMeta, parentBuild.Meta)
 			}
 
 			// delete local version of external meta
@@ -324,7 +324,7 @@ func SetExternalMeta(api screwdriver.API, pipelineID, parentBuildID int, mergedM
 				}
 			}
 		} else {
-			resultMeta = deepMergeJSON(parentBuild.Meta, resultMeta)
+			resultMeta = deepMergeJSON(resultMeta, parentBuild.Meta)
 		}
 	}
 
@@ -453,7 +453,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		"build": buildMeta,
 	}
 	if build.Meta != nil {
-		mergedMeta = deepMergeJSON(build.Meta, mergedMeta)
+		mergedMeta = deepMergeJSON(mergedMeta, build.Meta)
 	}
 
 	// Create meta space
@@ -466,7 +466,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 	if len(event.Meta) > 0 { // If has meta, marshal it
 		log.Printf("Fetching Event Meta JSON %v", event.ID)
 		if event.Meta != nil {
-			mergedMeta = deepMergeJSON(event.Meta, mergedMeta)
+			mergedMeta = deepMergeJSON(mergedMeta, event.Meta)
 		}
 	}
 
@@ -495,7 +495,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		}
 
 		if parentEvent.Meta != nil {
-			mergedMeta = deepMergeJSON(parentEvent.Meta, mergedMeta)
+			mergedMeta = deepMergeJSON(mergedMeta, parentEvent.Meta)
 		}
 
 		metaLog = fmt.Sprintf(`Event(%v)`, parentEvent.ID)

--- a/launch_test.go
+++ b/launch_test.go
@@ -1272,12 +1272,12 @@ func TestFetchParentBuildsMeta(t *testing.T) {
 	api := mockAPI(t, TestBuildID, TestJobID, 0, "RUNNING")
 	api.buildFromID = func(buildID int) (screwdriver.Build, error) {
 		if buildID == TestParentBuildID {
-			return screwdriver.Build(FakeBuild{ID: TestBuildID, JobID: TestParentJobID, Meta: TestMeta1}), nil
+			return screwdriver.Build(FakeBuild{ID: buildID, JobID: TestParentJobID, Meta: TestMeta1}), nil
 		}
 		if buildID == 2222 {
-			return screwdriver.Build(FakeBuild{ID: TestBuildID, JobID: 1114, Meta: TestMeta2}), nil
+			return screwdriver.Build(FakeBuild{ID: buildID, JobID: 1114, Meta: TestMeta2}), nil
 		}
-		return screwdriver.Build(FakeBuild{ID: TestBuildID, JobID: TestJobID, ParentBuildID: IDs}), nil
+		return screwdriver.Build(FakeBuild{ID: buildID, JobID: TestJobID, ParentBuildID: IDs}), nil
 	}
 	api.jobFromID = func(jobID int) (screwdriver.Job, error) {
 		if jobID == TestParentJobID {
@@ -1314,7 +1314,7 @@ func TestFetchParentBuildsMeta(t *testing.T) {
 
 	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
 
-	want := []byte("{\"batman\":\"robin\",\"build\":{\"buildId\":\"1234\",\"coverageKey\":\"job:fake\",\"eventId\":\"0\",\"jobId\":\"2345\",\"jobName\":\"main\",\"pipelineId\":\"3456\",\"sha\":\"\"},\"foo\":{\"bird\":\"chirp\",\"cat\":\"meow\",\"dog\":\"woof\"},\"wonder\":\"woman\"}")
+	want := []byte("{\"batman\":\"robin\",\"build\":{\"buildId\":\"1234\",\"coverageKey\":\"job:fake\",\"eventId\":\"0\",\"jobId\":\"2345\",\"jobName\":\"main\",\"pipelineId\":\"3456\",\"sha\":\"\"},\"foo\":{\"bird\":\"twitter\",\"cat\":\"meow\",\"dog\":\"woof\"},\"wonder\":\"woman\"}")
 	wantParent := []byte("{\"batman\":\"robin\",\"foo\":{\"bird\":\"chirp\",\"cat\":\"meow\"}}")
 	wantParent2 := []byte("{\"foo\":{\"bird\":\"twitter\",\"dog\":\"woof\"},\"wonder\":\"woman\"}")
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
If there is a metadata key conflict between eventmeta and parentbuildmeta, metadata should take parentbuildmeta.
However, current metadata takes eventmeta value. ( screwdriver-cd/screwdriver#2422 )
We fix the priority of meta value.


## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
[mergemap](https://github.com/peterbourgon/mergemap) merges the src map into the dst map.
If there is a key conflict, it takes the src value.
[mergemap takes first arg as dst.](https://github.com/peterbourgon/mergemap/blob/e21c03b7a721e413718d2703181ead350d3c9d6f/mergemap.go#L17)
We should reverse the order of deepMergeJSON arg.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

screwdriver-cd/screwdriver#2422

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
