### PR TITLE
fix(2952): encode percent of rootDir

### DIFF
--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -338,7 +338,9 @@ func (a api) GetAPIURL() (string, error) {
 
 // Get coverage object with coverage information
 func (a api) GetCoverageInfo(jobID, pipelineID int, jobName, pipelineName, scope, prNum, prParentJobId string) (coverage Coverage, err error) {
-	url, err := a.makeURL(fmt.Sprintf(CoverageURL, jobID, pipelineID, jobName, pipelineName, scope, prNum, prParentJobId))
+	// If pipelineName contains a percent sign (%), it needs to be encoded to ensure the URL can be parsed correctly.
+	encodedPipelineName := strings.Replace(pipelineName, "%", "%25", -1)
+	url, err := a.makeURL(fmt.Sprintf(CoverageURL, jobID, pipelineID, jobName, encodedPipelineName, scope, prNum, prParentJobId))
 	body, err := a.get(url)
 	if err != nil {
 		return coverage, err

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -252,11 +252,13 @@ func TestGetCoverageInfo(t *testing.T) {
 		"SD_SONAR_ENTERPRISE": false,
 	}
 	tests := []struct {
-		coverage   Coverage
-		statusCode int
-		err        error
+		pipelineName string
+		coverage     Coverage
+		statusCode   int
+		err          error
 	}{
 		{
+			pipelineName: "d2lam/mytest",
 			coverage: Coverage{
 				EnvVars: envVars,
 			},
@@ -264,16 +266,26 @@ func TestGetCoverageInfo(t *testing.T) {
 			err:        nil,
 		},
 		{
-			coverage:   Coverage{},
-			statusCode: 500,
+			pipelineName: "specialCharacter/!\"#$%&'()-=|@`{;+]},<.>　🚗",
+			coverage: Coverage{
+				EnvVars: envVars,
+			},
+			statusCode: 200,
+			err:        nil,
+		},
+		{
+			pipelineName: "d2lam/mytest",
+			coverage:     Coverage{},
+			statusCode:   500,
 			err: errors.New("WARNING: received error from GET(http://fakeurl/v4/coverage/info?jobId=123&pipelineId=456&jobName=main&pipelineName=d2lam/mytest&scope=&prNum=&prParentJobId=): " +
 				"Get \"http://fakeurl/v4/coverage/info?jobId=123&pipelineId=456&jobName=main&pipelineName=d2lam/mytest&scope=&prNum=&prParentJobId=\": " +
 				"GET http://fakeurl/v4/coverage/info?jobId=123&pipelineId=456&jobName=main&pipelineName=d2lam/mytest&scope=&prNum=&prParentJobId= giving up after 5 attempts "),
 		},
 		{
-			coverage:   Coverage{},
-			statusCode: 404,
-			err:        errors.New("WARNING: received response 404 from http://fakeurl/v4/coverage/info?jobId=123&pipelineId=456&jobName=main&pipelineName=d2lam/mytest&scope=&prNum=&prParentJobId= "),
+			pipelineName: "d2lam/mytest",
+			coverage:     Coverage{},
+			statusCode:   404,
+			err:          errors.New("WARNING: received response 404 from http://fakeurl/v4/coverage/info?jobId=123&pipelineId=456&jobName=main&pipelineName=d2lam/mytest&scope=&prNum=&prParentJobId= "),
 		},
 	}
 
@@ -288,7 +300,7 @@ func TestGetCoverageInfo(t *testing.T) {
 		client.HTTPClient = makeFakeHTTPClient(t, test.statusCode, string(JSON))
 		testAPI := api{"http://fakeurl", "faketoken", client}
 
-		coverage, err := testAPI.GetCoverageInfo(123, 456, "main", "d2lam/mytest", "", "", "")
+		coverage, err := testAPI.GetCoverageInfo(123, 456, "main", test.pipelineName, "", "", "")
 
 		if !reflect.DeepEqual(err, test.err) {
 			t.Errorf("Unexpected error from GetCoverageInfo: \n%v\n want \n%v", err.Error(), test.err.Error())


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

This PR is for https://github.com/screwdriver-cd/screwdriver/issues/2952#issuecomment-1809697640.

Pipeline build with rootDir containing `%` fails at `sd-setup-launcher` step.

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
```

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
`url.Parse()` fails at the point where it encodes `%`, so replace `%` with `%25` before that.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
