### PR TITLE
Move /usr/sd/bin/bash to /bin/bash

### DIFF
--- a/Docker/launcher_entrypoint.sh
+++ b/Docker/launcher_entrypoint.sh
@@ -66,10 +66,10 @@ smart_run mkdir -p /usr/sd/bin
 
 # Binlinking bash from core/bash into /bin
 if ! binary_exists bash; then
-    smart_run /opt/sd/bin/hab pkg binlink -d /usr/sd/bin core/bash bash || echo 'Failed to symlink bash'
+    smart_run /opt/sd/bin/hab pkg binlink core/bash bash || echo 'Failed to symlink bash'
 fi
 
-# Binlinking jq from core/jq into /bin
+# Binlinking jq from core/jq into /usr/sd/bin
 if ! binary_exists jq; then
     smart_run /opt/sd/bin/hab pkg binlink -d /usr/sd/bin core/jq-static jq || echo 'Failed to symlink jq'
 fi


### PR DESCRIPTION
## Context
Last time, we moved `jq` and `bash` to `/usr/sd/bin/`.
https://github.com/screwdriver-cd/launcher/pull/426

However, [the launcher needs `/bin/bash`](https://github.com/screwdriver-cd/launcher/blob/588f5583aee19838480396b7bd039ff3f96e4ac1/Docker/run.sh#L1), and if the build use an image where `/bin/bash` does not exist (e.g. [alpine/opencv](https://hub.docker.com/r/alpine/opencv)), the build will not start.
There are more users using images that do not have `/bin/bash` than we might think.

There are many users who install `jq` in the user step, but the number of users who install `bash` should be close to zero. We can install bash in `/bin/bash` and it won't cause any problems.

## Objective
Move `/usr/sd/bin/bash` to `/bin/bash`.

## References
https://github.com/screwdriver-cd/screwdriver/issues/2529
https://github.com/screwdriver-cd/launcher/pull/426

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
