### PR TITLE
[WIP] fix(2715): Some process do not stop after build timed out

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -356,7 +356,7 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 				firstError = buildTimeout
 				code = 3
 			}
-			_ = c.Process.Signal(syscall.SIGABRT)
+			syscall.Kill(-c.Process.Pid, syscall.SIGKILL)
 			terminateSleep(shellBin, sourceDir, true) // kill all running sleep
 
 		case stepAbort := <-sig:
@@ -365,7 +365,7 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 				firstError = stepAbort
 				code = 1
 			}
-			_ = c.Process.Signal(syscall.SIGABRT)
+			syscall.Kill(-c.Process.Pid, syscall.SIGKILL)
 			terminateSleep(shellBin, sourceDir, false) // kill all running sleep other than sleep $SD_TERMINATION_GRACE_PERIOD_SECS
 		}
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -356,7 +356,7 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 				firstError = buildTimeout
 				code = 3
 			}
-			syscall.Kill(-c.Process.Pid, syscall.SIGKILL)
+			syscall.Kill(-c.Process.Pid, syscall.SIGTERM)
 			terminateSleep(shellBin, sourceDir, true) // kill all running sleep
 
 		case stepAbort := <-sig:
@@ -365,7 +365,7 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 				firstError = stepAbort
 				code = 1
 			}
-			syscall.Kill(-c.Process.Pid, syscall.SIGKILL)
+			syscall.Kill(-c.Process.Pid, syscall.SIGTERM)
 			terminateSleep(shellBin, sourceDir, false) // kill all running sleep other than sleep $SD_TERMINATION_GRACE_PERIOD_SECS
 		}
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Fix the following Issue
https://github.com/screwdriver-cd/screwdriver/issues/2715

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This problem is caused by SIGABRT unable to stop processes created other than  described in sd-step.
In other words, if a grandchild process is created, the process does not stop and continues to run.

As a solution, modified the system to send a SIGTERM to the created process group.
Sending kill to `-PID` will send a signal to that process group.
https://man7.org/linux/man-pages/man2/kill.2.html

If this solution cannot be adopted, it is better to accept it as a specification in Screwdriver.cd.

Well-behaved programs create/process child processes themselves.
If the user defines the sd-step, there is also the idea that the user is responsible for it.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
- https://github.com/screwdriver-cd/screwdriver/issues/2715
- https://man7.org/linux/man-pages/man2/kill.2.html
## License

<!-- The following line must be included in your pull request -->
https://github.com/screwdriver-cd/screwdriver/issues/2715
https://man7.org/linux/man-pages/man2/kill.2.html

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
