### PR TITLE
feat: add environment variable of build cluster name 

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -635,6 +635,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		"SD_STORE_URL":            fmt.Sprintf("%s/%s/", storeURL, "v1"),
 		"SD_UI_URL":               fmt.Sprintf("%s/", uiURL),
 		"SD_UI_BUILD_URL":         fmt.Sprintf("%s/pipelines/%s/builds/%s", uiURL, strconv.Itoa(job.PipelineID), strconv.Itoa(buildID)),
+		"SD_BUILD_CLUSTER_NAME":   build.BuildClusterName,
 		"SD_TOKEN":                buildToken,
 		"SD_CACHE_STRATEGY":       cacheStrategy,
 		"SD_PIPELINE_CACHE_DIR":   pipelineCacheDir,

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -184,6 +184,7 @@ type Build struct {
 	Stats         struct {
 		QueueEntertime string `json:"queueEnterTime"`
 	} `json:"stats"`
+	BuildClusterName string `json:"buildClusterName"`
 }
 
 // Coverage is a Coverage object returned when getInfo is called

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -145,6 +145,7 @@ func TestBuildFromID(t *testing.T) {
 				}{
 					QueueEntertime: "2020-05-01T20:15:31.508Z",
 				},
+				BuildClusterName: "test-build-cluster-name",
 			},
 			statusCode: 200,
 			err:        nil,


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

We can change bookends for each build cluster. Users also want to change the process for each build cluster.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Add environment variable of build cluster name.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
