### PR TITLE
fix: (2529) Make /bin/jq writable

### DIFF
--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -61,14 +61,17 @@ find /opt/sd/hab/pkgs/core -mindepth 2 -maxdepth 2 -exec sh -c 'mkdir -p `echo $
 # this cmd will symlink the specific version: ln -s  /opt/sd/hab/pkgs/core/curl/7.54.1/20181008145326 /hab/pkgs/core/curl/7.54.1
 find /opt/sd/hab/pkgs/core -mindepth 3 -maxdepth 3 -exec sh -c 'ln -s $1 `dirname $1 | sed "s/\/opt\/sd//"`' -- {} \; || echo 'Failed to symlink hab cache'
 
+# Create directory for hab pkg binlink destination
+smart_run mkdir -p /usr/sd/bin
+
 # Binlinking bash from core/bash into /bin
 if ! binary_exists bash; then
-    smart_run /opt/sd/bin/hab pkg binlink -d /opt/sd core/bash bash || echo 'Failed to symlink bash'
+    smart_run /opt/sd/bin/hab pkg binlink -d /usr/sd/bin core/bash bash || echo 'Failed to symlink bash'
 fi
 
 # Binlinking jq from core/jq into /bin
 if ! binary_exists jq; then
-    smart_run /opt/sd/bin/hab pkg binlink -d /opt/sd core/jq-static jq || echo 'Failed to symlink jq'
+    smart_run /opt/sd/bin/hab pkg binlink -d /usr/sd/bin core/jq-static jq || echo 'Failed to symlink jq'
 fi
 
 echo 'Creating workspace and log pipe'

--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -61,17 +61,14 @@ find /opt/sd/hab/pkgs/core -mindepth 2 -maxdepth 2 -exec sh -c 'mkdir -p `echo $
 # this cmd will symlink the specific version: ln -s  /opt/sd/hab/pkgs/core/curl/7.54.1/20181008145326 /hab/pkgs/core/curl/7.54.1
 find /opt/sd/hab/pkgs/core -mindepth 3 -maxdepth 3 -exec sh -c 'ln -s $1 `dirname $1 | sed "s/\/opt\/sd//"`' -- {} \; || echo 'Failed to symlink hab cache'
 
-# Create directory for hab pkg binlink destination
-smart_run mkdir -p /usr/sd/bin
-
 # Binlinking bash from core/bash into /bin
 if ! binary_exists bash; then
-    smart_run /opt/sd/bin/hab pkg binlink -d /usr/sd/bin core/bash bash || echo 'Failed to symlink bash'
+    smart_run /opt/sd/bin/hab pkg binlink -d /opt/sd core/bash bash || echo 'Failed to symlink bash'
 fi
 
 # Binlinking jq from core/jq into /bin
 if ! binary_exists jq; then
-    smart_run /opt/sd/bin/hab pkg binlink -d /usr/sd/bin core/jq-static jq || echo 'Failed to symlink jq'
+    smart_run /opt/sd/bin/hab pkg binlink -d /opt/sd core/jq-static jq || echo 'Failed to symlink jq'
 fi
 
 echo 'Creating workspace and log pipe'

--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -63,7 +63,6 @@ find /opt/sd/hab/pkgs/core -mindepth 3 -maxdepth 3 -exec sh -c 'ln -s $1 `dirnam
 
 # Create directory for hab pkg binlink destination
 smart_run mkdir -p /usr/sd/bin
-PATH=${PATH}:/usr/sd/bin
 
 # Binlinking bash from core/bash into /bin
 if ! binary_exists bash; then

--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -61,14 +61,18 @@ find /opt/sd/hab/pkgs/core -mindepth 2 -maxdepth 2 -exec sh -c 'mkdir -p `echo $
 # this cmd will symlink the specific version: ln -s  /opt/sd/hab/pkgs/core/curl/7.54.1/20181008145326 /hab/pkgs/core/curl/7.54.1
 find /opt/sd/hab/pkgs/core -mindepth 3 -maxdepth 3 -exec sh -c 'ln -s $1 `dirname $1 | sed "s/\/opt\/sd//"`' -- {} \; || echo 'Failed to symlink hab cache'
 
+# Create directory for hab pkg binlink destination
+smart_run mkdir -p /usr/sd/bin
+PATH=${PATH}:/usr/sd/bin
+
 # Binlinking bash from core/bash into /bin
 if ! binary_exists bash; then
-    smart_run /opt/sd/bin/hab pkg binlink core/bash bash || echo 'Failed to symlink bash'
+    smart_run /opt/sd/bin/hab pkg binlink -d /usr/sd/bin core/bash bash || echo 'Failed to symlink bash'
 fi
 
 # Binlinking jq from core/jq into /bin
 if ! binary_exists jq; then
-    smart_run /opt/sd/bin/hab pkg binlink core/jq-static jq || echo 'Failed to symlink jq'
+    smart_run /opt/sd/bin/hab pkg binlink -d /usr/sd/bin core/jq-static jq || echo 'Failed to symlink jq'
 fi
 
 echo 'Creating workspace and log pipe'

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -155,7 +155,7 @@ func doRunCommand(guid, path string, emitter screwdriver.Emitter, f *os.File, fR
 // Executes teardown commands
 func doRunTeardownCommand(cmd screwdriver.CommandDef, emitter screwdriver.Emitter, shellBin, exportFile, sourceDir string, stepExitCode int) (int, error) {
 	shargs := []string{"-e", "-c"}
-	cmdStr := "export PATH=$PATH:/opt/sd SD_STEP_EXIT_CODE=" + strconv.Itoa(stepExitCode) + " && " +
+	cmdStr := "export PATH=${PATH}:/opt/sd:/usr/sd/bin SD_STEP_EXIT_CODE=" + strconv.Itoa(stepExitCode) + " && " +
 		"START=$(date +'%s'); while ! [ -f " + exportFile + " ] && [ $(($(date +'%s')-$START)) -lt " + strconv.Itoa(WaitTimeout) + " ]; do sleep 1; done; " +
 		"if [ -f " + exportFile + " ]; then set +e; . " + exportFile + "; set -e; fi; " +
 		cmd.Cmd
@@ -274,7 +274,7 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 	// Run setup commands
 	setupCommands := []string{
 		"set -e",
-		"export PATH=$PATH:/opt/sd",
+		"export PATH=${PATH}:/opt/sd:/usr/sd/bin",
 		// trap ABRT(6) and EXIT, echo the last step ID and write ENV to /tmp/buildEnv
 		"finish() { " +
 			"EXITCODE=$?; " +

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -155,7 +155,7 @@ func doRunCommand(guid, path string, emitter screwdriver.Emitter, f *os.File, fR
 // Executes teardown commands
 func doRunTeardownCommand(cmd screwdriver.CommandDef, emitter screwdriver.Emitter, shellBin, exportFile, sourceDir string, stepExitCode int) (int, error) {
 	shargs := []string{"-e", "-c"}
-	cmdStr := "export PATH=${PATH}:/opt/sd:/usr/sd/bin SD_STEP_EXIT_CODE=" + strconv.Itoa(stepExitCode) + " && " +
+	cmdStr := "export PATH=$PATH:/opt/sd SD_STEP_EXIT_CODE=" + strconv.Itoa(stepExitCode) + " && " +
 		"START=$(date +'%s'); while ! [ -f " + exportFile + " ] && [ $(($(date +'%s')-$START)) -lt " + strconv.Itoa(WaitTimeout) + " ]; do sleep 1; done; " +
 		"if [ -f " + exportFile + " ]; then set +e; . " + exportFile + "; set -e; fi; " +
 		cmd.Cmd
@@ -274,7 +274,7 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 	// Run setup commands
 	setupCommands := []string{
 		"set -e",
-		"export PATH=${PATH}:/opt/sd:/usr/sd/bin",
+		"export PATH=$PATH:/opt/sd",
 		// trap ABRT(6) and EXIT, echo the last step ID and write ENV to /tmp/buildEnv
 		"finish() { " +
 			"EXITCODE=$?; " +


### PR DESCRIPTION
## Context
<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Currently, `/bin/jq` is readonly and users cannot overwrite it. We do not want the build system to occupy areas that is often used by users.

## Objective
<!-- What does this PR fix? What intentional changes will this PR make? -->
I created a `/usr/sd/bin` directory and put links of jq and bash in it. Then I added `/usr/sd/bin` to the `$PATH`.

## References
[#2529](https://github.com/screwdriver-cd/screwdriver/issues/2529)
[docs of hab-pkg-binlink](https://docs.chef.io/habitat/habitat_cli/#hab-pkg-binlink)
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
