### PR TITLE
feat: output tool versions on build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,15 @@ RUN set -x \
    # Download Launcher
    && wget -q -O - https://github.com/screwdriver-cd/launcher/releases/latest \
       | egrep -o '/screwdriver-cd/launcher/releases/download/v[0-9.]*/launcher_linux_amd64' \
+      | sed -e "s/\/screwdriver-cd\/\([a-zA-Z-]*\)\/releases\/download\/\(v[0-9.]*\)\/launcher_linux_amd64/\1 \2/" >> tool-versions \
+   && wget -q -O - https://github.com/screwdriver-cd/launcher/releases/latest \
+      | egrep -o '/screwdriver-cd/launcher/releases/download/v[0-9.]*/launcher_linux_amd64' \
       | wget --base=http://github.com/ -i - -O launch \
    && chmod +x launch \
    # Download Log Service
+   && wget -q -O - https://github.com/screwdriver-cd/log-service/releases/latest \
+      | egrep -o '/screwdriver-cd/log-service/releases/download/v[0-9.]*/log-service_linux_amd64' \
+      | sed -e "s/\/screwdriver-cd\/\([a-zA-Z-]*\)\/releases\/download\/\(v[0-9.]*\)\/log-service_linux_amd64/\1 \2/" >> tool-versions \
    && wget -q -O - https://github.com/screwdriver-cd/log-service/releases/latest \
       | egrep -o '/screwdriver-cd/log-service/releases/download/v[0-9.]*/log-service_linux_amd64' \
       | wget --base=http://github.com/ -i - -O logservice \
@@ -22,9 +28,15 @@ RUN set -x \
    # Download Meta CLI
    && wget -q -O - https://github.com/screwdriver-cd/meta-cli/releases/latest \
       | egrep -o '/screwdriver-cd/meta-cli/releases/download/v[0-9.]*/meta-cli_linux_amd64' \
+      | sed -e "s/\/screwdriver-cd\/\([a-zA-Z-]*\)\/releases\/download\/\(v[0-9.]*\)\/meta-cli_linux_amd64/\1 \2/" >> tool-versions \
+   && wget -q -O - https://github.com/screwdriver-cd/meta-cli/releases/latest \
+      | egrep -o '/screwdriver-cd/meta-cli/releases/download/v[0-9.]*/meta-cli_linux_amd64' \
       | wget --base=http://github.com/ -i - -O meta \
    && chmod +x meta \
    # Download sd-step
+   && wget -q -O - https://github.com/screwdriver-cd/sd-step/releases/latest \
+      | egrep -o '/screwdriver-cd/sd-step/releases/download/v[0-9.]*/sd-step_linux_amd64' \
+      | sed -e "s/\/screwdriver-cd\/\([a-zA-Z-]*\)\/releases\/download\/\(v[0-9.]*\)\/sd-step_linux_amd64/\1 \2/" >> tool-versions \
    && wget -q -O - https://github.com/screwdriver-cd/sd-step/releases/latest \
       | egrep -o '/screwdriver-cd/sd-step/releases/download/v[0-9.]*/sd-step_linux_amd64' \
       | wget --base=http://github.com/ -i - -O sd-step \
@@ -32,9 +44,15 @@ RUN set -x \
    # Download sd-cmd
    && wget -q -O - https://github.com/screwdriver-cd/sd-cmd/releases/latest \
       | egrep -o '/screwdriver-cd/sd-cmd/releases/download/v[0-9.]*/sd-cmd_linux_amd64' \
+      | sed -e "s/\/screwdriver-cd\/\([a-zA-Z-]*\)\/releases\/download\/\(v[0-9.]*\)\/sd-cmd_linux_amd64/\1 \2/" >> tool-versions \
+   && wget -q -O - https://github.com/screwdriver-cd/sd-cmd/releases/latest \
+      | egrep -o '/screwdriver-cd/sd-cmd/releases/download/v[0-9.]*/sd-cmd_linux_amd64' \
       | wget --base=http://github.com/ -i - -O sd-cmd \
    && chmod +x sd-cmd \
    # Download store-cli
+   && wget -q -O - https://github.com/screwdriver-cd/store-cli/releases/latest \
+      | egrep -o '/screwdriver-cd/store-cli/releases/download/v[0-9.]*/store-cli_linux_amd64' \
+      | sed -e "s/\/screwdriver-cd\/\([a-zA-Z-]*\)\/releases\/download\/\(v[0-9.]*\)\/store-cli_linux_amd64/\1 \2/" >> tool-versions \
    && wget -q -O - https://github.com/screwdriver-cd/store-cli/releases/latest \
       | egrep -o '/screwdriver-cd/store-cli/releases/download/v[0-9.]*/store-cli_linux_amd64' \
       | wget --base=http://github.com/ -i - -O store-cli \


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
We check for differences in dependent packages when updating components. As for launcher, there is no way to confirm which version of the tool is installed in an image, and it is difficult to clarify the range to be checked.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR allows you to view the installed tool version in a simple format.

```
/opt/sd # cat tool-versions
launcher v6.0.133
log-service v0.0.44
meta-cli v0.0.46
sd-step v0.0.19
sd-cmd v0.0.45
store-cli v0.0.64
```

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
