### PR TITLE
fix(482): Bump store-cli version to the latest.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,10 +113,10 @@ RUN set -x \
    | wget --base=http://github.com/ -i - -O sd-cmd \
    && chmod +x sd-cmd \
    # Download store-cli
-   && wget -q -O - https://api.github.com/repos/screwdriver-cd/store-cli/releases/tags/v0.0.71 \
+   && wget -q -O - https://api.github.com/repos/screwdriver-cd/store-cli/releases/latest \
    | egrep -o "/screwdriver-cd/store-cli/releases/download/v[0-9.]*/store-cli_${TARGETOS}_${TARGETARCH}" \
    | sed -e "s/\/screwdriver-cd\/\([a-zA-Z-]*\)\/releases\/download\/\(v[0-9.]*\)\/store-cli_${TARGETOS}_${TARGETARCH}/\1 \2/" >> tool-versions \
-   && wget -q -O - https://api.github.com/repos/screwdriver-cd/store-cli/releases/tags/v0.0.71 \
+   && wget -q -O - https://api.github.com/repos/screwdriver-cd/store-cli/releases/latest \
    | egrep -o "/screwdriver-cd/store-cli/releases/download/v[0-9.]*/store-cli_${TARGETOS}_${TARGETARCH}" \
    | wget --base=http://github.com/ -i - -O store-cli \
    && chmod +x store-cli \


### PR DESCRIPTION
## Context

There was an issue with store-cli where it would wait for 5 seconds during uploads if there was no handling for the Expect header.
This has been fixed in the following PR: https://github.com/screwdriver-cd/store-cli/pull/83

Therefore, I would like to update the store-cli to the latest.

## Objective

I would like to revert the fixed version back to the latest.
https://github.com/screwdriver-cd/launcher/pull/482

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/launcher/pull/482
https://github.com/screwdriver-cd/store-cli/pull/83

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
