### PR TITLE
[1] feat(3235): use API-provided meta if available

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -500,7 +500,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 		mergedMeta = deepMergeJSON(mergedMeta, build.Meta)
 	}
 
-		// Create meta space
+	// Create meta space
 	err = createMetaSpace(metaSpace)
 	if err != nil {
 		return err, "", ""


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
The process of setting the metadata needs to be moved from the launcher to the API.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- If the metadata is set on the API side, use it.
  - The `coverageKey` is always set on the launcher side, because setting it on the API side would complicate the process.
- If metadata is not set on the API side, set metadata on the launcher side as before.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/3235

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
