### PR TITLE
feat: add default event meta

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -527,6 +527,16 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		mergedMeta["build"] = buildMeta
 	}
 
+	eventMeta := map[string]interface{}{
+		"creator": event.Creator["username"],
+	}
+
+	if mergedMeta["event"] != nil {
+		mergedMeta["event"] = deepMergeJSON(mergedMeta["event"].(map[string]interface{}), eventMeta)
+	} else {
+		mergedMeta["event"] = eventMeta
+	}
+
 	log.Println("Marshalling Merged Meta JSON")
 	metaByte, err = marshal(mergedMeta)
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

The metadata `event.creator` was added in [this PR](https://github.com/screwdriver-cd/models/pull/532).
But this value is overwrote by the parent event's value, so we cannot get the correct value when run a build by `(Re)Start pipeline from here`.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR changes the metadata `event.creator` to be set in the launcher as in `build.buildId`.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
