### PR TITLE
fix: add SHELLOPTS to ignore list in teardown step

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -276,7 +276,7 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 	// Command to Export Env. Use tmpfile just in case export -p takes some time
 	exportEnvCmd :=
 		"tmpfile=" + tmpFile + "; exportfile=" + exportFile + "; " +
-			"export -p | grep -vi \"PS1=\" > $tmpfile && mv -f $tmpfile $exportfile; "
+			"export -p | grep -vi \"PS1=|SHELLOPTS=\" > $tmpfile && mv -f $tmpfile $exportfile; "
 
 	// Run setup commands
 	setupCommands := []string{


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

To address issues like
```
/tmp/env_export: line 110: SHELLOPTS: readonly variable
```

When user has script in sd.yaml such as

```
      steps:
        - env: |
            set -x; # export SHELLOPTS
            env
```

We will have issue like: 

![image](https://user-images.githubusercontent.com/15989893/235992053-84c07ccd-fdad-48a3-8638-4d9b5127d0b4.png)


## Objective
This PR add `SHELLOPTS` to be ignored
<!-- What does this PR fix? What intentional changes will this PR make? -->

Test pending


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
