### PR TITLE
fix(2646): Do not include parameters from external builds during remote join

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -320,7 +320,7 @@ func SetExternalMeta(api screwdriver.API, pipelineID, parentBuildID int, mergedM
 				// Always exclude parameters from external meta
 				delete(externalParentBuildMeta, "parameters")
 
-				resultMeta = deepMergeJSON(resultMeta, parentBuild.Meta)
+				resultMeta = deepMergeJSON(resultMeta, externalParentBuildMeta)
 			}
 
 			// delete local version of external meta


### PR DESCRIPTION



## Context

Parameters from external builds are being included during remote join.

## Objective

Parameters must be available only to pipeline and its jobs. Parameters from external builds (jobs of another pipeline) should not be made available to the jobs during remote join.

## References

https://github.com/screwdriver-cd/screwdriver/issues/2646

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
