### PR TITLE
feat(3234): event and parentEvent meta should be mutually exclusive

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -476,7 +476,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 
 	// Note: event and parent event meta are mutually exclusive
 	// the first event in the build chain for a restart case will use the parent event meta
-	// on launcher exit, the meta will be updated to the current event meta
+	// on launcher exit, the build meta will be merged int to the current event meta
 
 	// merge event meta if available
 	if len(event.Meta) > 0 {

--- a/launch.go
+++ b/launch.go
@@ -475,7 +475,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 	}
 
 	// Note: event and parent event meta are mutually exclusive
-	// the first event in the build chain for a restart case will use the parent event meta
+	// the first build in the event for a restart case will use the parent event meta
 	// on launcher exit, the build meta will be merged int to the current event meta
 
 	// merge event meta if available

--- a/launch.go
+++ b/launch.go
@@ -489,12 +489,29 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		metaLog = fmt.Sprintf(`Event(%v)`, parentEvent.ID)
 	}
 
-	// Always merge event meta
+	// Note: event and parent event meta are mutually exclusive
+	// the first event in the build chain for a restart case will use the parent event meta
+	// on launcher exit, the meta will be updated to the current event meta
+
+	// merge event meta if available
 	if len(event.Meta) > 0 { // If has meta, marshal it
 		log.Printf("Fetching Event Meta JSON %v", event.ID)
 		if event.Meta != nil {
 			mergedMeta = deepMergeJSON(mergedMeta, event.Meta)
 		}
+	} else if event.ParentEventID != 0 { // otherwise, fetch from parent event
+		// If has parent event, fetch meta from parent event
+		log.Printf("Fetching Parent Event %d", event.ParentEventID)
+		parentEvent, err := api.EventFromID(event.ParentEventID)
+		if err != nil {
+			return fmt.Errorf("Fetching Parent Event ID %d: %v", event.ParentEventID, err), "", ""
+		}
+
+		if parentEvent.Meta != nil {
+			mergedMeta = deepMergeJSON(mergedMeta, parentEvent.Meta)
+		}
+
+		metaLog = fmt.Sprintf(`Event(%v)`, parentEvent.ID)
 	}
 
 	if len(parentBuildIDs) > 1 { // If has multiple parent build IDs, merge their metadata (join case)

--- a/launch.go
+++ b/launch.go
@@ -479,13 +479,12 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 	// on launcher exit, the meta will be updated to the current event meta
 
 	// merge event meta if available
-	if len(event.Meta) > 0 { // If has meta, marshal it
+	if len(event.Meta) > 0 {
 		log.Printf("Fetching Event Meta JSON %v", event.ID)
 		if event.Meta != nil {
 			mergedMeta = deepMergeJSON(mergedMeta, event.Meta)
 		}
-	} else if event.ParentEventID != 0 { // otherwise, fetch from parent event
-		// If has parent event, fetch meta from parent event
+	} else if event.ParentEventID != 0 {
 		log.Printf("Fetching Parent Event %d", event.ParentEventID)
 		parentEvent, err := api.EventFromID(event.ParentEventID)
 		if err != nil {

--- a/launch.go
+++ b/launch.go
@@ -474,21 +474,6 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		return err, "", ""
 	}
 
-	// Always merge parent event meta if it exists (Issue #3234)
-	if event.ParentEventID != 0 { // If has parent event, fetch meta from parent event
-		log.Printf("Fetching Parent Event %d", event.ParentEventID)
-		parentEvent, err := api.EventFromID(event.ParentEventID)
-		if err != nil {
-			return fmt.Errorf("Fetching Parent Event ID %d: %v", event.ParentEventID, err), "", ""
-		}
-
-		if parentEvent.Meta != nil {
-			mergedMeta = deepMergeJSON(mergedMeta, parentEvent.Meta)
-		}
-
-		metaLog = fmt.Sprintf(`Event(%v)`, parentEvent.ID)
-	}
-
 	// Note: event and parent event meta are mutually exclusive
 	// the first event in the build chain for a restart case will use the parent event meta
 	// on launcher exit, the meta will be updated to the current event meta

--- a/launch.go
+++ b/launch.go
@@ -474,9 +474,9 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		return err, "", ""
 	}
 
-	// Note: event and parent event meta are mutually exclusive
-	// the first build in the event for a restart case will use the parent event meta
-	// on launcher exit, the build meta will be merged int to the current event meta
+	// Note: Event and parent event meta are mutually exclusive.
+	// The first build in the event for a restart case will use the parent event meta.
+	// On launcher exit, the build meta will be merged into the current event meta.
 
 	// merge event meta if available
 	if len(event.Meta) > 0 {

--- a/launch_test.go
+++ b/launch_test.go
@@ -2069,7 +2069,6 @@ func TestMetaWhenTriggeredFromPipelinesByANDLogicWithParentBuildMeta(t *testing.
 		"build_and_event_and_inner_pipeline": "inner_pipeline_value",
 		"build_and_event_and_external_pipeline": "external_pipeline_value",
 		"build_and_event_and_parent_event": "inner_pipeline_value",
-		"parent_event_only": "parent_event_value",
 		"event_and_parent_event": "event_value",
 		"build":{
 			"buildId": "%d",
@@ -2084,9 +2083,7 @@ func TestMetaWhenTriggeredFromPipelinesByANDLogicWithParentBuildMeta(t *testing.
 			"inner_pipeline_only": "inner_pipeline_value",
 			"external_pipeline_only": "external_pipeline_value",
 			"build_and_event_and_inner_pipeline": "inner_pipeline_value",
-			"build_and_event_and_external_pipeline": "external_pipeline_value",
-			"build_and_event_and_parent_event": "parent_event_value",
-			"parent_event_only": "parent_event_value"
+			"build_and_event_and_external_pipeline": "external_pipeline_value"
 		},
 		"event": {
 			"creator": "%s"
@@ -2097,9 +2094,7 @@ func TestMetaWhenTriggeredFromPipelinesByANDLogicWithParentBuildMeta(t *testing.
 			"external_pipeline_only": "external_pipeline_value",
 			"inner_pipeline_only": "inner_pipeline_value",
 			"build_and_event_and_inner_pipeline": "inner_pipeline_value",
-			"build_and_event_and_external_pipeline": "external_pipeline_value",
-			"build_and_event_and_parent_event": "parent_event_value",
-			"parent_event_only": "parent_event_value"
+			"build_and_event_and_external_pipeline": "external_pipeline_value"
 		},
 		"parameters": {
 			"build_only": "build_value",
@@ -2516,8 +2511,6 @@ func TestMetaWhenTriggeredFromExternalPipelineByORLogicWithParentBuildMeta(t *te
 		"build_only": "build_value",
 		"event_only": "event_value",
 		"build_and_event_and_external_pipeline": "event_value",
-		"build_and_event_and_parent_event": "parent_event_value",
-		"parent_event_only": "parent_event_value",
 		"build":{
 			"buildId": "%d",
 			"jobId": "%d",
@@ -2528,9 +2521,7 @@ func TestMetaWhenTriggeredFromExternalPipelineByORLogicWithParentBuildMeta(t *te
 			"coverageKey": "%s",
 			"build_only": "build_value",
 			"event_only": "event_value",
-			"build_and_event_and_external_pipeline": "event_value",
-			"build_and_event_and_parent_event": "parent_event_value",
-			"parent_event_only": "parent_event_value"
+			"build_and_event_and_external_pipeline": "event_value"
 		},
 		"event": {
 			"creator": "%s"
@@ -2538,9 +2529,7 @@ func TestMetaWhenTriggeredFromExternalPipelineByORLogicWithParentBuildMeta(t *te
 		"meta": {
 			"build_only": "build_value",
 			"event_only": "event_value",
-			"build_and_event_and_external_pipeline": "event_value",
-			"build_and_event_and_parent_event": "parent_event_value",
-			"parent_event_only": "parent_event_value"
+			"build_and_event_and_external_pipeline": "event_value"
 		},
 		"parameters": {
 			"build_only": "build_value",
@@ -2693,7 +2682,6 @@ func TestMetaWhenStartFromAnyJobWithParentEvent(t *testing.T) {
 	want := fmt.Sprintf(`{
 		"build_only": "build_value",
 		"event_only": "event_value",
-		"parent_event_only": "parent_event_value",
 		"build_and_event_and_parent_event": "event_value",
 		"build":{
 			"buildId": "%d",
@@ -2705,7 +2693,6 @@ func TestMetaWhenStartFromAnyJobWithParentEvent(t *testing.T) {
 			"coverageKey": "%s",
 			"build_only": "build_value",
 			"event_only": "event_value",
-			"parent_event_only": "parent_event_value",
 			"build_and_event_and_parent_event": "event_value"
 		},
 		"event": {
@@ -2714,7 +2701,6 @@ func TestMetaWhenStartFromAnyJobWithParentEvent(t *testing.T) {
 		"meta":{
 			"build_only": "build_value",
 			"event_only": "event_value",
-			"parent_event_only": "parent_event_value",
 			"build_and_event_and_parent_event": "event_value"
 		},
 		"parameters":{


### PR DESCRIPTION
## Context

The current implementation of meta behavior causes the merging of parentEvent and event altogether whenever they are available. 

## Objective

This implementation should not be necessary, instead event and parentEvent meta should be mutually exclusive. The parentEvent will only be relevant for the initial build of the restart. Afterward, it will simply be part of the event, as the first build will update the event appropriately during the launcher exit.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3234

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
