### PR TITLE
fix(3234): Always merge parent event meta last

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -499,7 +499,10 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		}
 
 		metaLog = fmt.Sprintf(`Build(%v)`, parentBuildIDs[0])
-	} else if event.ParentEventID != 0 { // If has parent event, fetch meta from parent event
+	}
+
+	// Always merge parent event meta if it exists (Issue #3234)
+	if event.ParentEventID != 0 { // If has parent event, fetch meta from parent event
 		log.Printf("Fetching Parent Event %d", event.ParentEventID)
 		parentEvent, err := api.EventFromID(event.ParentEventID)
 		if err != nil {


### PR DESCRIPTION
## Context

During a restart case, sometimes the metadata from parentEvent is expected but with the current implementation, the metadata from parentBuildId wins over that from a parentEvent, ending in a situation where some metadata is missing.

## Objective

This PR always merges parent event meta if it exists. Order of precedence goes: build > parent event > parent build > event

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/3234

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
