### PR TITLE
fix(2952): Allow colon to be used in root directory

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -205,7 +205,7 @@ func parseScmURI(scmURI, scmName string) (scmPath, error) {
 	uri := strings.Split(scmURI, ":")
 	orgRepo := strings.Split(scmName, "/")
 
-	if (len(uri) != 3 && len(uri) != 4) || len(orgRepo) != 2 {
+	if len(uri) < 3 || len(orgRepo) != 2 {
 		return scmPath{}, fmt.Errorf("Unable to parse scmUri %v and scmName %v", scmURI, scmName)
 	}
 
@@ -218,7 +218,7 @@ func parseScmURI(scmURI, scmName string) (scmPath, error) {
 	}
 
 	if len(uri) > 3 {
-		parsed.RootDir = uri[3]
+		parsed.RootDir = strings.Join(uri[3:], ":")
 	}
 
 	return parsed, nil

--- a/launch_test.go
+++ b/launch_test.go
@@ -419,9 +419,9 @@ func TestParseScmURI(t *testing.T) {
 	wantOrg := "screwdriver-cd"
 	wantRepo := "launcher"
 	wantBranch := "master"
-	wantRootDir := "childDirectory"
+	wantRootDir := "child:Directory"
 
-	scmURI := "github.com:123456:master:childDirectory"
+	scmURI := "github.com:123456:master:child:Directory"
 	scmName := "screwdriver-cd/launcher"
 	parsedURL, err := parseScmURI(scmURI, scmName)
 	host, org, repo, branch, rootDir := parsedURL.Host, parsedURL.Org, parsedURL.Repo, parsedURL.Branch, parsedURL.RootDir


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Cannot start build if rootDirectory contains a colon.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
I fix to correctly parse rootDirectory even if it contains a colon

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
issue: https://github.com/screwdriver-cd/screwdriver/issues/2952

PR:
- https://github.com/screwdriver-cd/scm-github/pull/220
- https://github.com/screwdriver-cd/scm-base/pull/96
- https://github.com/screwdriver-cd/data-schema/pull/544

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
