### PR TITLE
fix: pin version of store-cli to v0.0.71

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,10 +101,10 @@ RUN set -x \
    | wget --base=http://github.com/ -i - -O sd-cmd \
    && chmod +x sd-cmd \
    # Download store-cli
-   && wget -q -O - https://api.github.com/repos/screwdriver-cd/store-cli/releases/latest \
+   && wget -q -O - https://api.github.com/repos/screwdriver-cd/store-cli/releases/tags/v0.0.71 \
    | egrep -o "/screwdriver-cd/store-cli/releases/download/v[0-9.]*/store-cli_${TARGETOS}_${TARGETARCH}" \
    | sed -e "s/\/screwdriver-cd\/\([a-zA-Z-]*\)\/releases\/download\/\(v[0-9.]*\)\/store-cli_${TARGETOS}_${TARGETARCH}/\1 \2/" >> tool-versions \
-   && wget -q -O - https://api.github.com/repos/screwdriver-cd/store-cli/releases/latest \
+   && wget -q -O - https://api.github.com/repos/screwdriver-cd/store-cli/releases/tags/v0.0.71 \
    | egrep -o "/screwdriver-cd/store-cli/releases/download/v[0-9.]*/store-cli_${TARGETOS}_${TARGETARCH}" \
    | wget --base=http://github.com/ -i - -O store-cli \
    && chmod +x store-cli \


### PR DESCRIPTION
## Context

https://github.com/screwdriver-cd/store-cli/pull/82 introduced the 5 seconds timeout for waiting for SD store to return 100 status code before sending over the payload when it sends an `Expect` header.

This change caused the launcher to bring in new release of store cli which ALWAYS stalls for 5-seconds because the store doesn't handle the `Expect` header in endpoints (e.g. build artifacts) other than the cache, see [this](https://github.com/screwdriver-cd/store/pull/146)

## Objective

Pin the version of store-cli in launcher to v0.0.71 until the store can handle the `Expect` header for other endpoints.

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.