### PR TITLE
fix: refix sd-local display bug

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -288,7 +288,7 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 			"EXITCODE=$?; " +
 			exportEnvCmd +
 			"echo $SD_STEP_ID $EXITCODE; }", //mv newfile to file
-		"trap finish ABRT EXIT;\necho ;\n",
+		"trap finish ABRT EXIT;\n\n",
 	}
 
 	setupReader := bufio.NewReader(f)

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -118,6 +118,7 @@ func doRunSetupCommand(emitter screwdriver.Emitter, f *os.File, r io.Reader, set
 
 	t, err = readln(reader)
 	for err == nil {
+		t = strings.TrimLeft(t, "# ")
 		t = strings.TrimLeft(t, "$ ")
 		echoCmd := reEcho.FindStringSubmatch(t)
 		if len(echoCmd) != 0 {
@@ -288,7 +289,7 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 			"EXITCODE=$?; " +
 			exportEnvCmd +
 			"echo $SD_STEP_ID $EXITCODE; }", //mv newfile to file
-		"trap finish ABRT EXIT;\n\n",
+		"trap finish ABRT EXIT;\necho ;\n",
 	}
 
 	setupReader := bufio.NewReader(f)

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -118,6 +118,7 @@ func doRunSetupCommand(emitter screwdriver.Emitter, f *os.File, r io.Reader, set
 
 	t, err = readln(reader)
 	for err == nil {
+		t = strings.TrimLeft(t, "$ ")
 		echoCmd := reEcho.FindStringSubmatch(t)
 		if len(echoCmd) != 0 {
 			_, werr := fmt.Fprintln(emitter, t)
@@ -287,7 +288,7 @@ func Run(path string, env []string, emitter screwdriver.Emitter, build screwdriv
 			"EXITCODE=$?; " +
 			exportEnvCmd +
 			"echo $SD_STEP_ID $EXITCODE; }", //mv newfile to file
-		"trap finish ABRT EXIT;\n\n",
+		"trap finish ABRT EXIT;\necho ;\n",
 	}
 
 	setupReader := bufio.NewReader(f)


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
#465 was insufficient so the sd-local user step still included the output of the sd-setup-launcher step.

The reason is that the output of the sd-setup-laucher command changes depending on the job image.
In some images, the output of `echo ;` was not empty and contained a prompt characters such as `$` and `#`, which could cause the loop to be stuck.

## Objective
The goal is that the sd-local user step does not include the output of the sd-setup-launcher step.

As a result of the fixes, it now works as follows.

Before
```
sd-setup-launcher: set -e && export PATH=${PATH}:/opt/sd:/usr/sd/bin:/usr/sd-static/bin && finish() { EXITCODE=$?; tmpfile=/tmp/env_tmp; exportfile=/tmp/env_export; export -p | grep -vi "PS1=" > $tmpfile && mv -f $tmpfile $exportfile; echo $SD_STEP_ID $EXITCODE; } && trap finish ABRT EXIT;
sd-setup-launcher: 
echo: $ echo "Hello world"
echo: <port; export -p | grep -vi "PS1=" > $tmpfile && mv -f $tmpfile $exportfile; echo $SD_STEP_ID $EXITCODE; } && trap finish ABRT EXIT;
echo: 
echo: Hello world
echo: 
```

After
```
sd-setup-launcher: set -e && export PATH=${PATH}:/opt/sd:/usr/sd/bin:/usr/sd-static/bin && finish() { EXITCODE=$?; tmpfile=/tmp/env_tmp; exportfile=/tmp/env_export; export -p | grep -vi "PS1=" > $tmpfile && mv -f $tmpfile $exportfile; echo $SD_STEP_ID $EXITCODE; } && trap finish ABRT EXIT;
sd-setup-launcher: echo ;
sd-setup-launcher: <port; export -p | grep -vi "PS1=" > $tmpfile && mv -f $tmpfile $exportfile; echo $SD_STEP_ID $EXITCODE; } && trap finish ABRT EXIT;
sd-setup-launcher: echo ;
sd-setup-launcher: 
echo: $ echo "Hello world"
echo: Hello world
echo: 
```



<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
