### PR TITLE
feat: Add source directory to Sonarqube project name

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -449,7 +449,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 
 	pipelineName := pipeline.ScmRepo.Name
 	if scm.RootDir != "" {
-		pipelineName = pipeline.ScmRepo.Name + ":" + scm.RootDir
+		pipelineName += ":" + scm.RootDir
 	}
 
 	coverageScope := ""

--- a/launch_test.go
+++ b/launch_test.go
@@ -419,11 +419,12 @@ func TestParseScmURI(t *testing.T) {
 	wantOrg := "screwdriver-cd"
 	wantRepo := "launcher"
 	wantBranch := "master"
+	wantRootDir := "childDirectory"
 
-	scmURI := "github.com:123456:master"
+	scmURI := "github.com:123456:master:childDirectory"
 	scmName := "screwdriver-cd/launcher"
 	parsedURL, err := parseScmURI(scmURI, scmName)
-	host, org, repo, branch := parsedURL.Host, parsedURL.Org, parsedURL.Repo, parsedURL.Branch
+	host, org, repo, branch, rootDir := parsedURL.Host, parsedURL.Org, parsedURL.Repo, parsedURL.Branch, parsedURL.RootDir
 	if err != nil {
 		t.Errorf("Unexpected error parsing SCM URI %q: %v", scmURI, err)
 	}
@@ -442,6 +443,10 @@ func TestParseScmURI(t *testing.T) {
 
 	if branch != wantBranch {
 		t.Errorf("branch = %q, want %q", branch, wantBranch)
+	}
+
+	if rootDir != wantRootDir {
+		t.Errorf("rootDir = %q, want %q", rootDir, wantRootDir)
 	}
 }
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

If there are multiple projects in one repository, the source directory can be set for the pipeline, but the source directory is not set for the project name in SonarQube.

In SonarQube UI, it is not possible to distinguish which directory the project was created from, so modify the source directory so that it is set to the project name.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

In pipelines where the source directory is set, modify it so that it is set in the format `repositoryName:sourceDir:jobName`.

![image](https://github.com/screwdriver-cd/launcher/assets/59165943/c9508ecd-26b5-4b7e-ad36-f543fb395c6a)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
