### PR TITLE
fix(3234): always allow parent event metadata to be merged during the build

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -498,6 +498,31 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		metaLog = fmt.Sprintf(`Event(%v)`, parentEvent.ID)
 	}
 
+	// Note: event and parent event meta are mutually exclusive
+	// the first event in the build chain for a restart case will use the parent event meta
+	// on launcher exit, the meta will be updated to the current event meta
+
+	// merge event meta if available
+	if len(event.Meta) > 0 { // If has meta, marshal it
+		log.Printf("Fetching Event Meta JSON %v", event.ID)
+		if event.Meta != nil {
+			mergedMeta = deepMergeJSON(mergedMeta, event.Meta)
+		}
+	} else if event.ParentEventID != 0 { // otherwise, fetch from parent event
+		// If has parent event, fetch meta from parent event
+		log.Printf("Fetching Parent Event %d", event.ParentEventID)
+		parentEvent, err := api.EventFromID(event.ParentEventID)
+		if err != nil {
+			return fmt.Errorf("Fetching Parent Event ID %d: %v", event.ParentEventID, err), "", ""
+		}
+
+		if parentEvent.Meta != nil {
+			mergedMeta = deepMergeJSON(mergedMeta, parentEvent.Meta)
+		}
+
+		metaLog = fmt.Sprintf(`Event(%v)`, parentEvent.ID)
+	}
+
 	if len(parentBuildIDs) > 1 { // If has multiple parent build IDs, merge their metadata (join case)
 		// Get meta from all parent builds
 		for _, pbID := range parentBuildIDs {

--- a/launch_test.go
+++ b/launch_test.go
@@ -2080,10 +2080,12 @@ func TestMetaWhenTriggeredFromPipelinesByANDLogicWithParentBuildMeta(t *testing.
 			"coverageKey": "%s",
 			"build_only": "build_value",
 			"event_only": "event_value",
+			"parent_event_only": "parent_event_value",
 			"inner_pipeline_only": "inner_pipeline_value",
 			"external_pipeline_only": "external_pipeline_value",
 			"build_and_event_and_inner_pipeline": "inner_pipeline_value",
-			"build_and_event_and_external_pipeline": "external_pipeline_value"
+			"build_and_event_and_external_pipeline": "external_pipeline_value",
+			"build_and_event_and_parent_event": "parent_event_value"
 		},
 		"event": {
 			"creator": "%s"
@@ -2094,7 +2096,9 @@ func TestMetaWhenTriggeredFromPipelinesByANDLogicWithParentBuildMeta(t *testing.
 			"external_pipeline_only": "external_pipeline_value",
 			"inner_pipeline_only": "inner_pipeline_value",
 			"build_and_event_and_inner_pipeline": "inner_pipeline_value",
-			"build_and_event_and_external_pipeline": "external_pipeline_value"
+			"build_and_event_and_external_pipeline": "external_pipeline_value",
+			"build_and_event_and_parent_event": "parent_event_value",
+			"parent_event_only": "parent_event_value"
 		},
 		"parameters": {
 			"build_only": "build_value",
@@ -2120,7 +2124,8 @@ func TestMetaWhenTriggeredFromPipelinesByANDLogicWithParentBuildMeta(t *testing.
 				"inner_pipeline_only": "inner_pipeline_value",
 				"external_pipeline_only": "external_pipeline_value"
 			}
-		}
+		},
+		"parent_event_only": "parent_event_value"
 	}`, TestBuildID, TestJobID, TestPipelineID, TestEnvVars["SD_SONAR_PROJECT_KEY"], TestEventCreator["username"], InnerPipelineID, ExternalPipelineID)
 	assert.JSONEq(t, want, string(defaultMeta))
 
@@ -2521,7 +2526,9 @@ func TestMetaWhenTriggeredFromExternalPipelineByORLogicWithParentBuildMeta(t *te
 			"coverageKey": "%s",
 			"build_only": "build_value",
 			"event_only": "event_value",
-			"build_and_event_and_external_pipeline": "event_value"
+			"build_and_event_and_external_pipeline": "event_value",
+			"build_and_event_and_parent_event": "parent_event_value",
+			"parent_event_only": "parent_event_value"
 		},
 		"event": {
 			"creator": "%s"
@@ -2529,7 +2536,10 @@ func TestMetaWhenTriggeredFromExternalPipelineByORLogicWithParentBuildMeta(t *te
 		"meta": {
 			"build_only": "build_value",
 			"event_only": "event_value",
-			"build_and_event_and_external_pipeline": "event_value"
+			"build_and_event_and_external_pipeline": "event_value",
+			"build_and_event_and_parent_event": "parent_event_value",
+			"event_only": "event_value",
+			"parent_event_only": "parent_event_value"
 		},
 		"parameters": {
 			"build_only": "build_value",
@@ -2542,7 +2552,9 @@ func TestMetaWhenTriggeredFromExternalPipelineByORLogicWithParentBuildMeta(t *te
 				"build_only": "build_value",
 				"event_only": "event_value"
 			}
-		}
+		},
+		"parent_event_only": "parent_event_value",
+		"build_and_event_and_parent_event": "parent_event_value"
 	}`, TestBuildID, TestJobID, TestPipelineID, TestEnvVars["SD_SONAR_PROJECT_KEY"], TestEventCreator["username"], ExternalPipelineID)
 	assert.JSONEq(t, want, string(defaultMeta))
 
@@ -2693,7 +2705,8 @@ func TestMetaWhenStartFromAnyJobWithParentEvent(t *testing.T) {
 			"coverageKey": "%s",
 			"build_only": "build_value",
 			"event_only": "event_value",
-			"build_and_event_and_parent_event": "event_value"
+			"build_and_event_and_parent_event": "event_value",
+			"parent_event_only": "parent_event_value"
 		},
 		"event": {
 			"creator": "%s"
@@ -2701,12 +2714,15 @@ func TestMetaWhenStartFromAnyJobWithParentEvent(t *testing.T) {
 		"meta":{
 			"build_only": "build_value",
 			"event_only": "event_value",
-			"build_and_event_and_parent_event": "event_value"
+			"build_and_event_and_parent_event": "event_value",
+			"event_only": "event_value",
+			"parent_event_only": "parent_event_value"
 		},
 		"parameters":{
 			"build_only": "build_value",
 			"build_and_event_and_parent_event": "build_value"
-		}
+		},
+		"parent_event_only": "parent_event_value"
 	}`, TestBuildID, TestJobID, TestPipelineID, TestEnvVars["SD_SONAR_PROJECT_KEY"], TestEventCreator["username"])
 
 	assert.JSONEq(t, want, string(defaultMeta))


### PR DESCRIPTION
## Context

On the case of event restarted, when event meta is not empty, the metadata from parent event will be ignored and this is not the expected behavior. 

## Objective

Fix the expected behavior to always allow parent event metadata to be merged as predecessor of other metadata, i.e. event meta, parent builds. 

## References

https://github.com/screwdriver-cd/screwdriver/issues/3234

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
