### PR TITLE
fix(2754): Update build status if SIGTERM is received

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -357,7 +357,7 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 				code = 3
 			}
 			_ = c.Process.Signal(syscall.SIGABRT)
-			terminateSleep(shellBin, sourceDir, true) // kill all running sleep
+			TerminateSleep(shellBin, sourceDir, true) // kill all running sleep
 
 		case stepAbort := <-sig:
 			f.Write([]byte{4})
@@ -366,7 +366,7 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 				code = 1
 			}
 			_ = c.Process.Signal(syscall.SIGABRT)
-			terminateSleep(shellBin, sourceDir, false) // kill all running sleep other than sleep $SD_TERMINATION_GRACE_PERIOD_SECS
+			TerminateSleep(shellBin, sourceDir, false) // kill all running sleep other than sleep $SD_TERMINATION_GRACE_PERIOD_SECS
 		}
 
 		if err := api.UpdateStepStop(buildID, cmd.Name, code); err != nil {
@@ -402,12 +402,11 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 			firstError = cmdErr
 		}
 	}
-	terminateSleep(shellBin, sourceDir, true) // kill running sleep $SD_TERMINATION_GRACE_PERIOD_SECS
 	return firstError
 }
 
 // terminate long running sleep process for abort, timeout, n after teardown steps
-func terminateSleep(shellBin, sourceDir string, killAll bool) {
+func TerminateSleep(shellBin, sourceDir string, killAll bool) {
 	var stdout, stderr bytes.Buffer
 	shargs := []string{"-e", "-c"}
 	cmdStr := "pids=$(ps -ef | grep '[s]leep' | awk '{print $2}'); pidcnt=$(echo $pids | wc -w); if [ $pidcnt -gt 1 ]; then kill $(echo $pids | awk '{$NF=\"\"}1'); else echo $pids; fi;"

--- a/launch_test.go
+++ b/launch_test.go
@@ -281,7 +281,20 @@ func TestMain(m *testing.M) {
 func TestBuildJobPipelineFromID(t *testing.T) {
 	testPipelineID := 9999
 	api := mockAPI(t, TestBuildID, TestJobID, testPipelineID, "RUNNING")
-	launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
+	err, sourceDir, shellBin := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
+	if err != nil {
+		t.Errorf("err should be nil")
+	}
+
+	expectSourceDir := "/sd/workspace/src/github.com/screwdriver-cd/launcher"
+	if sourceDir != expectSourceDir {
+		t.Errorf("sourceDir == %s, want %s", sourceDir, expectSourceDir)
+	}
+
+	expectShellBin := "/bin/sh"
+	if shellBin != expectShellBin {
+		t.Errorf("shellBin == %s, want %s", shellBin, expectShellBin)
+	}
 }
 
 func TestBuildFromIdError(t *testing.T) {
@@ -292,9 +305,19 @@ func TestBuildFromIdError(t *testing.T) {
 		},
 	}
 
-	err := launch(screwdriver.API(api), 0, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
+	err, sourceDir, shellBin := launch(screwdriver.API(api), 0, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
 	if err == nil {
 		t.Errorf("err should not be nil")
+	}
+
+	expectSourceDir := ""
+	if sourceDir != expectSourceDir {
+		t.Errorf("sourceDir == %s, want %s", sourceDir, expectSourceDir)
+	}
+
+	expectShellBin := ""
+	if shellBin != expectShellBin {
+		t.Errorf("shellBin == %s, want %s", shellBin, expectShellBin)
 	}
 
 	expected := `Fetching Build ID 0`
@@ -311,9 +334,19 @@ func TestEventFromIdError(t *testing.T) {
 		},
 	}
 
-	err := launch(screwdriver.API(api), 0, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
+	err, sourceDir, shellBin := launch(screwdriver.API(api), 0, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
 	if err == nil {
 		t.Errorf("err should not be nil")
+	}
+
+	expectSourceDir := ""
+	if sourceDir != expectSourceDir {
+		t.Errorf("sourceDir == %s, want %s", sourceDir, expectSourceDir)
+	}
+
+	expectShellBin := ""
+	if shellBin != expectShellBin {
+		t.Errorf("shellBin == %s, want %s", shellBin, expectShellBin)
 	}
 
 	expected := `Fetching Event ID 0`
@@ -329,9 +362,19 @@ func TestJobFromIdError(t *testing.T) {
 		return screwdriver.Job(FakeJob{}), err
 	}
 
-	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
+	err, sourceDir, shellBin := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
 	if err == nil {
 		t.Errorf("err should not be nil")
+	}
+
+	expectSourceDir := ""
+	if sourceDir != expectSourceDir {
+		t.Errorf("sourceDir == %s, want %s", sourceDir, expectSourceDir)
+	}
+
+	expectShellBin := ""
+	if shellBin != expectShellBin {
+		t.Errorf("shellBin == %s, want %s", shellBin, expectShellBin)
 	}
 
 	expected := fmt.Sprintf(`Fetching Job ID %d`, TestJobID)
@@ -348,9 +391,19 @@ func TestPipelineFromIdError(t *testing.T) {
 		return screwdriver.Pipeline(FakePipeline{}), err
 	}
 
-	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
+	err, sourceDir, shellBin := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
 	if err == nil {
 		t.Fatalf("err should not be nil")
+	}
+
+	expectSourceDir := ""
+	if sourceDir != expectSourceDir {
+		t.Errorf("sourceDir == %s, want %s", sourceDir, expectSourceDir)
+	}
+
+	expectShellBin := ""
+	if shellBin != expectShellBin {
+		t.Errorf("shellBin == %s, want %s", shellBin, expectShellBin)
 	}
 
 	expected := fmt.Sprintf(`Fetching Pipeline ID %d`, testPipelineID)
@@ -454,10 +507,20 @@ func TestCreateWorkspaceError(t *testing.T) {
 		return nil
 	}
 
-	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
+	err, sourceDir, shellBin := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
 
 	if err.Error() != "Cannot create meta-space path \"./data/meta\": Spooky error" {
 		t.Errorf("Error is wrong, got %v", err)
+	}
+
+	expectSourceDir := ""
+	if sourceDir != expectSourceDir {
+		t.Errorf("sourceDir == %s, want %s", sourceDir, expectSourceDir)
+	}
+
+	expectShellBin := ""
+	if shellBin != expectShellBin {
+		t.Errorf("shellBin == %s, want %s", shellBin, expectShellBin)
 	}
 }
 
@@ -513,11 +576,21 @@ func TestUpdateBuildStatusError(t *testing.T) {
 		return fmt.Errorf("Spooky error")
 	}
 
-	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
+	err, sourceDir, shellBin := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
 
 	want := "Updating build status to RUNNING: Spooky error"
 	if err.Error() != want {
 		t.Errorf("Error is wrong. got %v, want %v", err, want)
+	}
+
+	expectSourceDir := ""
+	if sourceDir != expectSourceDir {
+		t.Errorf("sourceDir == %s, want %s", sourceDir, expectSourceDir)
+	}
+
+	expectShellBin := ""
+	if shellBin != expectShellBin {
+		t.Errorf("shellBin == %s, want %s", shellBin, expectShellBin)
 	}
 }
 
@@ -820,7 +893,7 @@ func TestSetEnv(t *testing.T) {
 		return nil
 	}
 
-	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
+	err, sourceDir, shellBin := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
 	if err != nil {
 		t.Fatalf("Unexpected error from launch: %v", err)
 	}
@@ -830,12 +903,22 @@ func TestSetEnv(t *testing.T) {
 		}
 	}
 
+	expectSourceDir := "/sd/workspace/src/github.com/screwdriver-cd/launcher"
+	if sourceDir != expectSourceDir {
+		t.Errorf("sourceDir == %s, want %s", sourceDir, expectSourceDir)
+	}
+
+	expectShellBin := "/bin/sh"
+	if shellBin != expectShellBin {
+		t.Errorf("shellBin == %s, want %s", shellBin, expectShellBin)
+	}
+
 	// in case of no coverage plugins
 	delete(tests, "SD_SONAR_AUTH_URL")
 	delete(tests, "SD_SONAR_HOST")
 	TestEnvVars = map[string]interface{}{}
 	foundEnv = map[string]string{}
-	err = launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
+	err, sourceDir, shellBin = launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
 	if err != nil {
 		t.Fatalf("Unexpected error from launch: %v", err)
 	}
@@ -850,12 +933,24 @@ func TestSetEnv(t *testing.T) {
 		return screwdriver.Pipeline(FakePipeline{ID: pipelineID, ScmURI: TestScmURI + ":lib", ScmRepo: TestScmRepo}), nil
 	}
 	tests["SD_SOURCE_DIR"] = tests["SD_SOURCE_DIR"] + "/lib"
+	tempShellBin := "/bin/bash"
 	TestEnvVars = map[string]interface{}{}
 	foundEnv = map[string]string{}
-	err = launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
+	err, sourceDir, shellBin = launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, tempShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
 	if err != nil {
 		t.Fatalf("Unexpected error from launch: %v", err)
 	}
+
+	expectSourceDir = "/sd/workspace/src/github.com/screwdriver-cd/launcher/lib"
+	if sourceDir != expectSourceDir {
+		t.Errorf("sourceDir == %s, want %s", sourceDir, expectSourceDir)
+	}
+
+	expectShellBin = "/bin/bash"
+	if shellBin != expectShellBin {
+		t.Errorf("shellBin == %s, want %s", shellBin, expectShellBin)
+	}
+
 	for k, v := range tests {
 		if foundEnv[k] != v {
 			t.Fatalf("foundEnv[%s] = %s, want %s", k, foundEnv[k], v)
@@ -873,10 +968,19 @@ func TestSetEnv(t *testing.T) {
 	tests["SD_PRIVATE_PIPELINE"] = "true"
 	TestEnvVars = map[string]interface{}{}
 	foundEnv = map[string]string{}
-	err = launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
+	err, _, _ = launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
 	if err != nil {
 		t.Fatalf("Unexpected error from launch: %v", err)
 	}
+
+	if sourceDir != expectSourceDir {
+		t.Errorf("sourceDir == %s, want %s", sourceDir, expectSourceDir)
+	}
+
+	if shellBin != expectShellBin {
+		t.Errorf("shellBin == %s, want %s", shellBin, expectShellBin)
+	}
+
 	for k, v := range tests {
 		if foundEnv[k] != v {
 			t.Fatalf("foundEnv[%s] = %s, want %s", k, foundEnv[k], v)
@@ -921,7 +1025,7 @@ func TestEnvSecrets(t *testing.T) {
 		return nil
 	}
 
-	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
+	err, _, _ := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
 	if err != nil {
 		t.Fatalf("Unexpected error from launch: %v", err)
 	}
@@ -1036,7 +1140,7 @@ func TestFetchDefaultMeta(t *testing.T) {
 		return nil
 	}
 
-	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
+	err, _, _ := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
 	want := []byte("{\"build\":{\"buildId\":\"1234\",\"coverageKey\":\"job:fake\",\"eventId\":\"0\",\"jobId\":\"2345\",\"jobName\":\"main\",\"pipelineId\":\"3456\",\"sha\":\"\"}}")
 
 	if err != nil || string(defaultMeta) != string(want) {
@@ -1060,11 +1164,21 @@ func TestFetchParentBuildsMetaParseError(t *testing.T) {
 		return nil, fmt.Errorf("Testing parsing parent builds meta")
 	}
 
-	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
+	err, sourceDir, shellBin := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
 	expected := fmt.Sprint("Parsing Meta JSON: Testing parsing parent builds meta")
 
 	if err.Error() != expected {
 		t.Errorf("Error is wrong, got '%v', expected '%v'", err, expected)
+	}
+
+	expectSourceDir := ""
+	if sourceDir != expectSourceDir {
+		t.Errorf("sourceDir == %s, want %s", sourceDir, expectSourceDir)
+	}
+
+	expectShellBin := ""
+	if shellBin != expectShellBin {
+		t.Errorf("shellBin == %s, want %s", shellBin, expectShellBin)
 	}
 }
 
@@ -1083,11 +1197,21 @@ func TestFetchParentEventMetaParseError(t *testing.T) {
 		return nil, fmt.Errorf("Testing parsing parent event meta")
 	}
 
-	err := launch(screwdriver.API(api), TestEventID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
+	err, sourceDir, shellBin := launch(screwdriver.API(api), TestEventID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
 	expected := fmt.Sprint("Parsing Meta JSON: Testing parsing parent event meta")
 
 	if err.Error() != expected {
 		t.Errorf("Error is wrong, got '%v', expected '%v'", err, expected)
+	}
+
+	expectSourceDir := ""
+	if sourceDir != expectSourceDir {
+		t.Errorf("sourceDir == %s, want %s", sourceDir, expectSourceDir)
+	}
+
+	expectShellBin := ""
+	if shellBin != expectShellBin {
+		t.Errorf("shellBin == %s, want %s", shellBin, expectShellBin)
 	}
 }
 
@@ -1118,11 +1242,21 @@ func TestFetchParentBuildMetaParseError(t *testing.T) {
 		return nil, fmt.Errorf("Testing parsing parent build meta")
 	}
 
-	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
+	err, sourceDir, shellBin := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
 	expected := fmt.Sprint("Parsing Meta JSON: Testing parsing parent build meta")
 
 	if err.Error() != expected {
 		t.Errorf("Error is wrong, got '%v', expected '%v'", err, expected)
+	}
+
+	expectSourceDir := ""
+	if sourceDir != expectSourceDir {
+		t.Errorf("sourceDir == %s, want %s", sourceDir, expectSourceDir)
+	}
+
+	expectShellBin := ""
+	if shellBin != expectShellBin {
+		t.Errorf("shellBin == %s, want %s", shellBin, expectShellBin)
 	}
 }
 
@@ -1153,11 +1287,21 @@ func TestFetchParentBuildMetaWriteError(t *testing.T) {
 		return fmt.Errorf("Testing writing parent build meta")
 	}
 
-	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
+	err, sourceDir, shellBin := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
 	expected := fmt.Sprintf(`Writing Parent Build(%d) Meta JSON: Testing writing parent build meta`, TestParentBuildID)
 
 	if err.Error() != expected {
 		t.Errorf("Error is wrong, got '%v', expected '%v'", err, expected)
+	}
+
+	expectSourceDir := ""
+	if sourceDir != expectSourceDir {
+		t.Errorf("sourceDir == %s, want %s", sourceDir, expectSourceDir)
+	}
+
+	expectShellBin := ""
+	if shellBin != expectShellBin {
+		t.Errorf("shellBin == %s, want %s", shellBin, expectShellBin)
 	}
 }
 
@@ -1234,7 +1378,7 @@ func TestFetchParentBuildsMeta(t *testing.T) {
 		return nil
 	}
 
-	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
+	err, _, _ := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
 
 	want := []byte("{\"batman\":\"robin\",\"build\":{\"buildId\":\"1234\",\"coverageKey\":\"job:fake\",\"eventId\":\"0\",\"jobId\":\"2345\",\"jobName\":\"main\",\"pipelineId\":\"3456\",\"sha\":\"\"},\"foo\":{\"bird\":\"twitter\",\"cat\":\"meow\",\"dog\":\"woof\"},\"wonder\":\"woman\"}")
 	wantParent := []byte("{\"batman\":\"robin\",\"foo\":{\"bird\":\"chirp\",\"cat\":\"meow\"}}")
@@ -1308,11 +1452,21 @@ func TestFetchParentEventMetaWriteError(t *testing.T) {
 		return fmt.Errorf("Testing writing parent event meta")
 	}
 
-	err := launch(screwdriver.API(api), TestEventID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
+	err, sourceDir, shellBin := launch(screwdriver.API(api), TestEventID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
 	expected := fmt.Sprintf(`Writing Parent Event(%d) Meta JSON: Testing writing parent event meta`, TestParentEventID)
 
 	if err.Error() != expected {
 		t.Errorf("Error is wrong, got '%v', expected '%v'", err, expected)
+	}
+
+	expectSourceDir := ""
+	if sourceDir != expectSourceDir {
+		t.Errorf("sourceDir == %s, want %s", sourceDir, expectSourceDir)
+	}
+
+	expectShellBin := ""
+	if shellBin != expectShellBin {
+		t.Errorf("shellBin == %s, want %s", shellBin, expectShellBin)
 	}
 }
 
@@ -1334,11 +1488,21 @@ func TestFetchEventMetaMarshalError(t *testing.T) {
 		return nil, fmt.Errorf("Testing parsing event meta")
 	}
 
-	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
+	err, sourceDir, shellBin := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
 	expected := fmt.Sprint("Parsing Meta JSON: Testing parsing event meta")
 
 	if err.Error() != expected {
 		t.Errorf("Error is wrong, got '%v', expected '%v'", err, expected)
+	}
+
+	expectSourceDir := ""
+	if sourceDir != expectSourceDir {
+		t.Errorf("sourceDir == %s, want %s", sourceDir, expectSourceDir)
+	}
+
+	expectShellBin := ""
+	if shellBin != expectShellBin {
+		t.Errorf("shellBin == %s, want %s", shellBin, expectShellBin)
 	}
 }
 
@@ -1388,7 +1552,7 @@ func TestMetaWhenStartPipeline(t *testing.T) {
 		return nil
 	}
 
-	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
+	err, _, _ := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
 	want := fmt.Sprintf(`{
 		"build_only": "build_value",
 		"build": {
@@ -1497,7 +1661,7 @@ func TestMetaWhenTriggeredFromParentBuildWithoutParentBuildMeta(t *testing.T) {
 		return nil
 	}
 
-	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
+	err, _, _ := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
 	want := fmt.Sprintf(`{
 		"build_only": "build_value",
 		"event_only": "event_value",
@@ -1755,7 +1919,7 @@ func TestMetaWhenTriggeredFromPipelinesByANDLogicWithParentBuildMeta(t *testing.
 		return nil
 	}
 
-	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
+	err, _, _ := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
 	want := fmt.Sprintf(`{
 		"build_only": "build_value",
 		"event_only": "event_value",
@@ -1948,7 +2112,7 @@ func TestMetaWhenTriggeredFromInnerPipelineByORLogicWithParentBuildMeta(t *testi
 		return nil
 	}
 
-	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
+	err, _, _ := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
 	want := fmt.Sprintf(`{
 		"build_only": "build_value",
 		"event_only": "event_value",
@@ -2137,7 +2301,7 @@ func TestMetaWhenTriggeredFromExternalPipelineByORLogicWithParentBuildMeta(t *te
 		return nil
 	}
 
-	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
+	err, _, _ := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
 	want := fmt.Sprintf(`{
 		"build_only": "build_value",
 		"event_only": "event_value",
@@ -2296,7 +2460,7 @@ func TestMetaWhenStartFromAnyJobWithParentEvent(t *testing.T) {
 		return nil
 	}
 
-	err := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
+	err, _, _ := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
 	want := fmt.Sprintf(`{
 		"build_only": "build_value",
 		"event_only": "event_value",


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Fix as discussed in https://github.com/screwdriver-cd/screwdriver/issues/2754.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
The launcher now updates the build status when a pod is sent a SIGTERM via soft evict or kubectl delete.

I experimented in kubernetes v1.22.9 environment.

Before the fix, the build status is not updated during soft evict, so the status remains RUNNING. buildCluster-queue-worker doesn't send delete request, so build pod stays.

![nonUpdated](https://user-images.githubusercontent.com/32473622/189625182-232b21b3-47ca-4086-80ed-e878e2b4f709.png)

After fixing, the build status will be updated to Failure when soft evict. At this time, the buildCluster-queue-worker can sends a delete request to clean up the build pot.

![updated](https://user-images.githubusercontent.com/32473622/189625237-8cb6a03c-f9d6-44e8-ba31-2f91b5a294ac.png)

What this PR doing:
- export TerminateSleep function
- remove terminateSleep before build status's update
- decomposed the function of `exit` into `cleanExit` and `prepareExit`
- `launch` function returns `sourceDir` and `shellBin`
- Execute `TerminateSleep` after updating buildStatus (`prepareExit`)
- Added tests for when `launch` fails and when the return value of `launch` is changed from the default
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2754

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
