### PR TITLE
fix: Unstable docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,8 +67,9 @@ RUN set -x \
       | wget --base=http://github.com/ -i - -O tini-static.asc \
    && found=''; \
       ( \
-      gpg --no-tty --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 || \
+      gpg --no-tty --keyserver keyserver.ubuntu.com --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 || \
       gpg --no-tty --keyserver pgp.mit.edu --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 || \
+      gpg --no-tty --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 || \
       gpg --no-tty --keyserver keyserver.pgp.com --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 || \
       gpg --no-tty --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 || \
       gpg --no-tty --keyserver ha.pool.sks-keyservers.net --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
@@ -86,7 +87,7 @@ RUN set -x \
    # Install Habitat
    && mkdir -p /hab/bin /opt/sd/bin \
    # Download Habitat Binary
-   && wget -O hab.tar.gz 'https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-0.79.1-20190410220617-x86_64-linux.tar.gz?bt_package=hab-x86_64-linux' \
+   && wget -O hab.tar.gz 'https://packages.chef.io/files/stable/habitat/0.79.1/hab-x86_64-linux.tar.gz' \
    && tar -C . -ozxvf hab.tar.gz \
    && mv hab-*/hab /hab/bin/hab \
    && chmod +x /hab/bin/hab \

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -44,6 +44,7 @@ RUN set -x \
       | wget --base=http://github.com/ -i - -O tini-static.asc \
    && found=''; \
       ( \
+      gpg --no-tty --keyserver keyserver.ubuntu.com --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 || \
       gpg --no-tty --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 || \
       gpg --no-tty --keyserver pgp.mit.edu --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 || \
       gpg --no-tty --keyserver keyserver.pgp.com --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 || \
@@ -63,7 +64,7 @@ RUN set -x \
    # Install Habitat
    && mkdir -p /hab/bin /opt/sd/bin \
    # Download Habitat Binary
-   && wget -O hab.tar.gz 'https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-0.79.1-20190410220617-x86_64-linux.tar.gz?bt_package=hab-x86_64-linux' \
+   && wget -O hab.tar.gz 'https://packages.chef.io/files/stable/habitat/0.79.1/hab-x86_64-linux.tar.gz' \
    && tar -C . -ozxvf hab.tar.gz \
    && mv hab-*/hab /hab/bin/hab \
    && chmod +x /hab/bin/hab \
@@ -82,14 +83,16 @@ RUN set -x \
    && mv sonar-scanner-*-linux sonarscanner-cli-linux \
    && mv sonar-scanner-*-macosx sonarscanner-cli-macosx \
    # Install skope
-   && wget -q -O skopeo-linux.tar.gz 'https://bintray.com/screwdrivercd/screwdrivercd/download_file?file_path=skopeo-1.0.0-linux.tar.gz' \
+   && wget -q -O skopeo-linux.tar.gz 'https://github.com/screwdriver-cd/sd-packages/releases/download/v0.0.30/skopeo-linux.tar.gz' \
    && tar -C . -ozxvf skopeo-linux.tar.gz \
    && chmod +x skopeo \
    # Install zstd
-   && wget -q -O zstd-cli-linux.tar.gz 'https://bintray.com/screwdrivercd/screwdrivercd/download_file?file_path=zstd-cli-1.4.8-linux.tar.gz' \
-   && wget -q -O zstd-cli-macosx.tar.gz 'https://bintray.com/screwdrivercd/screwdrivercd/download_file?file_path=zstd-cli-1.4.8-macosx.tar.gz' \
+   && wget -q -O zstd-cli-linux.tar.gz 'https://github.com/screwdriver-cd/sd-packages/releases/download/v0.0.30/zstd-cli-linux.tar.gz' \
+   && wget -q -O zstd-cli-macosx.tar.gz 'https://github.com/screwdriver-cd/sd-packages/releases/download/v0.0.30/zstd-cli-macosx.tar.gz' \
    && tar -C . -ozxvf zstd-cli-linux.tar.gz \
+   && mv zstd zstd-cli-linux \
    && tar -C . -ozxvf zstd-cli-macosx.tar.gz \
+   && mv zstd zstd-cli-macosx \
    && chmod +x zstd-cli-linux \
    && chmod +x zstd-cli-macosx \
    # Cleanup Habitat Files


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Fix launcher's unstable build.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
The launcher uses gpg keyserver to verify tini, but with a high probability it fails and the build is unstable.
Therefore, add the keyserver by referring to the comments below.
https://github.com/krallin/tini/issues/124#issuecomment-420578042

Also, launcher uses bintray to get the hab command, but it seems that it is not available now.
```
$ wget -O hab.tar.gz 'https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-0.79.1-20190410220617-x86_64-linux.tar.gz?bt_package=hab-x86_64-linux'
--2021-07-12 01:55:08--  https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-0.79.1-20190410220617-x86_64-linux.tar.gz?bt_package=hab-x86_64-linux
Resolving api.bintray.com (api.bintray.com)... 75.126.118.184
Connecting to api.bintray.com (api.bintray.com)|75.126.118.184|:443... connected.
HTTP request sent, awaiting response... 403 Forbidden
2021-07-12 01:55:09 ERROR 403: Forbidden.
```

To solve this problem, fix it so that it will be downloaded from an available location.


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
