### PR TITLE
[2] fix(2501): set build parameter explicitly

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -506,6 +506,11 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		delete(metadata.(map[string]interface{}), "summary")
 	}
 
+	// Set build parameter explicitly (Issue #2501)
+	if mergedMeta["parameters"] != nil {
+		mergedMeta["parameters"] = build.Meta["parameters"]
+	}
+
 	log.Println("Marshalling Merged Meta JSON")
 	metaByte, err = marshal(mergedMeta)
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
fix https://github.com/screwdriver-cd/screwdriver/issues/2501

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

The parameters of the parent event overwrote the parameters of the current build during event restart. By explicitly setting the build parameters, the parameters set by the user will be used preferentially.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
Please merge after docker build become stable
https://github.com/screwdriver-cd/launcher/pull/420

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
