### PR TITLE
fix(2878): exclude warning from merging build meta

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -524,11 +524,12 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		buildMeta["coverageKey"] = coverageInfo.EnvVars["SD_SONAR_PROJECT_KEY"]
 	}
 
+	mergedBuildMeta := buildMeta
 	if mergedMeta["build"] != nil {
-		mergedMeta["build"] = deepMergeJSON(mergedMeta["build"].(map[string]interface{}), buildMeta)
-	} else {
-		mergedMeta["build"] = buildMeta
+		mergedBuildMeta = deepMergeJSON(mergedMeta["build"].(map[string]interface{}), buildMeta)
 	}
+	delete(mergedBuildMeta, "warning")
+	mergedMeta["build"] = mergedBuildMeta
 
 	eventMeta := map[string]interface{}{
 		"creator": event.Creator["username"],

--- a/launch_test.go
+++ b/launch_test.go
@@ -2557,6 +2557,7 @@ func TestMetaWhenStartFromAnyJobWithParentEvent(t *testing.T) {
 			"coverageKey":                      "parent_event_value", // Overwrote by default value
 			"parent_event_only":                "parent_event_value", // Remain
 			"build_and_event_and_parent_event": "parent_event_value", // Remain
+			"warning":                          "parent_event_value", // Removed from merged meta
 		},
 		"event": map[string]interface{}{
 			"creator": "parent_event_value", // Overwrote by default value


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
build warning should be specific to the build
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
exclude build warning from inheriting to downstream builds
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
