### PR TITLE
fix: set GIT_ASKPASS=echo

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -622,7 +622,8 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		"PS1":                     "",
 		"SCREWDRIVER":             isCI,
 		"CI":                      isCI,
-		"GIT_PAGER":               "cat", // https://github.com/screwdriver-cd/screwdriver/issues/1583#issuecomment-539677403
+		"GIT_PAGER":               "cat",  // https://github.com/screwdriver-cd/screwdriver/issues/1583#issuecomment-539677403
+		"GIT_ASKPASS":             "echo", // https://github.com/screwdriver-cd/screwdriver/issues/1583#issuecomment-2451234577
 		"CONTINUOUS_INTEGRATION":  isCI,
 		"SD_JOB_NAME":             oldJobName,
 		"SD_PIPELINE_NAME":        pipeline.ScmRepo.Name,


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Screwdriver build shell is interactive. The build is stopped when the step requires user input.

Setting `GIT_ASKPASS=echo` until https://github.com/screwdriver-cd/screwdriver/issues/1583#issuecomment-2451234577 is resolved.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

`GIT_ASKPASS` command is called when `git` commands need user login and fill user name and password automatically.
[Ref: doc](https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables#:~:text=my/repo.-,GIT_ASKPASS,-is%20an%20override)

Set `GIT_ASKPASS=echo` means filling username and password blank.
Thus we can fail fast the build.

- With `GIT_ASKPASS`: https://cd.screwdriver.cd/pipelines/15502/builds/965087/steps/sd-setup-scm
- No `GIT_ASKPASS`: https://cd.screwdriver.cd/pipelines/15502/builds/965086/steps/sd-setup-scm

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/1583

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
