### PR TITLE
fix(3125): merge parent build meta order by end time

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -295,13 +295,13 @@ func writeMetafile(metaSpace, metaFile, metaLog string, mergedMeta map[string]in
 }
 
 // setParentBuildsMeta checks if parent build is external and sets meta in external file accordingly
-func setParentBuildsMeta(api screwdriver.API, pipelineID int, parentBuildIds []int, mergedMeta map[string]interface{}, metaSpace, metaLog string) (map[string]interface{}, error) {
+func setParentBuildsMeta(api screwdriver.API, pipelineID int, parentBuildIDs []int, mergedMeta map[string]interface{}, metaSpace, metaLog string) (map[string]interface{}, error) {
 	var resultMeta = mergedMeta
-	var isJoin = len(parentBuildIds) > 1
+	var isJoin = len(parentBuildIDs) > 1
 
 	parentBuilds := []screwdriver.Build{}
 
-	for _, parentBuildId := range parentBuildIds {
+	for _, parentBuildId := range parentBuildIDs {
 		log.Printf("Fetching Parent Build %d", parentBuildId)
 
 		parentBuild, err := api.BuildFromID(parentBuildId)
@@ -337,7 +337,7 @@ func setParentBuildsMeta(api screwdriver.API, pipelineID int, parentBuildIds []i
 			resultMeta, err = handleExternalPipelineMeta(parentBuild, parentJob, resultMeta, metaSpace, metaLog, isJoin)
 
 			if err != nil {
-				return resultMeta, fmt.Errorf("Mergeing meta of External Parent Build ID %d: %v", parentBuild.ID, err)
+				return resultMeta, fmt.Errorf("Merging meta of External Parent Build ID %d: %v", parentBuild.ID, err)
 			}
 		}
 	}

--- a/launch_test.go
+++ b/launch_test.go
@@ -2389,7 +2389,7 @@ func TestMetaWhenTriggeredFromPipelinesByANDLogicWithMultiParentBuildMeta(t *tes
 
 	err, _, _ := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
 	want := fmt.Sprintf(`{
-	    "build_1":"first_build_value",
+		"build_1":"first_build_value",
 		"build_12":"second_build_value",
 		"build_123":"third_build_value",
 		"build_13":"third_build_value",

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -183,6 +183,7 @@ type Build struct {
 	Meta          map[string]interface{} `json:"meta"`
 	EventID       int                    `json:"eventId"`
 	Createtime    string                 `json:"createTime"`
+	Endtime       time.Time              `json:"entTime"`
 	Stats         struct {
 		QueueEntertime string `json:"queueEnterTime"`
 	} `json:"stats"`

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -183,7 +183,7 @@ type Build struct {
 	Meta          map[string]interface{} `json:"meta"`
 	EventID       int                    `json:"eventId"`
 	Createtime    string                 `json:"createTime"`
-	Endtime       time.Time              `json:"entTime"`
+	Endtime       time.Time              `json:"endTime"`
 	Stats         struct {
 		QueueEntertime string `json:"queueEnterTime"`
 	} `json:"stats"`

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -140,6 +140,7 @@ func TestBuildFromID(t *testing.T) {
 				Commands:    testCmds,
 				Environment: testEnv,
 				Createtime:  "2020-04-28T20:34:01.907Z",
+				Endtime:     time.Date(2020, 4, 28, 20, 40, 0, 123, time.UTC),
 				Stats: struct {
 					QueueEntertime string `json:"queueEnterTime"`
 				}{


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Currently, if the parent builds have same key metadata, the value of the build completed earlier is used.
(Not value of the build completed later)

This behavior is a little strange.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Sort merging parent builds metadata order by their finished time.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/3125#issuecomment-2458897936

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
