### PR TITLE
fix(CVE-2022-37434): try alpine:3.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12 AS base
+FROM alpine:3.23 AS base
 LABEL MAINTAINER="Screwdriver Team <screwdriver.cd>"
 
 ARG TARGETOS TARGETARCH


### PR DESCRIPTION
## Context

launcher image was flagged for CVE-2022-37434

## Objective

resolve CVE-2022-37434

## References

CVE-2022-37434

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
