### PR TITLE
[1] fix(2882): Update build status with k8s hostname together

### DIFF
--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -106,6 +106,7 @@ func New(url, token string) (API, error) {
 type BuildStatusPayload struct {
 	Status string                 `json:"status"`
 	Meta   map[string]interface{} `json:"meta"`
+	Stats  map[string]interface{} `json:"stats"`
 }
 
 // BuildStatusMessagePayload is a Screwdriver Build Status Message payload.
@@ -113,6 +114,7 @@ type BuildStatusMessagePayload struct {
 	Status        string                 `json:"status"`
 	Meta          map[string]interface{} `json:"meta"`
 	StatusMessage string                 `json:"statusMessage"`
+	Stats         map[string]interface{} `json:"stats"`
 }
 
 // StepStartPayload is a Screwdriver Step Start payload.
@@ -439,18 +441,27 @@ func (a api) UpdateBuildStatus(status BuildStatus, meta map[string]interface{}, 
 		return fmt.Errorf("creating url: %v", err)
 	}
 
+	stats := map[string]interface{}{}
+	nodeId := os.Getenv("NODE_ID")
+
+	if nodeId != "" {
+		stats["hostname"] = nodeId
+	}
+
 	var payload []byte
 	if statusMessage != "" {
 		bs := BuildStatusMessagePayload{
 			Status:        status.String(),
 			Meta:          meta,
 			StatusMessage: statusMessage,
+			Stats:         stats,
 		}
 		payload, err = json.Marshal(bs)
 	} else {
 		bs := BuildStatusPayload{
 			Status: status.String(),
 			Meta:   meta,
+			Stats:  stats,
 		}
 		payload, err = json.Marshal(bs)
 	}


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Sometime, k8s node name is not output in `sd-setup-init` step log.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Implements of https://github.com/screwdriver-cd/screwdriver/issues/2882#issuecomment-1649346764 .

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/2882

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
