### PR TITLE
feat: download skope and zstd from sd-packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,14 +87,16 @@ RUN set -x \
    && mv sonar-scanner-*-linux sonarscanner-cli-linux \
    && mv sonar-scanner-*-macosx sonarscanner-cli-macosx \
    # Install skope
-   && wget -q -O skopeo-linux.tar.gz 'https://bintray.com/screwdrivercd/screwdrivercd/download_file?file_path=skopeo-1.0.0-linux.tar.gz' \
+   && wget -q -O skopeo-linux.tar.gz 'https://github.com/screwdriver-cd/sd-packages/releases/download/v0.0.30/skopeo-linux.tar.gz' \
    && tar -C . -ozxvf skopeo-linux.tar.gz \
    && chmod +x skopeo \
    # Install zstd
-   && wget -q -O zstd-cli-linux.tar.gz 'https://bintray.com/screwdrivercd/screwdrivercd/download_file?file_path=zstd-cli-1.4.8-linux.tar.gz' \
-   && wget -q -O zstd-cli-macosx.tar.gz 'https://bintray.com/screwdrivercd/screwdrivercd/download_file?file_path=zstd-cli-1.4.8-macosx.tar.gz' \
+   && wget -q -O zstd-cli-linux.tar.gz 'https://github.com/screwdriver-cd/sd-packages/releases/download/v0.0.30/zstd-cli-linux.tar.gz' \
+   && wget -q -O zstd-cli-macosx.tar.gz 'https://github.com/screwdriver-cd/sd-packages/releases/download/v0.0.30/zstd-cli-macosx.tar.gz' \
    && tar -C . -ozxvf zstd-cli-linux.tar.gz \
+   && mv zstd zstd-cli-linux \
    && tar -C . -ozxvf zstd-cli-macosx.tar.gz \
+   && mv zstd zstd-cli-macosx \
    && chmod +x zstd-cli-linux \
    && chmod +x zstd-cli-macosx \
    # Cleanup Habitat Files

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -17,7 +17,7 @@ scaffolding_go_base_path="github.com/screwdriver-cd"
 scaffolding_go_build_deps=(
     github.com/creack/pty
     github.com/urfave/cli
-    gopkg.in/myesui/uuid.v1
+    github.com/google/uuid
     gopkg.in/fatih/color.v1
 )
 


### PR DESCRIPTION
## Context

Launcher docker builds are broken after bintray sunset as has dependencies

## Objective

This PR downloads dependencies from sd-packages[https://github.com/screwdriver-cd/sd-packages/releases] library

## References

https://github.com/screwdriver-cd/screwdriver/issues/2475
https://github.com/screwdriver-cd/screwdriver/issues/2450

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
