### PR TITLE
fix(2892): add id into event.creator

### DIFF
--- a/launch_test.go
+++ b/launch_test.go
@@ -54,7 +54,10 @@ var TestEnvVars = make(map[string]interface{})
 var TestScmRepo = screwdriver.ScmRepo(FakeScmRepo{
 	Name: "screwdriver-cd/launcher",
 })
-var TestEventCreator = map[string]string{"username": "stjohn"}
+var TestEventCreator = map[string]interface{}{
+	"id":       1234,
+	"username": "stjohn",
+}
 
 type FakeBuild screwdriver.Build
 type FakeCoverage screwdriver.Coverage

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -197,7 +197,7 @@ type Event struct {
 	ID            int                    `json:"id"`
 	Meta          map[string]interface{} `json:"meta"`
 	ParentEventID int                    `json:"parentEventId"`
-	Creator       map[string]string      `json:"creator"`
+	Creator       map[string]interface{} `json:"creator"`
 }
 
 // Secret is a Screwdriver build secret.

--- a/screwdriver/screwdriver_local.go
+++ b/screwdriver/screwdriver_local.go
@@ -35,7 +35,7 @@ func (a localApi) EventFromID(eventID int) (event Event, err error) {
 		ID:            0,
 		Meta:          make(map[string]interface{}),
 		ParentEventID: 0,
-		Creator:       make(map[string]string),
+		Creator:       make(map[string]interface{}),
 	}
 
 	return event, nil

--- a/screwdriver/screwdriver_local_test.go
+++ b/screwdriver/screwdriver_local_test.go
@@ -29,7 +29,7 @@ func TestEventFromIDLocal(t *testing.T) {
 		0,
 		make(map[string]interface{}),
 		0,
-		make(map[string]string),
+		make(map[string]interface{}),
 	}
 
 	actual, err := testAPI.EventFromID(0)

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -203,7 +203,7 @@ func TestEventFromID(t *testing.T) {
 				ParentEventID: 8765,
 				Creator: map[string]interface{}{
 					"username": "testUsername",
-					"id":       1234,
+					"id":       float64(1234),
 				},
 			},
 			statusCode: 200,

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -201,8 +201,9 @@ func TestEventFromID(t *testing.T) {
 			event: Event{
 				ID:            1555,
 				ParentEventID: 8765,
-				Creator: map[string]string{
+				Creator: map[string]interface{}{
 					"username": "testUsername",
+					"id":       1234,
 				},
 			},
 			statusCode: 200,


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Event.creator got to have `id` by the following PR.

https://github.com/screwdriver-cd/screwdriver/pull/2890

The `id` is integer or string, but now the property of Event.creator must be string.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Fix to Event.creator be able to have integer property.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/2892

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
