### PR TITLE
fix(2973): setup commands stuck with xterm

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -105,16 +105,12 @@ func copyLinesUntil(r io.Reader, w io.Writer, match string) (int, error) {
 }
 
 func doRunSetupCommand(guid string, emitter screwdriver.Emitter, f *os.File, r io.Reader, setupCommands []string) error {
-	var (
-		err    error
-	)
-
 	shargs := strings.Join(setupCommands, " && ")
 
 	f.Write([]byte(shargs))
 
 	// ignore exit code in setup commands
-	_, err = copyLinesUntil(r, emitter, guid)
+	_, err := copyLinesUntil(r, emitter, guid)
 
 	return err
 }


### PR DESCRIPTION
## Context
Please refer to https://github.com/screwdriver-cd/screwdriver/issues/2973
Some environment(especially when using xterm), setup-launcher step is stuck.

Currently [doRunSetupCommand](https://github.com/screwdriver-cd/launcher/blob/ec83f2eb7078503c72eb151a42eb188a6285928a/executor/executor.go#L107), which read setupCommands output until it finds an empty line, can't detect the empty line correctly when xterm is set, because the output has terminal sequences as prefix like following.
```
\x1b[?2004l\r
```

## Objective
Fix setup-launcher not to stuck even if using xterm.


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
