### PR TITLE
feat: remove myesui/uuid.v1 and add google/uuid

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -17,8 +17,8 @@ import (
 	"time"
 
 	"github.com/creack/pty"
+	"github.com/google/uuid"
 	"github.com/screwdriver-cd/launcher/screwdriver"
-	"gopkg.in/myesui/uuid.v1"
 )
 
 const (
@@ -323,8 +323,8 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 			return fmt.Errorf("Writing to step script file: %v", err)
 		}
 
-		// Generate guid for the step
-		guid := uuid.NewV4().String()
+		// Generate guid v4 for the step
+		guid := uuid.Must(uuid.NewRandom()).String()
 
 		runErr := make(chan error, 1)
 		eCode := make(chan int, 1)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/creack/pty v1.1.11
+	github.com/google/uuid v1.2.0
 	github.com/hashicorp/go-retryablehttp v0.6.6
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/myesui/uuid v1.0.0 // indirect
@@ -12,6 +13,5 @@ require (
 	github.com/urfave/cli v1.22.2
 	golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634 // indirect
 	gopkg.in/fatih/color.v1 v1.7.0
-	gopkg.in/myesui/uuid.v1 v1.0.0
 	gopkg.in/stretchr/testify.v1 v1.2.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
@@ -36,8 +38,6 @@ golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634/go.mod h1:h1NjWce9XRLGQEsW7w
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fatih/color.v1 v1.7.0 h1:bYGjb+HezBM6j/QmgBfgm1adxHpzzrss6bj4r9ROppk=
 gopkg.in/fatih/color.v1 v1.7.0/go.mod h1:P7yosIhqIl/sX8J8UypY5M+dDpD2KmyfP5IRs5v/fo0=
-gopkg.in/myesui/uuid.v1 v1.0.0 h1:9y1k4tTQvYr0GliMtqWdBxMEX3X86gow12Uj6GIyBiE=
-gopkg.in/myesui/uuid.v1 v1.0.0/go.mod h1:OHnLC+jZGuFVkJVF3gLeL7pqB+S6rx0NlvgLqclsWc4=
 gopkg.in/stretchr/testify.v1 v1.2.2 h1:yhQC6Uy5CqibAIlk1wlusa/MJ3iAN49/BsR/dCCKz3M=
 gopkg.in/stretchr/testify.v1 v1.2.2/go.mod h1:QI5V/q6UbPmuhtm10CaFZxED9NreB8PnFYN9JcR6TxU=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
## Context

Launcher uses a package whose repository has already disappeared 

## Objective

This PR removes the dependency of myesui/uuid.v1[https://github.com/myesui/uuid] and adds google/uuid[https://pkg.go.dev/github.com/google/uuid] which is compliant with RFC 4122 and DCE 1.1

sample to generate v4 uuids with both pkgs

```package main

import (
	"fmt"

	uuidnew "github.com/google/uuid"
	uuidold "gopkg.in/myesui/uuid.v1"
)

func main() {
	guid := uuidold.NewV4().String()
	guid1 := uuidnew.Must(uuidnew.NewRandom()).String()

	fmt.Printf("uuids %v %v", guid, guid1)
	fmt.Printf(" length %v %v", len(guid), len(guid1))
}
// output: uuids 8c046b9c-537b-4efc-add0-be88b9fffa01 da6fb1b0-a5e0-4fc4-9cb0-182e608d02c8 length 36 36
```

## References

https://github.com/screwdriver-cd/screwdriver/issues/2475

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
