### PR TITLE
feat: add SD_STEP_NAME env variable

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -138,9 +138,11 @@ func doRunSetupCommand(emitter screwdriver.Emitter, f *os.File, r io.Reader, set
 	return nil
 }
 
-func doRunCommand(guid, path string, emitter screwdriver.Emitter, f *os.File, fReader io.Reader) (int, error) {
+func doRunCommand(guid, path string, emitter screwdriver.Emitter, f *os.File, fReader io.Reader, stepName string) (int, error) {
 	executionCommand := []string{
 		"export SD_STEP_ID=" + guid,
+		// escape not necessary because step name is limited to [A-Za-z0-9_-]
+		";export SD_STEP_NAME=" + stepName,
 		";. " + path,
 		";echo",
 		";echo " + guid + " $?\n",
@@ -336,7 +338,7 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 		fReader := bufio.NewReader(f)
 
 		go func() {
-			runCode, rcErr := doRunCommand(guid, stepFilePath, emitter, f, fReader)
+			runCode, rcErr := doRunCommand(guid, stepFilePath, emitter, f, fReader, cmd.Name)
 			// exit code & errors from doRunCommand
 			eCode <- runCode
 			runErr <- rcErr


### PR DESCRIPTION
## Context

As a user, I want to access the current step name from code executing within the step. 

## Objective

Add new environment variable SD_STEP_NAME set before each ordinary step is executed run. Only set for ordinary user steps, not setup or teardown commands (during teardown, SD_STEP_NAME would be set to the last successfully executed step). If desired I could change this behavior.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
