### PR TITLE
fix(3235): Retain metadata for pr-closed info

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -433,7 +433,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 	if sdMeta, ok := mergedMeta["sd"].(map[string]interface{}); ok {
 		for pipelineID, pipelineData := range sdMeta {
 			// Retain the meta information for tag/release
-			if pipelineID == "tag" || pipelineID == "release" {
+			if pipelineID == "tag" || pipelineID == "release" || pipelineID == "pr" {
 				continue
 			}
 			if jobDataMap, ok := pipelineData.(map[string]interface{}); ok {

--- a/launch.go
+++ b/launch.go
@@ -432,7 +432,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 	// Write external meta to file
 	if sdMeta, ok := mergedMeta["sd"].(map[string]interface{}); ok {
 		for pipelineID, pipelineData := range sdMeta {
-			// Retain the metadata for non-integer values (e.g., tags, releases, closed pull requests)
+			// Retain the metadata for non-integer values (e.g., tag, release, pr-closed)
 			if _, err := strconv.Atoi(pipelineID); err != nil {
 				continue
 			}

--- a/launch.go
+++ b/launch.go
@@ -432,7 +432,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 	// Write external meta to file
 	if sdMeta, ok := mergedMeta["sd"].(map[string]interface{}); ok {
 		for pipelineID, pipelineData := range sdMeta {
-			// Retain the meta information for tag/release
+			// Retain the metadata for non-integer values (e.g., tags, releases, closed pull requests)
 			if _, err := strconv.Atoi(pipelineID); err != nil {
 				continue
 			}

--- a/launch.go
+++ b/launch.go
@@ -433,7 +433,7 @@ func launch(api screwdriver.API, buildID int, rootDir, emitterPath, metaSpace, s
 	if sdMeta, ok := mergedMeta["sd"].(map[string]interface{}); ok {
 		for pipelineID, pipelineData := range sdMeta {
 			// Retain the meta information for tag/release
-			if pipelineID == "tag" || pipelineID == "release" || pipelineID == "pr" {
+			if _, err := strconv.Atoi(pipelineID); err != nil {
 				continue
 			}
 			if jobDataMap, ok := pipelineData.(map[string]interface{}); ok {

--- a/launch_test.go
+++ b/launch_test.go
@@ -1468,9 +1468,9 @@ func TestMetaWhenStartPipelineWithPRClosedTrigger(t *testing.T) {
 		},
 		"sd": map[string]interface{}{
 			"pr": map[string]interface{}{
-                "merged": false,
-                "name": "pull/48/merge",
-                "number": 123,
+				"merged": false,
+				"name":   "pull/48/merge",
+				"number": 123,
 			},
 		},
 	}

--- a/launch_test.go
+++ b/launch_test.go
@@ -1447,6 +1447,81 @@ func TestMetaWhenStartPipelineWithReleaseTrigger(t *testing.T) {
 	}
 }
 
+func TestMetaWhenStartPipelineWithPRClosedTrigger(t *testing.T) {
+	initCoverageMeta()
+	oldWriteFile := writeFile
+	defer func() { writeFile = oldWriteFile }()
+	var defaultMeta []byte
+
+	buildFromIDMeta := map[string]interface{}{
+		"meta1": "value1",
+		"build": map[string]interface{}{
+			"buildId":    TestBuildID,
+			"jobId":      TestJobID,
+			"eventId":    "0",
+			"pipelineId": TestPipelineID,
+			"sha":        "",
+			"jobName":    "main",
+		},
+		"event": map[string]interface{}{
+			"creator": TestEventCreator["username"],
+		},
+		"sd": map[string]interface{}{
+			"pr": map[string]interface{}{
+                "merged": false,
+                "name": "pull/48/merge",
+                "number": 123,
+			},
+		},
+	}
+
+	api := mockAPI(t, TestBuildID, TestJobID, 0, "RUNNING")
+	api.buildFromID = func(buildID int) (screwdriver.Build, error) {
+		return screwdriver.Build(FakeBuild{ID: buildID, JobID: TestJobID, Meta: buildFromIDMeta}), nil
+	}
+	api.jobFromID = func(jobID int) (screwdriver.Job, error) {
+		return screwdriver.Job(FakeJob{ID: jobID, PipelineID: TestPipelineID, Name: "main"}), nil
+	}
+	api.pipelineFromID = func(pipelineID int) (screwdriver.Pipeline, error) {
+		return screwdriver.Pipeline(FakePipeline{ID: pipelineID, ScmURI: TestScmURI, ScmRepo: TestScmRepo}), nil
+	}
+	writeFile = func(path string, data []byte, perm os.FileMode) (err error) {
+		if path == "./data/meta/meta.json" {
+			defaultMeta = data
+		}
+		return nil
+	}
+
+	err, _, _ := launch(screwdriver.API(api), TestBuildID, TestWorkspace, TestEmitter, TestMetaSpace, TestStoreURL, TestUIURL, TestShellBin, TestBuildTimeout, TestBuildToken, "", "", "", "", false, false, false, 0, 10000)
+	want := fmt.Sprintf(`{
+		"meta1": "value1",
+		"build": {
+			"buildId": %d,
+			"jobId": %d,
+			"eventId": "0",
+			"pipelineId": %d,
+			"sha": "",
+			"jobName": "main",
+			"coverageKey": "%s"
+		},
+		"event": {
+			"creator": "%s"
+		},
+        "sd": {
+            "pr": {
+                "merged": false,
+                "name": "pull/48/merge",
+                "number": 123
+            }
+        }
+	}`, TestBuildID, TestJobID, TestPipelineID, TestEnvVars["SD_SONAR_PROJECT_KEY"], TestEventCreator["username"])
+
+	assert.JSONEq(t, want, string(defaultMeta))
+	if err != nil {
+		t.Errorf(fmt.Sprintf("err returned: %s", err.Error()))
+	}
+}
+
 type RequestCapture struct {
 	Method string
 	URL    *url.URL


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
After https://github.com/screwdriver-cd/launcher/pull/493, the meta.sd.pr.* values are missing when the build is triggered by pr-closed.

I fixed this bug.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Retain pr-closed info meta in launch process.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/3235

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
