### PR TITLE
feat(3248): add status message to update build when launcher failed

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -764,13 +764,14 @@ func launchAction(api screwdriver.API, buildID int, rootDir, emitterPath, metaSp
 
 	err, sourceDir, launchShellBin := launch(api, buildID, rootDir, emitterPath, metaSpace, storeURI, uiURI, shellBin, buildTimeout, buildToken, cacheStrategy, pipelineCacheDir, jobCacheDir, eventCacheDir, cacheCompress, cacheMd5Check, isLocal, cacheMaxSizeInMB, cacheMaxGoThreads)
 	if err != nil {
-		if _, ok := err.(executor.ErrStatus); ok {
-			log.Printf("Failure due to non-zero exit code: %v\n", err)
-		} else {
-			log.Printf("Error running launcher: %v\n", err)
+		var errMsg string
+		errMsg = fmt.Sprintf("Error running launcher: %v", err)
+		if statusErr, ok := err.(executor.ErrStatus); ok {
+			errMsg = fmt.Sprintf("Error running launcher due to non-zero exit code: %v", statusErr)
 		}
+		log.Println(errMsg)
 
-		prepareExit(screwdriver.Failure, buildID, api, metaSpace, "")
+		prepareExit(screwdriver.Failure, buildID, api, metaSpace, errMsg)
 		TerminateSleep(launchShellBin, sourceDir, true)
 		cleanExit()
 		return nil


### PR DESCRIPTION
## Context

It is currently difficult to determine the root cause when a launcher fails, as no meaningful status message is provided when updating the build status to "fail." This lack of information complicates troubleshooting and delays issue resolution.

## Objective

This PR ensures that a detailed status message is included whenever a build status is updated to "FAILURE" during the launch action. The status message will provide relevant details about the failure, making it easier to identify and resolve the underlying issue quickly, as well as to create alerting system based on logs. 

## References

https://github.com/screwdriver-cd/screwdriver/issues/3248

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
