### PR TITLE
fix: Fix sd-local display bug

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -109,7 +109,7 @@ func doRunSetupCommand(emitter screwdriver.Emitter, f *os.File, r io.Reader, set
 		t      string
 		err    error
 		reader = bufio.NewReader(r)
-		reEcho = regexp.MustCompile("echo ;")
+		reEcho = regexp.MustCompile("^$")
 	)
 
 	shargs := strings.Join(setupCommands, " && ")

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -287,7 +287,7 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 			"EXITCODE=$?; " +
 			exportEnvCmd +
 			"echo $SD_STEP_ID $EXITCODE; }", //mv newfile to file
-		"trap finish ABRT EXIT;\n\necho ;\n",
+		"trap finish ABRT EXIT;\n\n",
 	}
 
 	setupReader := bufio.NewReader(f)

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -287,7 +287,7 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 			"EXITCODE=$?; " +
 			exportEnvCmd +
 			"echo $SD_STEP_ID $EXITCODE; }", //mv newfile to file
-		"trap finish ABRT EXIT;\necho ;\n",
+		"trap finish ABRT EXIT;\n\necho ;\n",
 	}
 
 	setupReader := bufio.NewReader(f)


### PR DESCRIPTION
## Context
<!-- Why do we need this PR? What was the reason that led you to make this change? -->
In sd-local, there was a bug that the sd-setup-launcher command and output was displayed in the job step as follows when using images such as centos7 with `/bin/sh` as `bash`.

The reason for this is that the `echo ;` at the end of the sd-setup-local command is a return condition, so the output of the command is left out and displayed in later job steps.

```
INFO   [0000] Prepare to start build...                    
INFO   [0012] Pulling docker image from centos:centos7...  
sd-setup-launcher: set -e && export PATH=${PATH}:/opt/sd:/usr/sd/bin:/usr/sd-static/bin && finish() { EXITCODE=$?; tmpfile=/tmp/env_tmp; exportfile=/tmp/env_export; export -p | grep -vi "PS1=" > $tmpfile && mv -f $tmpfile $exportfile; echo $SD_STEP_ID $EXITCODE; } && trap finish ABRT EXIT;
sd-setup-launcher: echo ;
case1: $ echo "Hello world"
case1: set -e && export PATH=${PATH}:/opt/sd:/usr/sd/bin:/usr/sd-static/bin && finish() { EXITCODE=$?; tmpfile=/tmp/<n && finish() { EXITCODE=$?; tmpfile=/tmp/env_tmp; exportfile=/tmp/env_export; export -p | grep -vi "PS1=" > $tmpfi</env_export; export -p | grep -vi "PS1=" > $tmpfile && mv -f $tmpfile $exportfile; echo $SD_STEP_ID $EXITCODE; } && trap finish ABRT EXIT;                                                          
case1: echo ;
case1: 
case1: Hello world
case1:
```

## Objective
<!-- What does this PR fix? What intentional changes will this PR make? -->
Prevent the sd-setup-launcher command and output from appearing in the job step by making the output of `echo ;` a Return condition.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
