### PR TITLE
fix(2501): Fetch parent meta.build if the key is not reserved

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -511,7 +511,11 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		buildMeta["coverageKey"] = coverageInfo.EnvVars["SD_SONAR_PROJECT_KEY"]
 	}
 
-	mergedMeta["build"] = buildMeta
+	if mergedMeta["build"] != nil {
+		mergedMeta["build"] = deepMergeJSON(mergedMeta["build"].(map[string]interface{}), buildMeta)
+	} else {
+		mergedMeta["build"] = buildMeta
+	}
 
 	log.Println("Marshalling Merged Meta JSON")
 	metaByte, err = marshal(mergedMeta)

--- a/launch_test.go
+++ b/launch_test.go
@@ -1442,6 +1442,10 @@ func TestFetchEventMeta(t *testing.T) {
 
 	mockMeta := make(map[string]interface{})
 	mockMeta["spooky"] = "ghost"
+	mockMeta["build"] = map[string]interface{}{
+		"buildId": "1111",
+		"foo":     "bar",
+	}
 	var eventMeta []byte
 
 	api := mockAPI(t, TestBuildID, TestJobID, 0, "RUNNING")
@@ -1462,7 +1466,7 @@ func TestFetchEventMeta(t *testing.T) {
 	}
 
 	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
-	want := []byte("{\"build\":{\"buildId\":\"1234\",\"coverageKey\":\"job:fake\",\"eventId\":\"2234\",\"jobId\":\"2345\",\"jobName\":\"main\",\"pipelineId\":\"0\",\"sha\":\"abc123\"},\"spooky\":\"ghost\"}")
+	want := []byte("{\"build\":{\"buildId\":\"1234\",\"coverageKey\":\"job:fake\",\"eventId\":\"2234\",\"foo\":\"bar\",\"jobId\":\"2345\",\"jobName\":\"main\",\"pipelineId\":\"0\",\"sha\":\"abc123\"},\"spooky\":\"ghost\"}")
 
 	if err != nil || string(eventMeta) != string(want) {
 		t.Errorf("Expected eventMeta is %v, but: %v", string(want), string(eventMeta))


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
meta data set on `build` key is now lost because it's overwriting build key.
https://github.com/screwdriver-cd/launcher/pull/421#discussion_r669215113
We should set properly `build` key meta.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
I fixed to deepMerge parent `build` meta and default `build` meta.
If there are the same keys, it should use default `build` meta.
Otherwise, it should set parent `build` meta.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2501

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
