### PR TITLE
feat(3234): parentevent should be a predecessor of other metadata

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -474,6 +474,21 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		return err, "", ""
 	}
 
+	// Always merge parent event meta if it exists (Issue #3234)
+	if event.ParentEventID != 0 { // If has parent event, fetch meta from parent event
+		log.Printf("Fetching Parent Event %d", event.ParentEventID)
+		parentEvent, err := api.EventFromID(event.ParentEventID)
+		if err != nil {
+			return fmt.Errorf("Fetching Parent Event ID %d: %v", event.ParentEventID, err), "", ""
+		}
+
+		if parentEvent.Meta != nil {
+			mergedMeta = deepMergeJSON(mergedMeta, parentEvent.Meta)
+		}
+
+		metaLog = fmt.Sprintf(`Event(%v)`, parentEvent.ID)
+	}
+
 	// Always merge event meta
 	if len(event.Meta) > 0 { // If has meta, marshal it
 		log.Printf("Fetching Event Meta JSON %v", event.ID)
@@ -499,21 +514,6 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		}
 
 		metaLog = fmt.Sprintf(`Build(%v)`, parentBuildIDs[0])
-	}
-
-	// Always merge parent event meta if it exists (Issue #3234)
-	if event.ParentEventID != 0 { // If has parent event, fetch meta from parent event
-		log.Printf("Fetching Parent Event %d", event.ParentEventID)
-		parentEvent, err := api.EventFromID(event.ParentEventID)
-		if err != nil {
-			return fmt.Errorf("Fetching Parent Event ID %d: %v", event.ParentEventID, err), "", ""
-		}
-
-		if parentEvent.Meta != nil {
-			mergedMeta = deepMergeJSON(mergedMeta, parentEvent.Meta)
-		}
-
-		metaLog = fmt.Sprintf(`Event(%v)`, parentEvent.ID)
 	}
 
 	// Initialize pr comments (Issue #1858)

--- a/launch_test.go
+++ b/launch_test.go
@@ -2278,7 +2278,7 @@ func TestMetaWhenTriggeredFromInnerPipelineByORLogicWithParentBuildMeta(t *testi
 		"build_only": "build_value",
 		"event_only": "event_value",
 		"inner_pipeline_only": "inner_pipeline_value",
-		"build_and_event_and_inner_pipeline": "event_value",
+		"build_and_event_and_inner_pipeline": "inner_pipeline_value",
 		"build":{
 			"buildId": "%d",
 			"jobId": "%d",
@@ -2290,7 +2290,7 @@ func TestMetaWhenTriggeredFromInnerPipelineByORLogicWithParentBuildMeta(t *testi
 			"build_only": "build_value",
 			"event_only": "event_value",
 			"inner_pipeline_only": "inner_pipeline_value",
-			"build_and_event_and_inner_pipeline": "event_value"
+			"build_and_event_and_inner_pipeline": "inner_pipeline_value"
 		},
 		"event": {
 			"creator": "%s"
@@ -2299,7 +2299,7 @@ func TestMetaWhenTriggeredFromInnerPipelineByORLogicWithParentBuildMeta(t *testi
 			"build_only": "build_value",
 			"event_only": "event_value",
 			"inner_pipeline_only": "inner_pipeline_value",
-			"build_and_event_and_inner_pipeline": "event_value"
+			"build_and_event_and_inner_pipeline": "inner_pipeline_value"
 		},
 		"parameters": {
 			"build_only": "build_value",
@@ -2694,7 +2694,7 @@ func TestMetaWhenStartFromAnyJobWithParentEvent(t *testing.T) {
 		"build_only": "build_value",
 		"event_only": "event_value",
 		"parent_event_only": "parent_event_value",
-		"build_and_event_and_parent_event": "parent_event_value",
+		"build_and_event_and_parent_event": "event_value",
 		"build":{
 			"buildId": "%d",
 			"jobId": "%d",
@@ -2706,7 +2706,7 @@ func TestMetaWhenStartFromAnyJobWithParentEvent(t *testing.T) {
 			"build_only": "build_value",
 			"event_only": "event_value",
 			"parent_event_only": "parent_event_value",
-			"build_and_event_and_parent_event": "parent_event_value"
+			"build_and_event_and_parent_event": "event_value"
 		},
 		"event": {
 			"creator": "%s"
@@ -2715,7 +2715,7 @@ func TestMetaWhenStartFromAnyJobWithParentEvent(t *testing.T) {
 			"build_only": "build_value",
 			"event_only": "event_value",
 			"parent_event_only": "parent_event_value",
-			"build_and_event_and_parent_event": "parent_event_value"
+			"build_and_event_and_parent_event": "event_value"
 		},
 		"parameters":{
 			"build_only": "build_value",

--- a/launch_test.go
+++ b/launch_test.go
@@ -1849,8 +1849,10 @@ func TestMetaWhenTriggeredFromPipelinesByANDLogicWithParentBuildMeta(t *testing.
 
 	eventFromIDMeta := map[string]interface{}{
 		"event_only":                            "event_value", // Remain
+		"event_and_parent_event":                "event_value", // Remain
 		"build_and_event_and_inner_pipeline":    "event_value", // Overwrote by inner pipeline
 		"build_and_event_and_external_pipeline": "event_value", // Overwrote by external pipeline
+		"build_and_event_and_parent_event":      "event_value", // Overwrote by inner pipeline
 		"parameters": map[string]string{
 			"event_only":                            "event_value", // This should be deleted
 			"build_and_event_and_inner_pipeline":    "event_value", // Overwrote by build
@@ -1896,7 +1898,7 @@ func TestMetaWhenTriggeredFromPipelinesByANDLogicWithParentBuildMeta(t *testing.
 
 	parentEventMeta := map[string]interface{}{
 		"parent_event_only":                "parent_event_value", // Remain
-		"build_and_event_and_parent_event": "parent_event_value", // Remain
+		"build_and_event_and_parent_event": "parent_event_value", // Overwrote by inner pipeline
 		"parameters": map[string]string{
 			"parent_event_only":                "parent_event_value", // This should be deleted
 			"build_and_event_and_parent_event": "parent_event_value", // Overwrote by build
@@ -1929,6 +1931,7 @@ func TestMetaWhenTriggeredFromPipelinesByANDLogicWithParentBuildMeta(t *testing.
 	innerParentBuildMeta := map[string]interface{}{
 		"inner_pipeline_only":                "inner_pipeline_value", // Remain
 		"build_and_event_and_inner_pipeline": "inner_pipeline_value", // Remain
+		"build_and_event_and_parent_event":   "inner_pipeline_value", // Remain
 		"parameters": map[string]string{
 			"inner_pipeline_only":                "inner_pipeline_value", // This should be deleted
 			"build_and_event_and_inner_pipeline": "inner_pipeline_value", // Overwrote by build
@@ -2065,8 +2068,9 @@ func TestMetaWhenTriggeredFromPipelinesByANDLogicWithParentBuildMeta(t *testing.
 		"inner_pipeline_only": "inner_pipeline_value",
 		"build_and_event_and_inner_pipeline": "inner_pipeline_value",
 		"build_and_event_and_external_pipeline": "external_pipeline_value",
-		"build_and_event_and_parent_event": "parent_event_value",
+		"build_and_event_and_parent_event": "inner_pipeline_value",
 		"parent_event_only": "parent_event_value",
+		"event_and_parent_event": "event_value",
 		"build":{
 			"buildId": "%d",
 			"jobId": "%d",


### PR DESCRIPTION
## Context

The behavior of [commit](https://github.com/screwdriver-cd/launcher/pull/475) might cause metadata from parent event to overwrite the metadata from the current event and the predecessor builds. 

## Objective

The parent event metadata should always be the predecessor of parentBuilds and event metadata because the parentEvent should happen before the current event or the predecessor builds (except for the case of restart from remote trigger)

## References

https://github.com/screwdriver-cd/screwdriver/issues/3234

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
